### PR TITLE
refactor(tui): add ContentRenderer registry + dynamic pane dispatch

### DIFF
--- a/application/src/ports/agent_progress.rs
+++ b/application/src/ports/agent_progress.rs
@@ -222,6 +222,17 @@ pub trait AgentProgressNotifier: Send + Sync {
     ///
     /// This happens when all models fail to generate plans in ensemble mode.
     fn on_ensemble_fallback(&self, _reason: &str) {}
+
+    // ==================== Ensemble Model Stream Callbacks ====================
+
+    /// Called when a model starts streaming during ensemble planning.
+    fn on_ensemble_model_stream_start(&self, _model: &str) {}
+
+    /// Called for each text chunk from a model during ensemble planning.
+    fn on_ensemble_model_stream_chunk(&self, _model: &str, _chunk: &str) {}
+
+    /// Called when a model finishes streaming during ensemble planning.
+    fn on_ensemble_model_stream_end(&self, _model: &str) {}
 }
 
 /// No-op implementation for when progress isn't needed

--- a/presentation/src/tui/content.rs
+++ b/presentation/src/tui/content.rs
@@ -2,11 +2,18 @@
 //!
 //! Each `ContentSlot` variant identifies a logical content type. Concrete
 //! structs (e.g. `ConversationContent`) own the data that widgets render.
+//!
+//! `ContentRenderer` trait and `ContentRegistry` provide registry-driven
+//! dispatch (same pattern as ToolSpec / ToolProvider).
 
-use super::state::{DisplayMessage, ProgressState};
+use std::collections::HashMap;
+
+use ratatui::{buffer::Buffer, layout::Rect};
+
+use super::state::{DisplayMessage, ProgressState, TuiState};
 
 /// Logical content slot — identifies what kind of content occupies a surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ContentSlot {
     Conversation,
     Progress,
@@ -15,6 +22,61 @@ pub enum ContentSlot {
     Help,
     /// Tool execution log — separable from Progress for independent routing.
     ToolLog,
+    /// Dynamic: Ensemble model output stream (keyed by model name).
+    ModelStream(String),
+}
+
+/// Content rendering capability (analogous to ToolProvider).
+///
+/// Each renderer knows which `ContentSlot` it handles and how to paint
+/// into a given area. Renderers are registered in `ContentRegistry` and
+/// dispatched by the render loop via route table lookup.
+pub trait ContentRenderer {
+    /// Which content slot this renderer handles.
+    fn slot(&self) -> ContentSlot;
+
+    /// Render content into the given area.
+    fn render_content(&self, state: &TuiState, area: Rect, buf: &mut Buffer);
+}
+
+/// ContentSlot → Renderer registry (analogous to ToolSpec).
+///
+/// Holds a mapping from each `ContentSlot` to its renderer implementation.
+/// Built via the builder pattern: `ContentRegistry::new().register(...)`.
+pub struct ContentRegistry {
+    renderers: HashMap<ContentSlot, Box<dyn ContentRenderer>>,
+}
+
+impl ContentRegistry {
+    pub fn new() -> Self {
+        Self {
+            renderers: HashMap::new(),
+        }
+    }
+
+    /// Register a renderer (builder pattern, consumes self).
+    pub fn register(mut self, renderer: Box<dyn ContentRenderer>) -> Self {
+        let slot = renderer.slot();
+        self.renderers.insert(slot, renderer);
+        self
+    }
+
+    /// Register a renderer mutably (for dynamic registration at runtime).
+    pub fn register_mut(&mut self, renderer: Box<dyn ContentRenderer>) {
+        let slot = renderer.slot();
+        self.renderers.insert(slot, renderer);
+    }
+
+    /// Look up the renderer for a given slot.
+    pub fn get(&self, slot: &ContentSlot) -> Option<&dyn ContentRenderer> {
+        self.renderers.get(slot).map(|r| r.as_ref())
+    }
+}
+
+impl Default for ContentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Conversation content — messages, streaming text, and scroll state.
@@ -57,5 +119,44 @@ mod tests {
     fn test_content_slot_eq() {
         assert_eq!(ContentSlot::Conversation, ContentSlot::Conversation);
         assert_ne!(ContentSlot::Conversation, ContentSlot::Progress);
+    }
+
+    #[test]
+    fn test_content_slot_model_stream() {
+        let slot_a = ContentSlot::ModelStream("claude".to_string());
+        let slot_b = ContentSlot::ModelStream("claude".to_string());
+        let slot_c = ContentSlot::ModelStream("gpt".to_string());
+        assert_eq!(slot_a, slot_b);
+        assert_ne!(slot_a, slot_c);
+    }
+
+    #[test]
+    fn test_content_registry_register_and_get() {
+        struct DummyRenderer;
+        impl ContentRenderer for DummyRenderer {
+            fn slot(&self) -> ContentSlot {
+                ContentSlot::Progress
+            }
+            fn render_content(&self, _state: &TuiState, _area: Rect, _buf: &mut Buffer) {}
+        }
+
+        let registry = ContentRegistry::new().register(Box::new(DummyRenderer));
+        assert!(registry.get(&ContentSlot::Progress).is_some());
+        assert!(registry.get(&ContentSlot::Conversation).is_none());
+    }
+
+    #[test]
+    fn test_content_registry_register_mut() {
+        struct DummyRenderer;
+        impl ContentRenderer for DummyRenderer {
+            fn slot(&self) -> ContentSlot {
+                ContentSlot::Help
+            }
+            fn render_content(&self, _state: &TuiState, _area: Rect, _buf: &mut Buffer) {}
+        }
+
+        let mut registry = ContentRegistry::new();
+        registry.register_mut(Box::new(DummyRenderer));
+        assert!(registry.get(&ContentSlot::Help).is_some());
     }
 }

--- a/presentation/src/tui/event.rs
+++ b/presentation/src/tui/event.rs
@@ -151,6 +151,18 @@ pub enum TuiEvent {
     },
     EnsembleFallback(String),
 
+    // -- Ensemble model stream (per-model live output) --
+    EnsembleModelStreamStart(String),
+    EnsembleModelStreamChunk {
+        model: String,
+        chunk: String,
+    },
+    EnsembleModelStreamEnd(String),
+    EnsembleVoteScore {
+        model: String,
+        score: f64,
+    },
+
     // -- Tool execution lifecycle --
     ToolExecutionUpdate {
         task_index: usize,

--- a/presentation/src/tui/mod.rs
+++ b/presentation/src/tui/mod.rs
@@ -20,7 +20,9 @@ pub mod tab;
 mod widgets;
 
 pub use app::TuiApp;
-pub use content::{ContentSlot, ConversationContent, ProgressContent};
+pub use content::{
+    ContentRegistry, ContentRenderer, ContentSlot, ConversationContent, ProgressContent,
+};
 pub use event::TuiEvent;
 pub use human_intervention::TuiHumanIntervention;
 pub use layout::{LayoutPreset, TuiLayoutConfig};

--- a/presentation/src/tui/progress.rs
+++ b/presentation/src/tui/progress.rs
@@ -294,6 +294,21 @@ impl AgentProgressNotifier for TuiProgressBridge {
     fn on_ensemble_fallback(&self, reason: &str) {
         self.emit(TuiEvent::EnsembleFallback(reason.to_string()));
     }
+
+    fn on_ensemble_model_stream_start(&self, model: &str) {
+        self.emit(TuiEvent::EnsembleModelStreamStart(model.to_string()));
+    }
+
+    fn on_ensemble_model_stream_chunk(&self, model: &str, chunk: &str) {
+        self.emit(TuiEvent::EnsembleModelStreamChunk {
+            model: model.to_string(),
+            chunk: chunk.to_string(),
+        });
+    }
+
+    fn on_ensemble_model_stream_end(&self, model: &str) {
+        self.emit(TuiEvent::EnsembleModelStreamEnd(model.to_string()));
+    }
 }
 
 #[cfg(test)]

--- a/presentation/src/tui/state.rs
+++ b/presentation/src/tui/state.rs
@@ -413,6 +413,27 @@ pub struct EnsembleProgress {
     pub voting_started: bool,
     pub plan_count: Option<usize>,
     pub selected: Option<(String, f64)>,
+    /// Per-model streaming state for live output display.
+    pub model_streams: std::collections::HashMap<String, ModelStreamState>,
+}
+
+/// Per-model streaming state during Ensemble planning.
+#[derive(Debug, Clone)]
+pub struct ModelStreamState {
+    pub model_name: String,
+    pub streaming_text: String,
+    pub status: ModelStreamStatus,
+    pub score: Option<f64>,
+    pub duration_ms: Option<u64>,
+}
+
+/// Status of a model stream during Ensemble planning.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ModelStreamStatus {
+    Pending,
+    Streaming,
+    Complete,
+    Error(String),
 }
 
 /// TUI input configuration (presentation-layer view)

--- a/presentation/src/tui/surface.rs
+++ b/presentation/src/tui/surface.rs
@@ -8,8 +8,9 @@ use super::widgets::MainLayout;
 use ratatui::layout::Rect;
 
 /// Named surface — a physical region of the terminal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SurfaceId {
+    // Fixed chrome
     MainPane,
     Sidebar,
     Overlay,
@@ -21,10 +22,27 @@ pub enum SurfaceId {
     ToolPane,
     /// Floating overlay for tool display.
     ToolFloat,
+    /// Dynamically added pane (e.g. Ensemble model streams).
+    DynamicPane(String),
+}
+
+impl SurfaceId {
+    /// Whether this surface is a content pane (participates in dynamic layout).
+    pub fn is_content_pane(&self) -> bool {
+        matches!(
+            self,
+            Self::MainPane | Self::Sidebar | Self::ToolPane | Self::DynamicPane(_)
+        )
+    }
+
+    /// Whether this surface is an overlay (rendered on top of content).
+    pub fn is_overlay(&self) -> bool {
+        matches!(self, Self::Overlay | Self::ToolFloat)
+    }
 }
 
 /// A surface with its resolved screen area.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ResolvedSurface {
     pub id: SurfaceId,
     pub area: Rect,
@@ -37,27 +55,22 @@ pub struct SurfaceLayout {
 
 impl SurfaceLayout {
     /// Look up the area for a given surface id.
-    pub fn area_for(&self, id: SurfaceId) -> Option<Rect> {
-        self.surfaces.iter().find(|s| s.id == id).map(|s| s.area)
+    pub fn area_for(&self, id: &SurfaceId) -> Option<Rect> {
+        self.surfaces.iter().find(|s| &s.id == id).map(|s| s.area)
     }
 
-    /// Build from the existing `MainLayout`.
+    /// Build from the existing `MainLayout` with dynamic pane mapping.
+    ///
+    /// `pane_surfaces` provides the SurfaceId for each pane in order.
+    /// `layout.panes[i]` is mapped to `pane_surfaces[i]`.
     ///
     /// Zero-size Rects (width=0 or height=0) are filtered out so that
     /// `area_for()` returns `None` for surfaces not present in the current preset.
-    pub fn from_main_layout(layout: &MainLayout) -> Self {
+    pub fn from_main_layout(layout: &MainLayout, pane_surfaces: &[SurfaceId]) -> Self {
         let mut candidates = vec![
             ResolvedSurface {
                 id: SurfaceId::Header,
                 area: layout.header,
-            },
-            ResolvedSurface {
-                id: SurfaceId::MainPane,
-                area: layout.conversation,
-            },
-            ResolvedSurface {
-                id: SurfaceId::Sidebar,
-                area: layout.progress,
             },
             ResolvedSurface {
                 id: SurfaceId::Input,
@@ -68,17 +81,22 @@ impl SurfaceLayout {
                 area: layout.status_bar,
             },
         ];
+
         if let Some(tab_bar) = layout.tab_bar {
             candidates.push(ResolvedSurface {
                 id: SurfaceId::TabBar,
                 area: tab_bar,
             });
         }
-        if let Some(tool_pane) = layout.tool_pane {
-            candidates.push(ResolvedSurface {
-                id: SurfaceId::ToolPane,
-                area: tool_pane,
-            });
+
+        // Map panes[i] → pane_surfaces[i]
+        for (i, pane_area) in layout.panes.iter().enumerate() {
+            if let Some(surface_id) = pane_surfaces.get(i) {
+                candidates.push(ResolvedSurface {
+                    id: surface_id.clone(),
+                    area: *pane_area,
+                });
+            }
         }
 
         // Filter out zero-size surfaces (e.g. Minimal preset sets progress to ZERO)
@@ -88,6 +106,12 @@ impl SurfaceLayout {
             .collect();
 
         Self { surfaces }
+    }
+
+    /// Add an overlay surface (for help dialog, HiL modal, etc.).
+    #[allow(dead_code)]
+    pub fn add_overlay(&mut self, id: SurfaceId, area: Rect) {
+        self.surfaces.push(ResolvedSurface { id, area });
     }
 }
 
@@ -100,37 +124,39 @@ mod tests {
         let layout = MainLayout {
             header: Rect::new(0, 0, 80, 3),
             tab_bar: None,
-            conversation: Rect::new(0, 3, 56, 17),
-            progress: Rect::new(56, 3, 24, 17),
+            panes: vec![
+                Rect::new(0, 3, 56, 17),  // MainPane
+                Rect::new(56, 3, 24, 17), // Sidebar
+            ],
             input: Rect::new(0, 20, 80, 3),
             status_bar: Rect::new(0, 23, 80, 1),
-            tool_pane: None,
         };
 
-        let surface = SurfaceLayout::from_main_layout(&layout);
+        let pane_surfaces = vec![SurfaceId::MainPane, SurfaceId::Sidebar];
+        let surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
 
         assert_eq!(
-            surface.area_for(SurfaceId::Header),
+            surface.area_for(&SurfaceId::Header),
             Some(Rect::new(0, 0, 80, 3))
         );
         assert_eq!(
-            surface.area_for(SurfaceId::MainPane),
+            surface.area_for(&SurfaceId::MainPane),
             Some(Rect::new(0, 3, 56, 17))
         );
         assert_eq!(
-            surface.area_for(SurfaceId::Sidebar),
+            surface.area_for(&SurfaceId::Sidebar),
             Some(Rect::new(56, 3, 24, 17))
         );
         assert_eq!(
-            surface.area_for(SurfaceId::Input),
+            surface.area_for(&SurfaceId::Input),
             Some(Rect::new(0, 20, 80, 3))
         );
         assert_eq!(
-            surface.area_for(SurfaceId::StatusBar),
+            surface.area_for(&SurfaceId::StatusBar),
             Some(Rect::new(0, 23, 80, 1))
         );
-        assert_eq!(surface.area_for(SurfaceId::TabBar), None);
-        assert_eq!(surface.area_for(SurfaceId::Overlay), None);
+        assert_eq!(surface.area_for(&SurfaceId::TabBar), None);
+        assert_eq!(surface.area_for(&SurfaceId::Overlay), None);
     }
 
     #[test]
@@ -138,17 +164,16 @@ mod tests {
         let layout = MainLayout {
             header: Rect::new(0, 0, 80, 3),
             tab_bar: Some(Rect::new(0, 3, 80, 1)),
-            conversation: Rect::new(0, 4, 56, 16),
-            progress: Rect::new(56, 4, 24, 16),
+            panes: vec![Rect::new(0, 4, 56, 16), Rect::new(56, 4, 24, 16)],
             input: Rect::new(0, 20, 80, 3),
             status_bar: Rect::new(0, 23, 80, 1),
-            tool_pane: None,
         };
 
-        let surface = SurfaceLayout::from_main_layout(&layout);
+        let pane_surfaces = vec![SurfaceId::MainPane, SurfaceId::Sidebar];
+        let surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
 
         assert_eq!(
-            surface.area_for(SurfaceId::TabBar),
+            surface.area_for(&SurfaceId::TabBar),
             Some(Rect::new(0, 3, 80, 1))
         );
     }
@@ -158,16 +183,18 @@ mod tests {
         let layout = MainLayout {
             header: Rect::new(0, 0, 80, 3),
             tab_bar: None,
-            conversation: Rect::new(0, 3, 80, 17),
-            progress: Rect::ZERO, // Minimal preset sets this to ZERO
+            panes: vec![
+                Rect::new(0, 3, 80, 17),
+                Rect::ZERO, // Minimal preset sets this to ZERO
+            ],
             input: Rect::new(0, 20, 80, 3),
             status_bar: Rect::new(0, 23, 80, 1),
-            tool_pane: None,
         };
 
-        let surface = SurfaceLayout::from_main_layout(&layout);
-        assert_eq!(surface.area_for(SurfaceId::Sidebar), None);
-        assert!(surface.area_for(SurfaceId::MainPane).is_some());
+        let pane_surfaces = vec![SurfaceId::MainPane, SurfaceId::Sidebar];
+        let surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
+        assert_eq!(surface.area_for(&SurfaceId::Sidebar), None);
+        assert!(surface.area_for(&SurfaceId::MainPane).is_some());
     }
 
     #[test]
@@ -175,17 +202,85 @@ mod tests {
         let layout = MainLayout {
             header: Rect::new(0, 0, 120, 3),
             tab_bar: None,
-            conversation: Rect::new(0, 3, 72, 17),
-            progress: Rect::new(72, 3, 24, 17),
+            panes: vec![
+                Rect::new(0, 3, 72, 17),
+                Rect::new(72, 3, 24, 17),
+                Rect::new(96, 3, 24, 17),
+            ],
             input: Rect::new(0, 20, 120, 3),
             status_bar: Rect::new(0, 23, 120, 1),
-            tool_pane: Some(Rect::new(96, 3, 24, 17)),
         };
 
-        let surface = SurfaceLayout::from_main_layout(&layout);
+        let pane_surfaces = vec![SurfaceId::MainPane, SurfaceId::Sidebar, SurfaceId::ToolPane];
+        let surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
         assert_eq!(
-            surface.area_for(SurfaceId::ToolPane),
+            surface.area_for(&SurfaceId::ToolPane),
             Some(Rect::new(96, 3, 24, 17))
+        );
+    }
+
+    #[test]
+    fn test_dynamic_pane_surface() {
+        let layout = MainLayout {
+            header: Rect::new(0, 0, 120, 3),
+            tab_bar: None,
+            panes: vec![
+                Rect::new(0, 3, 60, 17),
+                Rect::new(60, 3, 30, 17),
+                Rect::new(90, 3, 30, 17),
+            ],
+            input: Rect::new(0, 20, 120, 3),
+            status_bar: Rect::new(0, 23, 120, 1),
+        };
+
+        let pane_surfaces = vec![
+            SurfaceId::MainPane,
+            SurfaceId::DynamicPane("claude".into()),
+            SurfaceId::DynamicPane("gpt".into()),
+        ];
+        let surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
+        assert_eq!(
+            surface.area_for(&SurfaceId::DynamicPane("claude".into())),
+            Some(Rect::new(60, 3, 30, 17))
+        );
+        assert_eq!(
+            surface.area_for(&SurfaceId::DynamicPane("gpt".into())),
+            Some(Rect::new(90, 3, 30, 17))
+        );
+    }
+
+    #[test]
+    fn test_surface_id_classification() {
+        assert!(SurfaceId::MainPane.is_content_pane());
+        assert!(SurfaceId::Sidebar.is_content_pane());
+        assert!(SurfaceId::ToolPane.is_content_pane());
+        assert!(SurfaceId::DynamicPane("test".into()).is_content_pane());
+        assert!(!SurfaceId::Header.is_content_pane());
+        assert!(!SurfaceId::Overlay.is_content_pane());
+
+        assert!(SurfaceId::Overlay.is_overlay());
+        assert!(SurfaceId::ToolFloat.is_overlay());
+        assert!(!SurfaceId::MainPane.is_overlay());
+    }
+
+    #[test]
+    fn test_add_overlay() {
+        let layout = MainLayout {
+            header: Rect::new(0, 0, 80, 3),
+            tab_bar: None,
+            panes: vec![Rect::new(0, 3, 80, 17)],
+            input: Rect::new(0, 20, 80, 3),
+            status_bar: Rect::new(0, 23, 80, 1),
+        };
+
+        let pane_surfaces = vec![SurfaceId::MainPane];
+        let mut surface = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
+        assert_eq!(surface.area_for(&SurfaceId::Overlay), None);
+
+        surface.add_overlay(SurfaceId::Overlay, Rect::new(10, 5, 60, 10));
+        assert_eq!(
+            surface.area_for(&SurfaceId::Overlay),
+            Some(Rect::new(10, 5, 60, 10))
         );
     }
 }

--- a/presentation/src/tui/widgets/conversation.rs
+++ b/presentation/src/tui/widgets/conversation.rs
@@ -1,5 +1,6 @@
 //! Conversation widget — message history + streaming text
 
+use crate::tui::content::{ContentRenderer, ContentSlot};
 use crate::tui::state::TuiState;
 use ratatui::{
     buffer::Buffer,
@@ -8,6 +9,19 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Widget, Wrap},
 };
+
+/// ContentRenderer adapter for the conversation pane.
+pub struct ConversationRenderer;
+
+impl ContentRenderer for ConversationRenderer {
+    fn slot(&self) -> ContentSlot {
+        ContentSlot::Conversation
+    }
+
+    fn render_content(&self, state: &TuiState, area: Rect, buf: &mut Buffer) {
+        ConversationWidget::new(state).render(area, buf);
+    }
+}
 
 pub struct ConversationWidget<'a> {
     state: &'a TuiState,

--- a/presentation/src/tui/widgets/model_stream.rs
+++ b/presentation/src/tui/widgets/model_stream.rs
@@ -1,0 +1,140 @@
+//! Model stream widget — per-model streaming output during Ensemble planning.
+//!
+//! Each Ensemble participant model gets its own pane showing live streaming
+//! text, status indicator, and optional vote score.
+
+use crate::tui::content::{ContentRenderer, ContentSlot};
+use crate::tui::state::{ModelStreamStatus, TuiState};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Widget, Wrap},
+};
+
+/// ContentRenderer for a specific model's streaming output.
+///
+/// Registered dynamically when Ensemble mode starts.
+pub struct ModelStreamRenderer {
+    model_name: String,
+}
+
+impl ModelStreamRenderer {
+    pub fn new(model_name: impl Into<String>) -> Self {
+        Self {
+            model_name: model_name.into(),
+        }
+    }
+}
+
+impl ContentRenderer for ModelStreamRenderer {
+    fn slot(&self) -> ContentSlot {
+        ContentSlot::ModelStream(self.model_name.clone())
+    }
+
+    fn render_content(&self, state: &TuiState, area: Rect, buf: &mut Buffer) {
+        ModelStreamWidget::new(state, &self.model_name).render(area, buf);
+    }
+}
+
+struct ModelStreamWidget<'a> {
+    state: &'a TuiState,
+    model_name: &'a str,
+}
+
+impl<'a> ModelStreamWidget<'a> {
+    fn new(state: &'a TuiState, model_name: &'a str) -> Self {
+        Self { state, model_name }
+    }
+}
+
+impl<'a> Widget for ModelStreamWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let pane = self.state.tabs.active_pane();
+        let mut lines: Vec<Line> = Vec::new();
+
+        if let Some(ref ep) = pane.progress.ensemble_progress
+            && let Some(ms) = ep.model_streams.get(self.model_name)
+        {
+            // Status indicator
+            let (status_icon, status_color) = match &ms.status {
+                ModelStreamStatus::Pending => ("◯", Color::DarkGray),
+                ModelStreamStatus::Streaming => ("▸", Color::Yellow),
+                ModelStreamStatus::Complete => ("✓", Color::Green),
+                ModelStreamStatus::Error(_) => ("✗", Color::Red),
+            };
+
+            let mut status_spans = vec![
+                Span::styled(
+                    format!("{} ", status_icon),
+                    Style::default().fg(status_color),
+                ),
+                Span::styled(
+                    format!("{:?}", ms.status),
+                    Style::default().fg(status_color),
+                ),
+            ];
+
+            if let Some(score) = ms.score {
+                status_spans.push(Span::styled(
+                    format!("  Score: {:.1}/10", score),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            }
+
+            lines.push(Line::from(status_spans));
+            lines.push(Line::from(""));
+
+            // Streaming text
+            if ms.streaming_text.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "Waiting for response...",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            } else {
+                for text_line in ms.streaming_text.lines() {
+                    lines.push(Line::from(format!("  {}", text_line)));
+                }
+                if ms.status == ModelStreamStatus::Streaming {
+                    lines.push(Line::from(Span::styled(
+                        "  ▌",
+                        Style::default().fg(Color::Green),
+                    )));
+                }
+            }
+
+            if let ModelStreamStatus::Error(ref err) = ms.status {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("Error: {}", err),
+                    Style::default().fg(Color::Red),
+                )));
+            }
+        } else {
+            lines.push(Line::from(Span::styled(
+                "No stream data",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        // Short model name for title (take last segment after /)
+        let short_name = self
+            .model_name
+            .rsplit('/')
+            .next()
+            .unwrap_or(self.model_name);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", short_name))
+            .style(Style::default().fg(Color::White));
+
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false })
+            .render(area, buf);
+    }
+}

--- a/presentation/src/tui/widgets/progress_panel.rs
+++ b/presentation/src/tui/widgets/progress_panel.rs
@@ -1,5 +1,6 @@
 //! Progress panel widget — phase, tools, quorum status, tool execution lifecycle
 
+use crate::tui::content::{ContentRenderer, ContentSlot};
 use crate::tui::state::{ToolExecutionDisplay, ToolExecutionDisplayStatus, TuiState};
 use quorum_domain::AgentPhase;
 use ratatui::{
@@ -9,6 +10,19 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Widget},
 };
+
+/// ContentRenderer adapter for the progress panel.
+pub struct ProgressRenderer;
+
+impl ContentRenderer for ProgressRenderer {
+    fn slot(&self) -> ContentSlot {
+        ContentSlot::Progress
+    }
+
+    fn render_content(&self, state: &TuiState, area: Rect, buf: &mut Buffer) {
+        ProgressPanelWidget::new(state).render(area, buf);
+    }
+}
 
 pub struct ProgressPanelWidget<'a> {
     state: &'a TuiState,
@@ -251,7 +265,10 @@ impl<'a> Widget for ProgressPanelWidget<'a> {
 ///
 /// Format: `    ▸ read_file  src/main.rs`
 ///         `    ✓ run_command  cargo test (1.2s)`
-fn render_tool_execution_line<'a>(lines: &mut Vec<Line<'a>>, exec: &ToolExecutionDisplay) {
+pub(super) fn render_tool_execution_line<'a>(
+    lines: &mut Vec<Line<'a>>,
+    exec: &ToolExecutionDisplay,
+) {
     let (icon, color, suffix) = match &exec.state {
         ToolExecutionDisplayStatus::Pending => ("…", Color::DarkGray, String::new()),
         ToolExecutionDisplayStatus::Running => ("▸", Color::Yellow, String::new()),
@@ -284,7 +301,7 @@ fn render_tool_execution_line<'a>(lines: &mut Vec<Line<'a>>, exec: &ToolExecutio
 }
 
 /// Format a duration in milliseconds to a human-readable string.
-fn format_duration(ms: u64) -> String {
+pub(super) fn format_duration(ms: u64) -> String {
     if ms < 1000 {
         format!(" ({}ms)", ms)
     } else {
@@ -293,7 +310,7 @@ fn format_duration(ms: u64) -> String {
 }
 
 /// Truncate a string to max_len characters, appending "..." if truncated.
-fn truncate_str(s: &str, max_len: usize) -> String {
+pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {
         s.to_string()
     } else {

--- a/presentation/src/tui/widgets/tool_log.rs
+++ b/presentation/src/tui/widgets/tool_log.rs
@@ -1,0 +1,114 @@
+//! Tool log widget — full tool execution history (no last-3 limit).
+//!
+//! Unlike ProgressPanel which shows only recent tool executions,
+//! ToolLogRenderer displays the complete tool execution log for all tasks
+//! in the current interaction.
+
+use crate::tui::content::{ContentRenderer, ContentSlot};
+use crate::tui::state::TuiState;
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Widget},
+};
+
+use super::progress_panel::{format_duration, render_tool_execution_line, truncate_str};
+
+/// ContentRenderer for the tool execution log.
+///
+/// Shows all tool executions across all tasks (not limited to last 3 like ProgressPanel).
+pub struct ToolLogRenderer;
+
+impl ContentRenderer for ToolLogRenderer {
+    fn slot(&self) -> ContentSlot {
+        ContentSlot::ToolLog
+    }
+
+    fn render_content(&self, state: &TuiState, area: Rect, buf: &mut Buffer) {
+        ToolLogWidget::new(state).render(area, buf);
+    }
+}
+
+struct ToolLogWidget<'a> {
+    state: &'a TuiState,
+}
+
+impl<'a> ToolLogWidget<'a> {
+    fn new(state: &'a TuiState) -> Self {
+        Self { state }
+    }
+}
+
+impl<'a> Widget for ToolLogWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let progress = &self.state.tabs.active_pane().progress;
+        let mut lines: Vec<Line> = Vec::new();
+
+        if let Some(ref tp) = progress.task_progress {
+            // Show all completed task tool executions (no limit)
+            for summary in &tp.completed_tasks {
+                let icon = if summary.success {
+                    Span::styled("✓ ", Style::default().fg(Color::Green))
+                } else {
+                    Span::styled("✗ ", Style::default().fg(Color::Red))
+                };
+                let duration_str = summary.duration_ms.map(format_duration).unwrap_or_default();
+                lines.push(Line::from(vec![
+                    icon,
+                    Span::styled(
+                        format!(
+                            "Task {}: {}",
+                            summary.index,
+                            truncate_str(&summary.description, 30)
+                        ),
+                        Style::default()
+                            .fg(Color::White)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(duration_str, Style::default().fg(Color::DarkGray)),
+                ]));
+
+                // All tool executions for this task (no limit)
+                for exec in &summary.tool_executions {
+                    render_tool_execution_line(&mut lines, exec);
+                }
+            }
+
+            // Show active task tool executions
+            if !tp.active_tool_executions.is_empty() {
+                if !lines.is_empty() {
+                    lines.push(Line::from(""));
+                }
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "▸ Task {}: {}",
+                        tp.current_index,
+                        truncate_str(&tp.description, 30)
+                    ),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )));
+                for exec in &tp.active_tool_executions {
+                    render_tool_execution_line(&mut lines, exec);
+                }
+            }
+        }
+
+        if lines.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "No tool executions",
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" Tool Log ")
+            .style(Style::default().fg(Color::White));
+
+        Paragraph::new(lines).block(block).render(area, buf);
+    }
+}


### PR DESCRIPTION
## Summary

ハードコードされたウィジェットレンダリングを、レジストリ駆動のディスパッチシステムに置き換え。Content→Surface ルーティングが完全に動的になり、Ensemble モードで実行時にモデルごとのストリーミングペーンを生成可能に。

### Phase 1 — Foundation
- `ContentRenderer` trait + `ContentRegistry`（HashMap ベース、ToolSpec パターン）
- `ContentSlot::ModelStream(String)`, `SurfaceId::DynamicPane(String)` バリアント追加
- `ContentSlot` / `SurfaceId` から `Copy` derive 削除（`String` フィールドのため）
- `RouteTable::required_pane_surfaces()` + `entries()` で動的ディスパッチ
- `LayoutPreset::default_splits()` + `split_direction()` ヘルパー
- `MainLayout` を `panes: Vec<Rect>` に統一（旧 `conversation` / `progress` / `tool_pane` フィールド削除）
- `SurfaceLayout::from_main_layout()` に動的 `pane_surfaces` マッピング追加

### Phase 2 — Built-in Renderers
- `ConversationRenderer`, `ProgressRenderer` で既存ウィジェットをラップ
- `ToolLogRenderer`（新規）— last-3 制限なしの完全なツール実行履歴
- `progress_panel` ヘルパーを `pub(super)` に昇格（再利用可能に）

### Phase 3 — ModelStream (Ensemble)
- `ModelStreamState` / `Status` を `TuiState` に追加、`EnsembleProgress.model_streams`
- `TuiEvent::EnsembleModelStream{Start,Chunk,End}`, `EnsembleVoteScore` 追加
- `AgentProgressNotifier::on_ensemble_model_stream_{start,chunk,end}()` コールバック
- `planning.rs` が ensemble plan 生成時にストリームイベントを発行
- `ModelStreamRenderer` で動的 Route/Surface 登録（ランタイム）

## Test plan
- [x] `cargo build` が通ることを確認
- [x] `cargo test --workspace` が通ることを確認
- [x] Solo モードで TUI レンダリングが正常に動作
- [x] Wide / Stacked / Minimal レイアウトプリセットで表示が崩れないこと
- [x] Ensemble モードでモデルストリーミングペーンが動的に生成されること

Closes #214