### PR TITLE
fix(docs): correct repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ graph TD
 ### From Source / ソースからビルド
 
 ```bash
-git clone https://github.com/archie/copilot-quorum
+git clone https://github.com/music-brain88/copilot-quorum
 cd copilot-quorum
 cargo install --path cli
 ```


### PR DESCRIPTION
## Summary
- README.md の `git clone` URLが `github.com/archie/copilot-quorum` になっていたのを正しい `github.com/music-brain88/copilot-quorum` に修正

## Test plan
- [x] README.md のクローンURLが正しいことを確認