### PR TITLE
fix(copilot): prevent orphan copilot-cli processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ reqwest = { version = "0.12", features = ["json"] }
 # HTML parsing (optional, for web tools)
 scraper = "0.22"
 
+# OS-level process management (Linux: PR_SET_PDEATHSIG)
+libc = "0.2"
+
 # Workspace crates
 quorum-domain = { path = "domain" }
 quorum-application = { path = "application" }

--- a/infrastructure/Cargo.toml
+++ b/infrastructure/Cargo.toml
@@ -47,6 +47,9 @@ reqwest = { workspace = true, optional = true }
 # HTML parsing (optional, for web tools)
 scraper = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [features]
 default = []
 web-tools = ["dep:reqwest", "dep:scraper"]


### PR DESCRIPTION
MessageRouterが破棄された際にcopilot-cliの子プロセスを適切にクリーンアップし、孤立プロセスがシステムリソースを消費するのを防止する。

変更点:
- MessageRouterに子プロセスを終了させるDrop実装を追加
- Dropからのアクセスを可能にするため_childをchildにリネーム
- Linux固有のプロセス管理のためのlibc依存関係を追加
- Linux上で親プロセスの異常終了を処理するためPR_SET_PDEATHSIGを使用

理由:
従来、MessageRouterが終了した場合（例: プラグイン再読み込み時やエラー時）、copilot-cli子プロセスが無限に実行され続け、システムリソースを浪費し、ポート競合を引き起こす可能性がありました。

Linux固有の処理:
Linuxでは、親プロセスが予期せず終了した場合（例: SIGKILL、OOM kill）にカーネルが子プロセスにSIGTERMを確実に送信するよう、prctl(PR_SET_PDEATHSIG, SIGTERM)を使用。Dropが実行されないケースを捕捉。

技術的詳細:
- Drop::drop() は正常なクリーンアップのために child.start_kill() を呼び出す
- PR_SET_PDEATHSIG は Linux 上でカーネルレベルの安全策を提供する
- libc 依存関係は cfg() 経由で Linux ターゲットのみにスコープされる