### PR TITLE
docs: improve Rust documentation coverage

### DIFF
--- a/application/src/config.rs
+++ b/application/src/config.rs
@@ -1,25 +1,30 @@
-//! Application-level configuration
+//! Application-level configuration.
 //!
-//! Configuration for use case behavior like timeouts and retries.
+//! This module provides configuration types that control how use cases behave,
+//! such as API timeouts and retry policies.
 
 use std::time::Duration;
 
-/// Application behavior configuration
+/// Application behavior configuration.
+///
+/// Controls runtime behavior of use cases like timeout limits for LLM API calls.
 #[derive(Debug, Clone, Default)]
 pub struct BehaviorConfig {
-    /// Timeout for API calls
+    /// Maximum time to wait for an API response before timing out.
     pub timeout: Option<Duration>,
 }
 
 impl BehaviorConfig {
-    /// Create a new BehaviorConfig with the given timeout in seconds
+    /// Creates a BehaviorConfig with a timeout specified in seconds.
     pub fn with_timeout_seconds(seconds: u64) -> Self {
         Self {
             timeout: Some(Duration::from_secs(seconds)),
         }
     }
 
-    /// Create from optional timeout seconds
+    /// Creates a BehaviorConfig from an optional timeout in seconds.
+    ///
+    /// If `seconds` is `None`, no timeout is applied.
     pub fn from_timeout_seconds(seconds: Option<u64>) -> Self {
         Self {
             timeout: seconds.map(Duration::from_secs),

--- a/domain/src/prompt/template.rs
+++ b/domain/src/prompt/template.rs
@@ -1,10 +1,26 @@
-//! Prompt templates for the Quorum flow
+//! Prompt templates for the Quorum (合議) flow.
+//!
+//! This module provides prompt templates used in each phase of a Quorum session:
+//!
+//! | Phase | System Prompt | User Prompt |
+//! |-------|--------------|-------------|
+//! | Initial Query | [`initial_system()`](PromptTemplate::initial_system) | [`initial_query()`](PromptTemplate::initial_query) |
+//! | Peer Review | [`review_system()`](PromptTemplate::review_system) | [`review_prompt()`](PromptTemplate::review_prompt) |
+//! | Synthesis | [`synthesis_system()`](PromptTemplate::synthesis_system) | [`synthesis_prompt()`](PromptTemplate::synthesis_prompt) |
+//!
+//! Each prompt is designed to guide the LLM's behavior for its specific role in the Quorum process.
 
-/// Templates for generating prompts at each stage
+/// Templates for generating prompts at each Quorum phase.
+///
+/// All methods are static and return either `&'static str` for system prompts
+/// or `String` for dynamically generated user prompts.
 pub struct PromptTemplate;
 
 impl PromptTemplate {
-    /// System prompt for initial query phase
+    /// System prompt for the Initial Query phase.
+    ///
+    /// Sets up the model to act as a knowledgeable expert providing
+    /// a well-reasoned, accurate response to the question.
     pub fn initial_system() -> &'static str {
         r#"You are a knowledgeable expert participating in a collaborative discussion.
 Your task is to provide a thoughtful, well-reasoned response to the question.
@@ -12,7 +28,10 @@ Be concise but comprehensive. Support your points with reasoning and examples wh
 Focus on accuracy and clarity."#
     }
 
-    /// User prompt for initial query
+    /// Generates the user prompt for the Initial Query phase.
+    ///
+    /// # Arguments
+    /// * `question` - The user's question to be answered
     pub fn initial_query(question: &str) -> String {
         format!(
             r#"Please answer the following question:
@@ -24,7 +43,10 @@ Provide a clear, well-structured response."#,
         )
     }
 
-    /// System prompt for peer review phase
+    /// System prompt for the Peer Review phase.
+    ///
+    /// Instructs the model to critically evaluate other responses,
+    /// identifying strengths, weaknesses, and providing scores.
     pub fn review_system() -> &'static str {
         r#"You are a critical reviewer evaluating responses from other experts.
 Your task is to objectively assess the quality, accuracy, and completeness of responses.
@@ -32,7 +54,11 @@ Be fair but thorough in your evaluation. Identify both strengths and weaknesses.
 Provide constructive feedback that would help improve the response."#
     }
 
-    /// User prompt for peer review
+    /// Generates the user prompt for the Peer Review phase.
+    ///
+    /// # Arguments
+    /// * `question` - The original question for context
+    /// * `responses` - List of (anonymous_id, content) pairs to review
     pub fn review_prompt(question: &str, responses: &[(String, String)]) -> String {
         let mut prompt = format!(
             r#"Original question: {}
@@ -66,7 +92,10 @@ Format your review clearly with headers for each response."#,
         prompt
     }
 
-    /// System prompt for synthesis phase
+    /// System prompt for the Synthesis phase.
+    ///
+    /// Sets up the model as a moderator who combines multiple responses
+    /// into a final answer, identifying consensus and disagreements.
     pub fn synthesis_system() -> &'static str {
         r#"You are a moderator synthesizing multiple expert opinions into a coherent conclusion.
 Your task is to:
@@ -78,7 +107,12 @@ Your task is to:
 Be balanced and objective. Give weight to well-reasoned arguments regardless of source."#
     }
 
-    /// User prompt for synthesis
+    /// Generates the user prompt for the Synthesis phase.
+    ///
+    /// # Arguments
+    /// * `question` - The original question
+    /// * `responses` - List of (model_name, response_content) pairs
+    /// * `reviews` - List of (reviewer_name, review_content) pairs
     pub fn synthesis_prompt(
         question: &str,
         responses: &[(String, String)],
@@ -122,7 +156,10 @@ Format your response with clear markdown headers."#,
         prompt
     }
 
-    /// User prompt for synthesis when there are no reviews
+    /// Generates the user prompt for Synthesis when peer review was skipped.
+    ///
+    /// This is a convenience method that calls [`synthesis_prompt`](Self::synthesis_prompt)
+    /// with an empty reviews list.
     pub fn synthesis_prompt_no_reviews(question: &str, responses: &[(String, String)]) -> String {
         Self::synthesis_prompt(question, responses, &[])
     }

--- a/infrastructure/src/copilot/error.rs
+++ b/infrastructure/src/copilot/error.rs
@@ -1,37 +1,51 @@
-//! Error types for the Copilot adapter
+//! Error types for the Copilot adapter.
+//!
+//! Provides structured error handling for all failure modes when
+//! communicating with the GitHub Copilot CLI process.
 
 use thiserror::Error;
 
-/// Result type alias for Copilot operations
+/// Result type alias for Copilot operations.
 pub type Result<T> = std::result::Result<T, CopilotError>;
 
-/// Errors that can occur when communicating with Copilot CLI
+/// Errors that can occur when communicating with Copilot CLI.
+///
+/// These cover process lifecycle, JSON-RPC protocol errors, and session management.
 #[derive(Error, Debug)]
 pub enum CopilotError {
+    /// Failed to start the Copilot CLI process.
     #[error("Failed to spawn Copilot process: {0}")]
     SpawnError(#[from] std::io::Error),
 
+    /// JSON serialization/deserialization failed.
     #[error("JSON serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
 
+    /// Could not parse a response from Copilot CLI.
     #[error("Failed to parse response: {error}\nRaw response: {raw}")]
     ParseError { error: String, raw: String },
 
+    /// JSON-RPC error returned by Copilot CLI.
     #[error("JSON-RPC error (code {code}): {message}")]
     RpcError { code: i64, message: String },
 
+    /// Received an unexpected response format.
     #[error("Unexpected response: {0}")]
     UnexpectedResponse(String),
 
+    /// Attempted to use a session before initialization.
     #[error("Session not initialized")]
     SessionNotInitialized,
 
+    /// The transport connection to Copilot CLI was closed.
     #[error("Transport closed")]
     TransportClosed,
 
+    /// Request timed out waiting for response.
     #[error("Request timeout")]
     Timeout,
 
+    /// Specified model is not supported.
     #[error("Invalid model: {0}")]
     InvalidModel(String),
 }

--- a/infrastructure/src/copilot/mod.rs
+++ b/infrastructure/src/copilot/mod.rs
@@ -1,6 +1,30 @@
-//! Copilot CLI adapter
+//! Copilot CLI adapter - LlmGateway implementation using GitHub Copilot.
 //!
-//! Implements LlmGateway for GitHub Copilot CLI.
+//! This module provides the infrastructure to communicate with LLMs through
+//! the GitHub Copilot CLI, implementing the `LlmGateway` port from the application layer.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────┐     ┌────────────────┐     ┌─────────────────┐
+//! │ CopilotLlmGateway │ --> │ CopilotSession │ --> │ CopilotTransport │
+//! │   (gateway.rs)   │     │  (session.rs)   │     │  (transport.rs)  │
+//! └─────────────────┘     └────────────────┘     └─────────────────┘
+//!                                                        │
+//!                                                        ▼
+//!                                                 ┌─────────────┐
+//!                                                 │ Copilot CLI │
+//!                                                 │  (gh copilot)│
+//!                                                 └─────────────┘
+//! ```
+//!
+//! # Modules
+//!
+//! - [`gateway`] - Main entry point implementing `LlmGateway`
+//! - [`session`] - Active conversation session with an LLM
+//! - [`transport`] - Low-level JSON-RPC communication with Copilot CLI
+//! - [`protocol`] - JSON-RPC message types and structures
+//! - [`error`] - Error types for Copilot operations
 
 pub mod error;
 pub mod gateway;

--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -1,10 +1,21 @@
-//! JSON-RPC protocol types for Copilot CLI communication
+//! JSON-RPC protocol types for Copilot CLI communication.
+//!
+//! This module defines the message structures used in the JSON-RPC 2.0 protocol
+//! for communicating with the Copilot CLI process.
+//!
+//! # Protocol Overview
+//!
+//! - **Requests**: Client → Copilot CLI (e.g., `session.create`, `session.send`)
+//! - **Responses**: Copilot CLI → Client (result or error)
+//! - **Notifications**: Copilot CLI → Client (e.g., `assistant.message`, `session.idle`)
 
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Global request ID counter for JSON-RPC requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Generates a unique request ID.
 fn next_id() -> u64 {
     REQUEST_ID.fetch_add(1, Ordering::SeqCst)
 }
@@ -20,6 +31,7 @@ pub struct JsonRpcRequest {
 }
 
 impl JsonRpcRequest {
+    /// Creates a new JSON-RPC request with an auto-generated ID.
     pub fn new(method: impl Into<String>, params: Option<serde_json::Value>) -> Self {
         Self {
             jsonrpc: "2.0",
@@ -64,6 +76,7 @@ pub struct Message {
 }
 
 impl Message {
+    /// Creates a system message (instructions for the model).
     pub fn system(content: impl Into<String>) -> Self {
         Self {
             role: Role::System,
@@ -71,6 +84,7 @@ impl Message {
         }
     }
 
+    /// Creates a user message (human input).
     pub fn user(content: impl Into<String>) -> Self {
         Self {
             role: Role::User,
@@ -78,6 +92,7 @@ impl Message {
         }
     }
 
+    /// Creates an assistant message (model response).
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             role: Role::Assistant,

--- a/infrastructure/src/copilot/session.rs
+++ b/infrastructure/src/copilot/session.rs
@@ -1,4 +1,7 @@
-//! Copilot session management
+//! Copilot session management.
+//!
+//! Provides [`CopilotSession`] which implements [`LlmSession`] for
+//! maintaining a conversation with a specific LLM model through Copilot CLI.
 
 use crate::copilot::error::{CopilotError, Result};
 use crate::copilot::protocol::{CreateSessionParams, JsonRpcRequest, SendParams};
@@ -9,7 +12,10 @@ use quorum_domain::Model;
 use std::sync::Arc;
 use tracing::{debug, info};
 
-/// A session with a specific Copilot model
+/// An active conversation session with a specific Copilot model.
+///
+/// Maintains session state and allows sending prompts and receiving responses.
+/// Implements [`LlmSession`] for use with the application layer.
 pub struct CopilotSession {
     transport: Arc<StdioTransport>,
     session_id: String,
@@ -52,17 +58,17 @@ impl CopilotSession {
         })
     }
 
-    /// Get the session ID
+    /// Returns the Copilot session ID.
     pub fn session_id(&self) -> &str {
         &self.session_id
     }
 
-    /// Send a message and get a response (non-streaming)
+    /// Sends a prompt and waits for the complete response.
     pub async fn ask(&self, content: &str) -> Result<String> {
         self.ask_streaming(content, |_| {}).await
     }
 
-    /// Send a message and stream the response
+    /// Sends a prompt and streams the response, calling `on_chunk` for each piece.
     pub async fn ask_streaming<F>(&self, content: &str, on_chunk: F) -> Result<String>
     where
         F: FnMut(&str),

--- a/infrastructure/src/copilot/transport.rs
+++ b/infrastructure/src/copilot/transport.rs
@@ -1,4 +1,7 @@
-//! Transport layer for Copilot CLI communication
+//! Transport layer for Copilot CLI communication.
+//!
+//! Handles the low-level JSON-RPC communication with the Copilot CLI process,
+//! including process spawning, TCP connection, and message serialization.
 
 use crate::copilot::error::{CopilotError, Result};
 use crate::copilot::protocol::{
@@ -11,7 +14,10 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tracing::{debug, info, trace, warn};
 
-/// Transport for communicating with Copilot CLI via TCP
+/// Transport for communicating with Copilot CLI via TCP.
+///
+/// Manages the Copilot CLI child process and TCP socket connection,
+/// providing methods for sending JSON-RPC requests and receiving responses.
 pub struct StdioTransport {
     #[allow(dead_code)]
     child: Child,


### PR DESCRIPTION
## Summary

Rust Docs（doc comments）を機能ベースで充実させ、LLM/開発者がコードを理解しやすくした。

### 1. Quorum（合議）機能
- `orchestration/entities.rs`: QuorumConfig, QuorumRun のメソッド説明
- `orchestration/value_objects.rs`: ModelResponse, PeerReview, SynthesisResult のメソッド説明
- `prompt/template.rs`: PromptTemplate 各フェーズのプロンプト説明

### 2. Agent（自律実行）機能
- `agent/value_objects.rs`: AgentId, TaskId, TaskResult, Thought, AgentContext のdoc comments
- `agent/entities.rs`: AgentState ライフサイクルメソッドの説明

### 3. 共通基盤
- `application/config.rs`: BehaviorConfig のフィールド説明
- `copilot/`: mod, error, protocol, session, transport のモジュール・メソッド説明

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] docs | `docs` | patch | ドキュメントのみの変更 |

## Related Issues

Closes #14

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] `cargo doc --workspace --no-deps` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた

## Additional Notes

コード変更なし。doc comments の追加のみ。