### PR TITLE
feat(ux): improve agent UI/UX with retry mechanism and quorum visibility

### DIFF
--- a/application/src/lib.rs
+++ b/application/src/lib.rs
@@ -18,7 +18,7 @@ pub use use_cases::init_context::{
     InitContextUseCase, NoInitContextProgress,
 };
 pub use use_cases::run_agent::{
-    AgentProgressNotifier, NoAgentProgress, RunAgentError, RunAgentInput, RunAgentOutput,
-    RunAgentUseCase,
+    AgentProgressNotifier, ErrorCategory, NoAgentProgress, RunAgentError, RunAgentInput,
+    RunAgentOutput, RunAgentUseCase,
 };
 pub use use_cases::run_quorum::{RunQuorumInput, RunQuorumUseCase};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,11 +208,7 @@ async fn main() -> Result<()> {
     let input = RunAgentInput::new(request, agent_config);
 
     let result = if repl_config.show_progress {
-        let progress = if cli.verbose > 0 {
-            AgentProgressReporter::verbose()
-        } else {
-            AgentProgressReporter::new()
-        };
+        let progress = AgentProgressReporter::with_options(cli.verbose > 0, cli.show_votes);
         use_case.execute_with_progress(input, &progress).await?
     } else {
         use_case.execute(input).await?

--- a/domain/src/agent/mod.rs
+++ b/domain/src/agent/mod.rs
@@ -6,5 +6,7 @@
 pub mod entities;
 pub mod value_objects;
 
-pub use entities::{AgentConfig, AgentState, Plan, Task, TaskStatus};
+pub use entities::{
+    AgentConfig, AgentPhase, AgentState, ModelVote, Plan, ReviewRound, Task, TaskStatus,
+};
 pub use value_objects::{AgentContext, AgentId, TaskId, TaskResult, Thought};

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -14,7 +14,9 @@ pub mod tool;
 
 // Re-export commonly used types
 pub use agent::{
-    entities::{AgentConfig, AgentPhase, AgentState, Plan, Task, TaskStatus},
+    entities::{
+        AgentConfig, AgentPhase, AgentState, ModelVote, Plan, ReviewRound, Task, TaskStatus,
+    },
     value_objects::{AgentContext, AgentId, TaskId, TaskResult, Thought, ThoughtType},
 };
 pub use config::OutputFormat;

--- a/presentation/src/cli/commands.rs
+++ b/presentation/src/cli/commands.rs
@@ -83,6 +83,10 @@ pub struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
 
+    /// Show detailed quorum vote information
+    #[arg(long)]
+    pub show_votes: bool,
+
     /// Suppress progress indicators
     #[arg(short, long)]
     pub quiet: bool,


### PR DESCRIPTION
## Summary

Agent Mode のUI/UXを大幅に改善。リトライ機構の拡張とQuorum投票の可視化を実装。

### 主な変更点

- **リトライ対象エラーの拡張**: `NOT_FOUND`（`multi_tool_use.parallel`などの未知ツール）をリトライ対象に追加
- **エラー可視化の強化**: `on_tool_error`, `on_tool_retry` コールバックで詳細なエラー表示
- **Action Rejection リトライ**: Quorumに拒否されたアクションをフィードバック付きでリトライ（最大2回）
- **Quorum投票履歴**: `ReviewRound`, `ModelVote` で投票履歴を追跡
- **投票サマリー表示**: `[●●○]` 形式で unanimous/majority を視覚化
- **進捗通知の追加**: `on_plan_revision`, `on_action_retry` 通知
- **実行サマリー強化**: Quorum Journey の表示
- **CLIフラグ追加**: `--show-votes` で詳細な投票情報を表示

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] feat | `feature` | minor | 新機能 |
| - [ ] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #33

## 変更ファイル

| レイヤー | ファイル | 変更内容 |
|---------|---------|---------|
| domain | `agent/entities.rs` | `ReviewRound`, `ModelVote` 追加 |
| application | `use_cases/run_agent.rs` | Action Retryロジック、エラー分類 |
| presentation | `agent/progress.rs` | 投票可視化、エラー表示コールバック |
| presentation | `agent/repl.rs` | Quorum Journey表示 |
| cli | `main.rs`, `commands.rs` | `--show-votes` フラグ |

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた

## Additional Notes

関連するサブIssueとして以下が存在:
- #34 - 処理中の人間介入を可能にする (Human-in-the-Loop)
- #28 - Ctrl+Cで長時間処理を中断できるようにする
- #26 - Action Reviewリトライ戦略

これらは本PRのスコープ外として、今後のIssueで対応予定。