### PR TITLE
refactor(tool): extract JSON Schema conversion to ToolSchemaPort (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ The agent system extends quorum to autonomous task execution with safety through
 - `infrastructure/tools/`: LocalToolExecutor implements ToolExecutorPort
 
 **Native Tool Use**: LLM の構造化 Tool Use API を使用してツールを呼び出す（唯一のツール実行パス）。
-- ツール定義は `ToolSpec::to_api_tools()` で JSON Schema に変換
+- ツール定義は `ToolSchemaPort::all_tools_schema()` で JSON Schema に変換（Port パターン）
 - Multi-turn loop: `send_with_tools()` → ToolUse stop → execute → `send_tool_results()` → repeat
 - Low-risk ツールは `futures::join_all()` で並列実行、High-risk は順次 + Quorum Review
 

--- a/application/src/lib.rs
+++ b/application/src/lib.rs
@@ -21,6 +21,7 @@ pub use ports::{
     progress::ProgressNotifier,
     reference_resolver::{ReferenceError, ReferenceResolverPort, ResolvedReference},
     tool_executor::ToolExecutorPort,
+    tool_schema::ToolSchemaPort,
 };
 pub use use_cases::init_context::{
     InitContextError, InitContextInput, InitContextOutput, InitContextProgressNotifier,

--- a/application/src/ports/mod.rs
+++ b/application/src/ports/mod.rs
@@ -10,4 +10,5 @@ pub mod llm_gateway;
 pub mod progress;
 pub mod reference_resolver;
 pub mod tool_executor;
+pub mod tool_schema;
 pub mod ui_event;

--- a/application/src/ports/tool_schema.rs
+++ b/application/src/ports/tool_schema.rs
@@ -1,0 +1,22 @@
+//! Tool schema conversion port.
+//!
+//! Separates "which tools to use" (domain) from "how to serialize for API"
+//! (infrastructure). The domain layer defines [`ToolDefinition`] and
+//! [`ToolSpec`] with filtering logic; this port handles the JSON Schema
+//! conversion that the LLM API requires.
+
+use quorum_domain::tool::entities::{ToolDefinition, ToolSpec};
+
+/// Port for converting tool definitions to LLM API format (JSON Schema).
+///
+/// Separates "which tools to use" (domain) from "how to serialize for API" (infrastructure).
+pub trait ToolSchemaPort: Send + Sync {
+    /// Convert a single tool definition to provider-neutral JSON Schema.
+    fn tool_to_schema(&self, tool: &ToolDefinition) -> serde_json::Value;
+
+    /// Convert all tools to JSON Schema array (sorted by name).
+    fn all_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value>;
+
+    /// Convert low-risk tools only to JSON Schema array (sorted by name).
+    fn low_risk_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value>;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -342,6 +342,7 @@ presentation/
 | `Question` にバリデーションを内包 | 不正な状態を作れないようにする（空の質問を防ぐ） |
 | ユースケースにジェネリクス使用 | 実行時DI（Box<dyn>）ではなくコンパイル時DI |
 | インフラ層でプロトコル詳細を隠蔽 | JSON-RPC, LSPヘッダーなどの詳細はドメインに漏れない |
+| JSON Schema 変換を Port パターンで分離 | domain 層はツールの定義・フィルタリングのみ担当し、LLM API フォーマット（JSON Schema）への変換は `ToolSchemaPort` 経由で infrastructure 層が実装 |
 
 ### TUI Design Philosophy / TUI 設計思想
 
@@ -632,6 +633,7 @@ Quorum（合意形成）に関する型を定義します。
 | `ToolExecutorPort` | ツール実行の抽象化 |
 | `ContextLoaderPort` | コンテキストファイル読み込みの抽象化 |
 | `AgentProgressNotifier` | エージェント進捗通知コールバック |
+| `ToolSchemaPort` | ツール定義 → JSON Schema 変換の抽象化 |
 
 ### Use Cases / ユースケース
 
@@ -668,6 +670,7 @@ Quorum（合意形成）に関する型を定義します。
 | `ToolRegistry` | `ToolExecutorPort` | プロバイダーを集約、優先度でルーティング |
 | `BuiltinProvider` | `ToolProvider` | 最小限の組み込みツール（priority: -100） |
 | `CliToolProvider` | `ToolProvider` | システムCLIツールのラッパー（priority: 50） |
+| `JsonSchemaToolConverter` | `ToolSchemaPort` | ツール定義 → JSON Schema 変換（Port パターン） |
 
 #### 利用可能なツール
 

--- a/domain/src/tool/entities.rs
+++ b/domain/src/tool/entities.rs
@@ -120,58 +120,6 @@ impl ToolDefinition {
     pub fn is_high_risk(&self) -> bool {
         self.risk_level.requires_quorum()
     }
-
-    /// Convert this tool definition to a provider-neutral JSON Schema object.
-    ///
-    /// Returns a JSON object with `name`, `description`, and `input_schema` fields.
-    /// This is the intermediate format used by [`ToolSpec::to_api_tools()`] before
-    /// provider-specific wrapping (e.g., OpenAI's `{"type": "function", "function": {...}}`).
-    ///
-    /// # JSON Schema Type Mapping
-    ///
-    /// | `param_type` | JSON Schema `type` |
-    /// |-------------|-------------------|
-    /// | `"string"`, `"path"` | `"string"` |
-    /// | `"number"` | `"number"` |
-    /// | `"integer"` | `"integer"` |
-    /// | `"boolean"` | `"boolean"` |
-    /// | anything else | `"string"` |
-    pub fn to_json_schema(&self) -> serde_json::Value {
-        let mut properties = serde_json::Map::new();
-        let mut required = Vec::new();
-
-        for param in &self.parameters {
-            let schema_type = match param.param_type.as_str() {
-                "string" | "path" => "string",
-                "number" => "number",
-                "integer" => "integer",
-                "boolean" => "boolean",
-                _ => "string",
-            };
-
-            let mut prop = serde_json::Map::new();
-            prop.insert("type".to_string(), serde_json::json!(schema_type));
-            prop.insert(
-                "description".to_string(),
-                serde_json::json!(param.description),
-            );
-            properties.insert(param.name.clone(), serde_json::Value::Object(prop));
-
-            if param.required {
-                required.push(serde_json::json!(param.name));
-            }
-        }
-
-        serde_json::json!({
-            "name": self.name,
-            "description": self.description,
-            "input_schema": {
-                "type": "object",
-                "properties": properties,
-                "required": required,
-            }
-        })
-    }
 }
 
 impl ToolParameter {
@@ -251,31 +199,6 @@ impl ToolSpec {
     /// Iterate over tools that execute directly without review ([`RiskLevel::Low`]).
     pub fn low_risk_tools(&self) -> impl Iterator<Item = &ToolDefinition> {
         self.tools.values().filter(|t| !t.is_high_risk())
-    }
-
-    /// Convert all registered tools to a provider-neutral JSON Schema array.
-    ///
-    /// Each element has `{"name", "description", "input_schema"}` format.
-    /// Provider-specific wrapping (e.g., OpenAI's `{"type": "function", "function": {...}}`)
-    /// is done in the infrastructure layer.
-    ///
-    /// This is the bridge between `ToolSpec` and the Native Tool Use API:
-    /// ```text
-    /// ToolSpec → to_api_tools() → Vec<Value> → LlmSession::send_with_tools()
-    /// ```
-    pub fn to_api_tools(&self) -> Vec<serde_json::Value> {
-        let mut tools: Vec<&ToolDefinition> = self.tools.values().collect();
-        tools.sort_by_key(|t| &t.name);
-        tools.into_iter().map(|t| t.to_json_schema()).collect()
-    }
-
-    /// Convert only low-risk tools to a provider-neutral JSON Schema array.
-    ///
-    /// Used by the Ask interaction to restrict tool access to read-only operations.
-    pub fn to_low_risk_api_tools(&self) -> Vec<serde_json::Value> {
-        let mut tools: Vec<&ToolDefinition> = self.low_risk_tools().collect();
-        tools.sort_by_key(|t| &t.name);
-        tools.into_iter().map(|t| t.to_json_schema()).collect()
     }
 
     /// Get the number of registered tools.
@@ -440,92 +363,6 @@ mod tests {
         assert_eq!(call.native_id, Some("toolu_abc123".to_string()));
         assert_eq!(call.get_string("path"), Some("/src/main.rs"));
         assert_eq!(call.reasoning, None);
-    }
-
-    #[test]
-    fn test_to_json_schema() {
-        let tool = ToolDefinition::new("read_file", "Read file contents", RiskLevel::Low)
-            .with_parameter(ToolParameter::new("path", "File path to read", true).with_type("path"))
-            .with_parameter(
-                ToolParameter::new("max_lines", "Max lines to read", false).with_type("integer"),
-            );
-
-        let schema = tool.to_json_schema();
-
-        assert_eq!(schema["name"], "read_file");
-        assert_eq!(schema["description"], "Read file contents");
-        assert_eq!(schema["input_schema"]["type"], "object");
-
-        // Check path parameter
-        let path_prop = &schema["input_schema"]["properties"]["path"];
-        assert_eq!(path_prop["type"], "string"); // "path" maps to "string"
-        assert_eq!(path_prop["description"], "File path to read");
-
-        // Check max_lines parameter
-        let lines_prop = &schema["input_schema"]["properties"]["max_lines"];
-        assert_eq!(lines_prop["type"], "integer");
-
-        // Check required
-        let required = schema["input_schema"]["required"].as_array().unwrap();
-        assert_eq!(required.len(), 1);
-        assert_eq!(required[0], "path");
-    }
-
-    #[test]
-    fn test_to_api_tools() {
-        let spec = ToolSpec::new()
-            .register(
-                ToolDefinition::new("read_file", "Read file", RiskLevel::Low)
-                    .with_parameter(ToolParameter::new("path", "File path", true)),
-            )
-            .register(ToolDefinition::new(
-                "write_file",
-                "Write file",
-                RiskLevel::High,
-            ));
-
-        let tools = spec.to_api_tools();
-        assert_eq!(tools.len(), 2);
-
-        // Results are sorted by name
-        assert_eq!(tools[0]["name"], "read_file");
-        assert_eq!(tools[1]["name"], "write_file");
-
-        // Check that all tools have the required fields
-        for tool in &tools {
-            assert!(tool["name"].is_string());
-            assert!(tool["description"].is_string());
-            assert!(tool["input_schema"]["type"].as_str() == Some("object"));
-        }
-    }
-
-    #[test]
-    fn test_to_low_risk_api_tools() {
-        let spec = ToolSpec::new()
-            .register(
-                ToolDefinition::new("read_file", "Read file", RiskLevel::Low)
-                    .with_parameter(ToolParameter::new("path", "File path", true)),
-            )
-            .register(ToolDefinition::new(
-                "write_file",
-                "Write file",
-                RiskLevel::High,
-            ))
-            .register(ToolDefinition::new("grep_search", "Search", RiskLevel::Low));
-
-        let low_risk_tools = spec.to_low_risk_api_tools();
-        assert_eq!(low_risk_tools.len(), 2);
-
-        // Sorted by name
-        assert_eq!(low_risk_tools[0]["name"], "grep_search");
-        assert_eq!(low_risk_tools[1]["name"], "read_file");
-
-        // High-risk tool excluded
-        let names: Vec<&str> = low_risk_tools
-            .iter()
-            .map(|t| t["name"].as_str().unwrap())
-            .collect();
-        assert!(!names.contains(&"write_file"));
     }
 
     #[test]

--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -150,8 +150,8 @@ pub struct SystemMessageConfig {
 
 /// Tool definition for the Copilot CLI session (**Native Tool Use**).
 ///
-/// Converted from the domain's [`ToolSpec::to_api_tools()`](quorum_domain::tool::ToolSpec::to_api_tools)
-/// JSON Schema format via [`from_api_tool`](Self::from_api_tool).
+/// Converted from the [`ToolSchemaPort`](quorum_application::ToolSchemaPort) JSON Schema
+/// format via [`from_api_tool`](Self::from_api_tool).
 ///
 /// The official Copilot SDK uses `"parameters"` for the tool schema field,
 /// not `"inputSchema"` or `"input_schema"`.
@@ -167,9 +167,9 @@ pub struct CopilotToolDefinition {
 }
 
 impl CopilotToolDefinition {
-    /// Convert from the domain's `to_api_tools()` JSON format.
+    /// Convert from the `ToolSchemaPort` JSON format.
     ///
-    /// Reads `"input_schema"` from the domain-layer JSON and maps it to
+    /// Reads `"input_schema"` from the provider-neutral JSON and maps it to
     /// `parameters` for the Copilot CLI wire format.
     pub fn from_api_tool(value: &serde_json::Value) -> Option<Self> {
         Some(Self {

--- a/infrastructure/src/lib.rs
+++ b/infrastructure/src/lib.rs
@@ -22,4 +22,6 @@ pub use copilot::{
     session::CopilotSession,
 };
 pub use reference::GitHubReferenceResolver;
-pub use tools::{LocalToolExecutor, default_tool_spec, read_only_tool_spec};
+pub use tools::{
+    JsonSchemaToolConverter, LocalToolExecutor, default_tool_spec, read_only_tool_spec,
+};

--- a/infrastructure/src/tools/custom_provider.rs
+++ b/infrastructure/src/tools/custom_provider.rs
@@ -670,7 +670,9 @@ mod tests {
             spec = spec.register(tool);
         }
 
-        let api_tools = spec.to_api_tools();
+        let converter = crate::tools::JsonSchemaToolConverter;
+        use quorum_application::ports::tool_schema::ToolSchemaPort;
+        let api_tools = converter.all_tools_schema(&spec);
         assert_eq!(api_tools.len(), 1);
         assert_eq!(api_tools[0]["name"], "my_custom_tool");
         assert_eq!(api_tools[0]["description"], "My custom tool");

--- a/infrastructure/src/tools/executor.rs
+++ b/infrastructure/src/tools/executor.rs
@@ -125,7 +125,7 @@ impl LocalToolExecutor {
     /// Register custom tools from config.
     ///
     /// Custom tool definitions are added to the tool spec so they appear
-    /// in `to_api_tools()` and `available_tools()`. Execution is delegated
+    /// in `ToolSchemaPort::all_tools_schema()` and `available_tools()`. Execution is delegated
     /// to the embedded [`CustomToolProvider`].
     pub fn with_custom_tools(
         mut self,
@@ -141,7 +141,7 @@ impl LocalToolExecutor {
         }
 
         // Register custom tool definitions in the tool spec so they appear
-        // in to_api_tools() and available_tools()
+        // in ToolSchemaPort::all_tools_schema() and available_tools()
         for (name, config) in configs {
             let risk_level = match config.risk_level.to_lowercase().as_str() {
                 "low" => quorum_domain::tool::entities::RiskLevel::Low,

--- a/infrastructure/src/tools/mod.rs
+++ b/infrastructure/src/tools/mod.rs
@@ -51,12 +51,14 @@ mod executor;
 mod registry;
 
 pub mod custom_provider;
+pub mod schema;
 
 pub use builtin::BuiltinProvider;
 pub use cli::CliToolProvider;
 pub use custom_provider::CustomToolProvider;
 pub use executor::LocalToolExecutor;
 pub use registry::{RegistryStats, ToolRegistry};
+pub use schema::JsonSchemaToolConverter;
 
 use quorum_domain::tool::entities::ToolSpec;
 

--- a/infrastructure/src/tools/schema.rs
+++ b/infrastructure/src/tools/schema.rs
@@ -1,0 +1,163 @@
+//! JSON Schema tool converter.
+//!
+//! Default implementation of [`ToolSchemaPort`] that produces provider-neutral
+//! JSON Schema for the Native Tool Use API.
+
+use quorum_application::ports::tool_schema::ToolSchemaPort;
+use quorum_domain::tool::entities::{ToolDefinition, ToolSpec};
+
+/// Default implementation producing provider-neutral JSON Schema.
+///
+/// Handles param_type → JSON Schema type mapping:
+/// - `"string"`, `"path"` → `"string"`
+/// - `"number"` → `"number"`
+/// - `"integer"` → `"integer"`
+/// - `"boolean"` → `"boolean"`
+/// - anything else → `"string"`
+pub struct JsonSchemaToolConverter;
+
+impl ToolSchemaPort for JsonSchemaToolConverter {
+    fn tool_to_schema(&self, tool: &ToolDefinition) -> serde_json::Value {
+        let mut properties = serde_json::Map::new();
+        let mut required = Vec::new();
+
+        for param in &tool.parameters {
+            let schema_type = match param.param_type.as_str() {
+                "string" | "path" => "string",
+                "number" => "number",
+                "integer" => "integer",
+                "boolean" => "boolean",
+                _ => "string",
+            };
+
+            let mut prop = serde_json::Map::new();
+            prop.insert("type".to_string(), serde_json::json!(schema_type));
+            prop.insert(
+                "description".to_string(),
+                serde_json::json!(param.description),
+            );
+            properties.insert(param.name.clone(), serde_json::Value::Object(prop));
+
+            if param.required {
+                required.push(serde_json::json!(param.name));
+            }
+        }
+
+        serde_json::json!({
+            "name": tool.name,
+            "description": tool.description,
+            "input_schema": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            }
+        })
+    }
+
+    fn all_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value> {
+        let mut tools: Vec<&ToolDefinition> = spec.all().collect();
+        tools.sort_by_key(|t| &t.name);
+        tools.into_iter().map(|t| self.tool_to_schema(t)).collect()
+    }
+
+    fn low_risk_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value> {
+        let mut tools: Vec<&ToolDefinition> = spec.low_risk_tools().collect();
+        tools.sort_by_key(|t| &t.name);
+        tools.into_iter().map(|t| self.tool_to_schema(t)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quorum_domain::tool::entities::{RiskLevel, ToolParameter};
+
+    #[test]
+    fn test_tool_to_schema() {
+        let converter = JsonSchemaToolConverter;
+        let tool = ToolDefinition::new("read_file", "Read file contents", RiskLevel::Low)
+            .with_parameter(ToolParameter::new("path", "File path to read", true).with_type("path"))
+            .with_parameter(
+                ToolParameter::new("max_lines", "Max lines to read", false).with_type("integer"),
+            );
+
+        let schema = converter.tool_to_schema(&tool);
+
+        assert_eq!(schema["name"], "read_file");
+        assert_eq!(schema["description"], "Read file contents");
+        assert_eq!(schema["input_schema"]["type"], "object");
+
+        // Check path parameter
+        let path_prop = &schema["input_schema"]["properties"]["path"];
+        assert_eq!(path_prop["type"], "string"); // "path" maps to "string"
+        assert_eq!(path_prop["description"], "File path to read");
+
+        // Check max_lines parameter
+        let lines_prop = &schema["input_schema"]["properties"]["max_lines"];
+        assert_eq!(lines_prop["type"], "integer");
+
+        // Check required
+        let required = schema["input_schema"]["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0], "path");
+    }
+
+    #[test]
+    fn test_all_tools_schema() {
+        let converter = JsonSchemaToolConverter;
+        let spec = ToolSpec::new()
+            .register(
+                ToolDefinition::new("read_file", "Read file", RiskLevel::Low)
+                    .with_parameter(ToolParameter::new("path", "File path", true)),
+            )
+            .register(ToolDefinition::new(
+                "write_file",
+                "Write file",
+                RiskLevel::High,
+            ));
+
+        let tools = converter.all_tools_schema(&spec);
+        assert_eq!(tools.len(), 2);
+
+        // Results are sorted by name
+        assert_eq!(tools[0]["name"], "read_file");
+        assert_eq!(tools[1]["name"], "write_file");
+
+        // Check that all tools have the required fields
+        for tool in &tools {
+            assert!(tool["name"].is_string());
+            assert!(tool["description"].is_string());
+            assert!(tool["input_schema"]["type"].as_str() == Some("object"));
+        }
+    }
+
+    #[test]
+    fn test_low_risk_tools_schema() {
+        let converter = JsonSchemaToolConverter;
+        let spec = ToolSpec::new()
+            .register(
+                ToolDefinition::new("read_file", "Read file", RiskLevel::Low)
+                    .with_parameter(ToolParameter::new("path", "File path", true)),
+            )
+            .register(ToolDefinition::new(
+                "write_file",
+                "Write file",
+                RiskLevel::High,
+            ))
+            .register(ToolDefinition::new("grep_search", "Search", RiskLevel::Low));
+
+        let low_risk_tools = converter.low_risk_tools_schema(&spec);
+        assert_eq!(low_risk_tools.len(), 2);
+
+        // Sorted by name
+        assert_eq!(low_risk_tools[0]["name"], "grep_search");
+        assert_eq!(low_risk_tools[1]["name"], "read_file");
+
+        // High-risk tool excluded
+        let names: Vec<&str> = low_risk_tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert!(!names.contains(&"write_file"));
+    }
+}

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -65,7 +65,7 @@ use std::io::{self, Write};
 /// use std::sync::Arc;
 ///
 /// let intervention = Arc::new(InteractiveHumanIntervention::new());
-/// let use_case = RunAgentUseCase::new(gateway, executor)
+/// let use_case = RunAgentUseCase::new(gateway, executor, tool_schema)
 ///     .with_human_intervention(intervention);
 /// ```
 pub struct InteractiveHumanIntervention;

--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -40,7 +40,8 @@ use crossterm::{
 use futures::stream::StreamExt;
 use quorum_application::QuorumConfig;
 use quorum_application::{
-    AgentController, CommandAction, ContextLoaderPort, LlmGateway, ToolExecutorPort, UiEvent,
+    AgentController, CommandAction, ContextLoaderPort, LlmGateway, ToolExecutorPort,
+    ToolSchemaPort, UiEvent,
 };
 use quorum_domain::core::string::truncate;
 use quorum_domain::{ConsensusLevel, HumanDecision, Model};
@@ -88,6 +89,7 @@ impl<G: LlmGateway + 'static, T: ToolExecutorPort + 'static, C: ContextLoaderPor
     pub fn new(
         gateway: Arc<G>,
         tool_executor: Arc<T>,
+        tool_schema: Arc<dyn ToolSchemaPort>,
         context_loader: Arc<C>,
         config: QuorumConfig,
     ) -> Self {
@@ -110,6 +112,7 @@ impl<G: LlmGateway + 'static, T: ToolExecutorPort + 'static, C: ContextLoaderPor
         let controller = AgentController::new(
             gateway,
             tool_executor,
+            tool_schema,
             context_loader,
             config,
             human_intervention,


### PR DESCRIPTION
## Summary

- `ToolDefinition::to_json_schema()` / `ToolSpec::to_api_tools()` / `ToolSpec::to_low_risk_api_tools()` を domain 層から削除し、Port パターンで application/infrastructure に分離
- domain 層はツールの **定義・フィルタリング** (`low_risk_tools()`, `all()`) のみ担当し、LLM API フォーマット（JSON Schema）への変換は `ToolSchemaPort` 経由で infrastructure 層が実装

## Changes

### 新規ファイル
| File | Description |
|------|-------------|
| `application/src/ports/tool_schema.rs` | `ToolSchemaPort` trait（3メソッド: `tool_to_schema`, `all_tools_schema`, `low_risk_tools_schema`） |
| `infrastructure/src/tools/schema.rs` | `JsonSchemaToolConverter` 実装 + テスト3件（domain から移行） |

### DI 伝播
`Arc<dyn ToolSchemaPort>` を以下のチェーンで注入:

```
CLI (JsonSchemaToolConverter)
  → TuiApp / RunAgentUseCase
    → AgentController
      → RunAgentUseCase
        → GatherContextUseCase
        → ExecuteTaskUseCase
  → RunAskUseCase (standalone)
```

### Domain 層からの削除
- `ToolDefinition::to_json_schema()`
- `ToolSpec::to_api_tools()`
- `ToolSpec::to_low_risk_api_tools()`
- 関連テスト 3件 → `infrastructure/src/tools/schema.rs` に移行

### ドキュメント更新
- `CLAUDE.md` — `to_api_tools()` → `ToolSchemaPort::all_tools_schema()` 参照更新
- `docs/ARCHITECTURE.md` — Port 一覧 + 設計判断に追記
- `docs/features/native-tool-use.md` — JSON Schema 変換セクション書き換え

## Design Decision

既存の `Arc<dyn ActionReviewer>`, `Arc<dyn HumanInterventionPort>` と同じ trait object パターンを採用。ジェネリクスの増殖を避けつつ、domain 層から API フォーマットの関心事を分離。

## Test plan

- [x] `cargo build` — 全クレートコンパイル通過
- [x] `cargo test --workspace` — 全 541 テスト通過（0 failures）
- [x] domain テスト — JSON Schema テスト 3件が削除されていること確認
- [x] infrastructure テスト — JSON Schema テスト 3件が移行されていること確認
- [x] application テスト — use case テスト（RunAsk, RunAgent flow tests）が通ること確認

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)