### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/application/src/config.rs
+++ b/application/src/config.rs
@@ -5,16 +5,10 @@
 use std::time::Duration;
 
 /// Application behavior configuration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BehaviorConfig {
     /// Timeout for API calls
     pub timeout: Option<Duration>,
-}
-
-impl Default for BehaviorConfig {
-    fn default() -> Self {
-        Self { timeout: None }
-    }
 }
 
 impl BehaviorConfig {

--- a/domain/src/config/output_format.rs
+++ b/domain/src/config/output_format.rs
@@ -5,21 +5,16 @@ use serde::{Deserialize, Serialize};
 /// Output format for Quorum results
 ///
 /// This is a domain concept representing how the output should be formatted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
     /// Full formatted output with all phases
     Full,
     /// Only the final synthesis (default)
+    #[default]
     Synthesis,
     /// JSON output
     Json,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        Self::Synthesis
-    }
 }
 
 #[cfg(test)]

--- a/infrastructure/src/config/loader.rs
+++ b/infrastructure/src/config/loader.rs
@@ -19,7 +19,7 @@ impl ConfigLoader {
     /// 3. XDG config: `$XDG_CONFIG_HOME/copilot-quorum/config.toml`
     /// 4. Fallback: `~/.config/copilot-quorum/config.toml`
     /// 5. Default values
-    pub fn load(config_path: Option<&PathBuf>) -> Result<FileConfig, figment::Error> {
+    pub fn load(config_path: Option<&PathBuf>) -> Result<FileConfig, Box<figment::Error>> {
         let mut figment = Figment::new().merge(Serialized::defaults(FileConfig::default()));
 
         // Add global config (XDG or fallback)
@@ -43,7 +43,7 @@ impl ConfigLoader {
             figment = figment.merge(Toml::file(path).nested());
         }
 
-        figment.extract()
+        figment.extract().map_err(Box::new)
     }
 
     /// Load only default configuration (for --no-config)

--- a/presentation/src/output/console.rs
+++ b/presentation/src/output/console.rs
@@ -41,9 +41,9 @@ impl ConsoleFormatter {
                 ));
             } else {
                 output.push_str(&format!(
-                    "\n{}\n{}\n",
+                    "\n{}\nError: {}\n",
                     format!("── {} ──", response.model).red().bold(),
-                    format!("Error: {}", response.error.as_deref().unwrap_or("Unknown"))
+                    response.error.as_deref().unwrap_or("Unknown")
                 ));
             }
         }


### PR DESCRIPTION
## Summary

Resolve all clippy warnings that were causing CI to fail.

### Changes

- **domain/src/config/output_format.rs**: Replace manual `Default` impl with `#[derive(Default)]` and `#[default]` attribute
- **application/src/config.rs**: Replace manual `Default` impl with `#[derive(Default)]`
- **presentation/src/output/console.rs**: Fix `format!` in `format!` args (clippy::format_in_format_args)
- **infrastructure/src/config/loader.rs**: Box `figment::Error` to fix result_large_err warning

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] CI passes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)