### PR TITLE
bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "copilot-quorum"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-application"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-domain"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-infrastructure"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-presentation"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["music-brain88"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This pull request makes a minor update to the workspace package version in `Cargo.toml`. The version has been incremented from `0.12.0` to `0.12.1`.