### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["archie"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Bump workspace version to 0.2.1 for new release with CI fix.

### Changes in v0.2.1

- Fix release workflow permissions (#8)

## Test plan

- [x] CI passes