### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["archie"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

バージョンを 0.3.0 に更新。

## Changes since 0.2.1

- fix(agent): retry planning when quorum rejects plan (#13)
- docs: improve Rust documentation coverage (#15)

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] chore | `chore` | patch | その他の変更 |

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた