### PR TITLE
fix(planning): create_plan ツールスキーマ強化と空レスポンスフィルタリング

### DIFF
--- a/application/src/use_cases/run_agent/planning.rs
+++ b/application/src/use_cases/run_agent/planning.rs
@@ -183,8 +183,13 @@ where
                     candidates.push(PlanCandidate::new(model, plan));
                 }
                 Ok((model, Ok(PlanningResult::TextResponse(text)))) => {
-                    info!("Model {} returned text response (no plan)", model);
-                    text_responses.push((model.to_string(), text));
+                    if text.trim().is_empty() {
+                        warn!("Model {} returned empty text response, discarding", model);
+                        failed_count += 1;
+                    } else {
+                        info!("Model {} returned text response (no plan)", model);
+                        text_responses.push((model.to_string(), text));
+                    }
                 }
                 Ok((model, Err(e))) => {
                     // All errors are retryable (timeout, transport close, router stopped, etc.)
@@ -247,8 +252,16 @@ where
                         candidates.push(PlanCandidate::new(model, plan));
                     }
                     Ok(PlanningResult::TextResponse(text)) => {
-                        info!("Model {} returned text response on retry (no plan)", model);
-                        text_responses.push((model.to_string(), text));
+                        if text.trim().is_empty() {
+                            warn!(
+                                "Model {} returned empty text response on retry, discarding",
+                                model
+                            );
+                            failed_count += 1;
+                        } else {
+                            info!("Model {} returned text response on retry (no plan)", model);
+                            text_responses.push((model.to_string(), text));
+                        }
                     }
                     Err(e) => {
                         warn!("Model {} retry failed: {}", model, e);

--- a/domain/src/prompt/agent.rs
+++ b/domain/src/prompt/agent.rs
@@ -53,32 +53,36 @@ Do not wrap tool calls in code blocks."#
     pub fn plan_tool_schema() -> serde_json::Value {
         json!({
             "name": "create_plan",
-            "description": "Create an execution plan. You MUST call this tool to submit your plan.",
+            "description": "Create an execution plan with all required fields. You MUST provide: 'objective' (string describing the goal), 'reasoning' (string explaining your approach), and 'tasks' (array of task objects). Do NOT call this tool with empty arguments.",
             "input_schema": {
                 "type": "object",
                 "properties": {
                     "objective": {
                         "type": "string",
-                        "description": "What we're trying to accomplish"
+                        "description": "A clear description of what we're trying to accomplish. Must not be empty.",
+                        "minLength": 1
                     },
                     "reasoning": {
                         "type": "string",
-                        "description": "Why this approach makes sense"
+                        "description": "Explanation of why this approach makes sense and what alternatives were considered. Must not be empty.",
+                        "minLength": 1
                     },
                     "tasks": {
                         "type": "array",
-                        "description": "Ordered list of tasks to execute",
+                        "description": "Ordered list of tasks to execute. Must contain at least one task.",
                         "minItems": 1,
                         "items": {
                             "type": "object",
                             "properties": {
                                 "id": {
                                     "type": "string",
-                                    "description": "Unique task identifier"
+                                    "description": "Unique task identifier (e.g. 'task-1', 'task-2')",
+                                    "minLength": 1
                                 },
                                 "description": {
                                     "type": "string",
-                                    "description": "What this task does"
+                                    "description": "What this task does",
+                                    "minLength": 1
                                 },
                                 "tool": {
                                     "type": "string",
@@ -94,11 +98,13 @@ Do not wrap tool calls in code blocks."#
                                     "description": "IDs of tasks this depends on"
                                 }
                             },
-                            "required": ["id", "description"]
+                            "required": ["id", "description"],
+                            "additionalProperties": false
                         }
                     }
                 },
-                "required": ["objective", "reasoning", "tasks"]
+                "required": ["objective", "reasoning", "tasks"],
+                "additionalProperties": false
             }
         })
     }


### PR DESCRIPTION
## Summary

- Ensemble planning で GPT/Gemini が `create_plan` を空引数で呼び、空テキストレスポンスがモデレーターに渡る問題を修正
- `create_plan` ツールスキーマを強化し、空レスポンスのフィルタリングを追加

### A. ツールスキーマ強化 (`domain/src/prompt/agent.rs`)
- `description` を具体化（必須フィールド明示、空引数禁止を明記）
- 各プロパティに `minLength: 1` 追加
- `additionalProperties: false` をトップレベル・tasks items 両方に追加

### B. 空テキストレスポンスフィルタリング (`application/src/use_cases/run_agent/planning.rs`)
- `text.trim().is_empty()` で空レスポンスを弾き `failed_count` に回す
- 初回・リトライ両方で対応

Closes #92

## Test plan

- [x] `cargo build` 成功
- [x] `cargo test --workspace` 全テストパス
- [x] Ensemble モードで実際にリクエストを投げて空レスポンスが弾かれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)