### PR TITLE
fix: resolve 4 quick-win issues (#129, #131, #158, #165)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["music-brain88"]
 license = "MIT OR Apache-2.0"

--- a/application/src/ports/llm_gateway.rs
+++ b/application/src/ports/llm_gateway.rs
@@ -115,6 +115,7 @@ impl StreamHandle {
 ///     tool_name: "read_file".to_string(),
 ///     output: "fn main() { ... }".to_string(),
 ///     is_error: false,
+///     is_rejected: false,
 /// };
 /// let next_response = session.send_tool_results(&[result]).await?;
 /// ```
@@ -128,6 +129,11 @@ pub struct ToolResultMessage {
     pub output: String,
     /// Whether this result represents an error.
     pub is_error: bool,
+    /// Whether this result was rejected by HiL / action review.
+    ///
+    /// When `true`, the transport layer sends `resultType: "rejected"` instead of
+    /// `"failure"`, allowing the LLM to distinguish policy rejections from tool errors.
+    pub is_rejected: bool,
 }
 
 /// An active LLM session

--- a/application/src/use_cases/gather_context.rs
+++ b/application/src/use_cases/gather_context.rs
@@ -275,6 +275,7 @@ impl<T: ToolExecutorPort + 'static, C: ContextLoaderPort + 'static> GatherContex
                         tool_name: call.tool_name.clone(),
                         output,
                         is_error,
+                        is_rejected: false,
                     });
                 } else {
                     warn!(

--- a/application/src/use_cases/run_agent/planning.rs
+++ b/application/src/use_cases/run_agent/planning.rs
@@ -508,6 +508,7 @@ pub(super) async fn generate_plan_from_session(
                      fields. Please call create_plan again with all required arguments."
                 .to_string(),
             is_error: true,
+            is_rejected: false,
         }];
         let retry = session.send_tool_results(&results).await?;
         if let Some(plan) = extract_plan_from_response(&retry) {

--- a/application/src/use_cases/run_ask.rs
+++ b/application/src/use_cases/run_ask.rs
@@ -186,6 +186,7 @@ impl<G: LlmGateway + 'static, T: ToolExecutorPort + 'static> RunAskUseCase<G, T>
                         tool_name: call.tool_name.clone(),
                         output,
                         is_error,
+                        is_rejected: false,
                     });
                 } else {
                     warn!(

--- a/docs/features/native-tool-use.md
+++ b/docs/features/native-tool-use.md
@@ -260,6 +260,7 @@ pub struct ToolResultMessage {
     pub tool_name: String,     // ツール名（ログ用）
     pub output: String,        // 実行結果 or エラーメッセージ
     pub is_error: bool,        // エラーかどうか
+    pub is_rejected: bool,     // HiL/action review で拒否されたか
 }
 ```
 

--- a/domain/src/interaction/mod.rs
+++ b/domain/src/interaction/mod.rs
@@ -7,7 +7,7 @@
 //! | Form | Description | Context Default |
 //! |------|-------------|-----------------|
 //! | [`Agent`](InteractionForm::Agent) | Autonomous task execution with planning | `Full` |
-//! | [`Ask`](InteractionForm::Ask) | Single question → answer (no tool use) | `Projected` |
+//! | [`Ask`](InteractionForm::Ask) | Single question → answer (read-only tools) | `Projected` |
 //! | [`Discuss`](InteractionForm::Discuss) | Multi-model discussion / council | `Full` |
 //!
 //! # Nesting
@@ -52,9 +52,10 @@ pub enum InteractionForm {
     ///
     /// Uses: `SessionMode`, `AgentPolicy`, `ExecutionParams`
     Agent,
-    /// Single question → answer. No tool use, no planning.
+    /// Single question → answer. Uses low-risk (read-only) tools for context
+    /// gathering, no planning.
     ///
-    /// Uses: `SessionMode` (for model selection only)
+    /// Uses: `SessionMode` (for model selection), `ExecutionParams` (max_tool_turns)
     Ask,
     /// Multi-model discussion / Quorum council.
     ///
@@ -99,9 +100,9 @@ impl InteractionForm {
 
     /// Whether this form uses `ExecutionParams` (iteration limits, tool turns, etc.).
     ///
-    /// Only `Agent` has execution loops that need limiting.
+    /// Both `Agent` and `Ask` have tool-use loops that need `max_tool_turns`.
     pub fn uses_execution_params(&self) -> bool {
-        matches!(self, InteractionForm::Agent)
+        matches!(self, InteractionForm::Agent | InteractionForm::Ask)
     }
 
     /// Returns the canonical string representation.
@@ -470,7 +471,7 @@ mod tests {
     #[test]
     fn test_interaction_form_uses_execution_params() {
         assert!(InteractionForm::Agent.uses_execution_params());
-        assert!(!InteractionForm::Ask.uses_execution_params());
+        assert!(InteractionForm::Ask.uses_execution_params());
         assert!(!InteractionForm::Discuss.uses_execution_params());
     }
 

--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -328,6 +328,13 @@ impl ToolCallResult {
         }
     }
 
+    pub fn rejected(text: impl Into<String>) -> Self {
+        Self {
+            text_result_for_llm: text.into(),
+            result_type: "rejected".to_string(),
+        }
+    }
+
     /// Serialize into the `{ "result": { ... } }` envelope expected by the
     /// Copilot CLI on the wire.
     pub fn into_rpc_value(self) -> serde_json::Value {
@@ -470,6 +477,16 @@ mod tests {
         let result = ToolCallResult::error("File not found");
         assert_eq!(result.result_type, "failure");
         assert_eq!(result.text_result_for_llm, "File not found");
+    }
+
+    #[test]
+    fn tool_call_result_rejected() {
+        let result = ToolCallResult::rejected("Action rejected by quorum review");
+        assert_eq!(result.result_type, "rejected");
+        assert_eq!(
+            result.text_result_for_llm,
+            "Action rejected by quorum review"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

4つの小さな Issue をまとめて修正。いずれも数行の変更で完結する Quick Win。

### #158: ConversationLogger がリジェクトされたツール呼び出しを記録しない
- `execute_task.rs` の `ReviewDecision::Rejected` ブロックで `continue` の前に `conversation_logger.log()` を2回追加（tool_call + tool_result）
- rejected フラグ付きで記録するため、通常のツール呼び出しと区別可能

### #165: InteractionForm::Ask のドキュメントと実装の不整合
- モジュール doc テーブル: `(no tool use)` → `(read-only tools)`
- Ask variant docstring: read-only tools for context gathering に更新
- `uses_execution_params()`: Ask → `true` に変更（Ask も `max_tool_turns` を使う）
- テスト更新

### #131: ツール結果送信の診断ログ追加
- `session.rs` の `send_tool_results()` に `debug!` ログ追加（tool名, resultType, output_bytes）
- `trace!` レベルで JSON ペイロード全体を出力

### #129: HiL 拒否時に resultType "rejected" を返す
- `ToolResultMessage` に `is_rejected: bool` フィールド追加
- `ToolCallResult::rejected()` コンストラクタ追加
- `send_tool_results()` で `is_rejected` を先にチェック → `resultType: "rejected"` を送信
- 全5箇所の `ToolResultMessage` 構築で `is_rejected: false` を追加
- rejected のみ `is_error: false, is_rejected: true` に変更
- ドキュメント更新

### Version Bump
- `0.10.0` → `0.10.1`

## Test plan

- [x] `cargo build` がクリーンにビルド
- [x] `cargo test --workspace` が全テスト通過（0 failed）
- [x] `ToolCallResult::rejected()` のユニットテスト追加
- [x] `InteractionForm::Ask.uses_execution_params()` のテスト更新

Closes #129, #131, #158, #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)