### PR TITLE
fix(config): correct config file loading by removing nested() call

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -148,6 +148,12 @@ async fn main() -> Result<()> {
         .with_quorum_models(effective_quorum_models)
         .with_verbose(cli.verbose > 0);
 
+        // Set moderator if explicitly configured
+        if let Some(ref moderator_name) = config.council.moderator {
+            let moderator: Model = moderator_name.parse().unwrap();
+            repl = repl.with_moderator(moderator);
+        }
+
         if let Some(dir) = working_dir {
             repl = repl.with_working_dir(dir);
         }

--- a/infrastructure/src/config/loader.rs
+++ b/infrastructure/src/config/loader.rs
@@ -33,7 +33,8 @@ impl ConfigLoader {
         for filename in &["quorum.toml", ".quorum.toml"] {
             let path = PathBuf::from(filename);
             if path.exists() {
-                figment = figment.merge(Toml::file(&path).nested());
+                // Remove nested() to merge at root level
+                figment = figment.merge(Toml::file(&path));
                 break;
             }
         }


### PR DESCRIPTION
## Summary

設定ファイル（`quorum.toml`）の読み込みが正しく動作しないバグを修正しました。

### 変更内容

- **config/loader.rs**: `figment`の`nested()`呼び出しを削除し、ルートレベルでTOMLをマージするように修正
- **main.rs**: 設定ファイルで指定された`moderator`を`AgentRepl`に渡すように追加
- **agent/repl.rs**: `moderator`フィールドと`with_moderator()`メソッドを追加、起動時にモデレーターを表示

### 原因

`Toml::file(&path).nested()`を使用すると、figmentはプロファイルベースのネストされた設定構造を期待しますが、`quorum.toml`はフラットな構造（`[council]`、`[behavior]`など）を使用しているため、設定が正しく読み込まれませんでした。

## Test Plan

- [x] `cargo build` が成功することを確認
- [x] `quorum.toml`の設定が正しく読み込まれることを確認
- [x] moderatorが起動時に正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)