### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.7"
+version = "0.6.0"
 edition = "2024"
 authors = ["music-brain88"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- ワークスペースのバージョンを `0.5.7` → `0.6.0` にバンプ

### v0.5.3 以降の主な変更

**feat:**
- Modal TUI with Actor pattern (#80)
- Native Tool Use 一本化 + カスタムツール (#76)
- Web tools サポート (#75)
- CopilotSession Native Tool Use + Ensemble フォールバック (#83, #84)
- Ensemble mode robustness improvements (#85)
- セッションベースのファイルロギング (#91)

**refactor:**
- AgentController / ReplPresenter 抽出 (#67, #71)
- run_agent モジュール責務分離 (#88, #90)

**fix:**
- parse_plan テキスト誤成功修正 (#82)
- orphan copilot-cli process 防止 (#87)
- expert tool timeout / retry 対応 (#86)
- create_plan 空引数 / 空レスポンス対応 (#93)

## Test plan

- [x] `cargo build` 全クレート v0.6.0 でビルド成功
- [x] マージ後に `git tag v0.6.0` を打つ

🤖 Generated with [Claude Code](https://claude.com/claude-code)