### PR TITLE
fix(ci): split release-drafter jobs to avoid target_commitish error

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,12 +11,28 @@ permissions:
   contents: read
 
 jobs:
+  autolabel:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   update_release_draft:
+    if: github.event_name == 'push'
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `pull_request` イベントで release-drafter が走ると `target_commitish` に `refs/pull/*/merge` がセットされ、GitHub API が 422 エラーを返す問題を修正
- ジョブを `autolabel`（PR用）と `update_release_draft`（push用）に分割し、それぞれ不要な機能を `disable-releaser` / `disable-autolabeler` で無効化

## Changes
- **`autolabel` job**: `pull_request` イベントのみ、`disable-releaser: true` でリリースドラフト更新をスキップ
- **`update_release_draft` job**: `push` イベントのみ、`disable-autolabeler: true` で PR ラベリングをスキップ

## Test plan
- [x] PR を push して `autolabel` ジョブだけが走り、ラベルが付与されることを確認
- [x] main にマージ後 `update_release_draft` ジョブが走り、ドラフトが正しく更新されることを確認