### PR TITLE
fix(ci): add permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

Fix release workflow failing with "Resource not accessible by integration" error.

### Problem

The release workflow was unable to upload assets because the `GITHUB_TOKEN` lacked write permissions for contents.

### Solution

Add `permissions: contents: write` to the release workflow.

## Test plan

- [x] CI passes
- [x] Re-run release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)