### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["archie"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Bump workspace version from 0.1.0 to 0.2.0 in preparation for v0.2.0 release.

### Changes in v0.2.0

- CI/CD workflows (PR #4)
- Clippy warning fixes (PR #6)

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)