### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "copilot-quorum"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-application"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-domain"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-infrastructure"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-presentation"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["music-brain88"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump workspace version from `0.11.0` to `0.12.0`
- All crates auto-follow via `version.workspace = true`

### Changes since v0.11.0

| PR | Type | Description |
|----|------|-------------|
| #175 | docs | ドキュメント全面リライト |
| #176 | chore | release-drafter に emoji 追加 |
| #177 | fix | CI release-drafter jobs 分割 |
| #178 | fix | README リポジトリURL修正 |
| #179 | refactor | TUI の Clone 削除・visibility 制限・builder |
| #180 | feat | ツール結果の truncated debug log + internal tool 実行記録 |
| #187 | refactor | ModelConfig にロールフィールド追加 |

Minor bump due to new feature (#180).

## Test plan

- [x] `cargo build` — all 5 crates compile at v0.12.0
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace` — no warnings