### PR TITLE
fix(cli): wrap LLM calls with cancellation support

### DIFF
--- a/application/src/use_cases/run_agent.rs
+++ b/application/src/use_cases/run_agent.rs
@@ -315,7 +315,10 @@ impl<G: LlmGateway + 'static, T: ToolExecutorPort + 'static, C: ContextLoaderPor
                 }
             }
         } else {
-            session.send(prompt).await.map_err(RunAgentError::GatewayError)
+            session
+                .send(prompt)
+                .await
+                .map_err(RunAgentError::GatewayError)
         }
     }
 


### PR DESCRIPTION
## Summary

#37 で追加したCtrl+Cキャンセル機能が、実際のLLM呼び出し中に効かない問題を修正しました。

### 問題

`CancellationToken`をRunAgentUseCaseに渡していたが、実際の`session.send()`呼び出しは`tokio::select!`でラップされておらず、LLM応答待ち中はキャンセルが効かなかった。

### 修正

`send_with_cancellation()`ヘルパーメソッドを追加し、すべてのLLM呼び出しをキャンセル対応に。

```rust
async fn send_with_cancellation(
    &self,
    session: &dyn LlmSession,
    prompt: &str,
) -> Result<String, RunAgentError> {
    if let Some(ref token) = self.cancellation_token {
        tokio::select! {
            biased;
            _ = token.cancelled() => Err(RunAgentError::Cancelled),
            result = session.send(prompt) => result.map_err(RunAgentError::GatewayError),
        }
    } else {
        session.send(prompt).await.map_err(RunAgentError::GatewayError)
    }
}
```

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Follow-up to #37
Relates to #28

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた

## Additional Notes

### 修正箇所

- `run_exploration_agent()` - コンテキスト収集時のLLM呼び出し
- `create_plan()` - プラン作成時のLLM呼び出し
- `execute_single_task()` - タスク実行時のLLM呼び出し
- `execute_tool_with_retry()` - ツールリトライ時のLLM呼び出し

🤖 Generated with [Claude Code](https://claude.ai/code)