### PR TITLE
feat(scripting): Lua scripting Phase 3 — plugins, commands, agent events (#231)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,15 +209,30 @@ The agent system extends quorum to autonomous task execution with safety through
 
 詳細は [docs/reference/architecture.md](docs/reference/architecture.md) を参照。
 
-## Lua Scripting (Phase 1 + 1.5)
+## Lua Scripting (Phase 1–3)
 
 User config via `~/.config/copilot-quorum/init.lua`, loaded at startup. Feature-gated behind `scripting` (default ON).
 
 **Lua APIs**:
-- `quorum.on(event, callback)` — Event subscription (ScriptLoading, ScriptLoaded, ConfigChanged, ModeChanged, SessionStarted)
+- `quorum.on(event, callback)` — Event subscription (ScriptLoading, ScriptLoaded, ConfigChanged, ModeChanged, SessionStarted, ToolCallBefore, ToolCallAfter, PhaseChanged, PlanCreated)
 - `quorum.config.get(key)` / `quorum.config.set(key, value)` / `quorum.config.keys()` — Runtime config access via `ConfigAccessorPort` (20 keys, all read-write)
 - `quorum.config["key"]` — Metatable proxy (`__index`/`__newindex`)
 - `quorum.keymap.set(mode, key, action)` — Custom keybindings (mode: normal/insert/command, action: string or Lua callback)
+- `quorum.command.register(name, opts)` — User-defined slash commands (opts: fn, description, usage)
+
+**Plugin System** (Phase 3):
+- `~/.config/copilot-quorum/plugins/*.lua` auto-loaded in alphabetical order after init.lua
+- Number prefix for ordering: `01_core.lua`, `02_lsp.lua` (Vim native packages style)
+- Directory absence: silent skip. Individual file failure: `eprintln!` warning, continue loading
+
+**Agent Events** (Phase 3):
+- `ToolCallBefore` (cancellable) — Lua returns false to skip tool execution (before HiL)
+- `ToolCallAfter` — tool_name, success, duration_ms, output_preview/error
+- `PhaseChanged` — phase name as string
+- `PlanCreated` — objective, task_count
+- `CompositeProgressNotifier<'a>` — borrowed refs, delegates to TUI + ScriptProgressBridge
+- `ScriptProgressBridge` — maps AgentProgressNotifier → ScriptingEnginePort::emit_event()
+- ToolCallBefore: Vim BufWritePre timing + BufWriteCmd cancel = hybrid design
 
 **Config Key Sections** (all mutable at runtime):
 - `agent.*` — consensus_level, phase_scope, strategy, hil_mode, max_plan_revisions
@@ -228,9 +243,11 @@ User config via `~/.config/copilot-quorum/init.lua`, loaded at startup. Feature-
 - `context_budget.*` — max_entry_bytes, max_total_bytes, recent_full_count
 
 **Key Components**:
-- `domain/scripting/`: ScriptEventType, ScriptEventData, ScriptValue
+- `domain/scripting/`: ScriptEventType (11 events), ScriptEventData, ScriptValue
 - `application/ports/scripting_engine.rs`: ScriptingEnginePort trait, NoScriptingEngine, EventOutcome, KeymapAction
-- `infrastructure/scripting/`: LuaScriptingEngine (mlua), EventBus, ConfigAPI, KeymapAPI, Sandbox
+- `application/ports/composite_progress.rs`: CompositeProgressNotifier<'a> (borrowed delegate pattern)
+- `application/ports/script_progress_bridge.rs`: ScriptProgressBridge (progress → scripting events)
+- `infrastructure/scripting/`: LuaScriptingEngine (mlua), EventBus, ConfigAPI, KeymapAPI, CommandAPI, Sandbox
 - `presentation/tui/mode.rs`: KeyAction::LuaCallback, CustomKeymap, `parse_key_descriptor()`
 - `cli/main.rs`: DI wiring with `Arc<Mutex<QuorumConfig>>` shared between AgentController and LuaScriptingEngine
 
@@ -254,4 +271,5 @@ User config via `~/.config/copilot-quorum/init.lua`, loaded at startup. Feature-
 | [native-tool-use.md](docs/systems/native-tool-use.md) | Native Tool Use API（構造化ツール呼び出し） |
 | [transport.md](docs/systems/transport.md) | Transport Demultiplexer（並列セッションルーティング） |
 | [logging.md](docs/systems/logging.md) | ログシステム（ConversationLogger、JSONL） |
+| [scripting-system.md](docs/systems/scripting-system.md) | Lua Scripting（Plugin、Commands、Agent Events） |
 | [vision/](docs/vision/README.md) | 将来ビジョン（Knowledge、Workflow、Extension） |

--- a/application/src/lib.rs
+++ b/application/src/lib.rs
@@ -44,6 +44,8 @@ pub use use_cases::run_quorum::{RunQuorumInput, RunQuorumUseCase};
 
 // Extracted use cases (Phase 1 + Phase 4)
 pub use ports::action_reviewer::{ActionReviewer, ReviewDecision};
+pub use ports::composite_progress::CompositeProgressNotifier;
+pub use ports::script_progress_bridge::ScriptProgressBridge;
 pub use use_cases::execute_task::ExecuteTaskUseCase;
 pub use use_cases::gather_context::GatherContextUseCase;
 

--- a/application/src/ports/agent_progress.rs
+++ b/application/src/ports/agent_progress.rs
@@ -132,7 +132,12 @@ pub trait AgentProgressNotifier: Send + Sync {
     /// Called when LLM streaming ends.
     fn on_llm_stream_end(&self) {}
 
-    // ==================== Plan Revision Callbacks ====================
+    // ==================== Plan Lifecycle Callbacks ====================
+
+    /// Called when the agent creates a plan.
+    ///
+    /// Used by ScriptProgressBridge to emit `PlanCreated` events.
+    fn on_plan_created(&self, _plan: &Plan) {}
 
     /// Called when a plan revision is triggered after rejection
     fn on_plan_revision(&self, _revision: usize, _feedback: &str) {}

--- a/application/src/ports/composite_progress.rs
+++ b/application/src/ports/composite_progress.rs
@@ -1,0 +1,331 @@
+//! Composite progress notifier — delegates to multiple notifiers.
+//!
+//! Used to fan out agent lifecycle events to both the TUI progress bridge
+//! and the scripting event bridge simultaneously.
+
+use super::agent_progress::AgentProgressNotifier;
+use quorum_domain::{
+    AgentPhase, ErrorCategory, Model, Plan, ReviewRound, StreamContext, Task, Thought,
+};
+
+/// A progress notifier that delegates to multiple inner notifiers.
+///
+/// Uses borrowed references with a lifetime parameter so both owned and
+/// borrowed notifiers can be composed without wrapper types.
+///
+/// ```text
+/// RunAgentUseCase.execute_with_progress(input, &composite_progress)
+///                                                |
+///                     +--------------------------+---------------------------+
+///                     |                                                      |
+///         TuiProgressBridge (existing)                  ScriptProgressBridge (new)
+///         → TuiEvent channel                            → ScriptingEnginePort::emit_event()
+/// ```
+pub struct CompositeProgressNotifier<'a> {
+    delegates: Vec<&'a dyn AgentProgressNotifier>,
+}
+
+impl<'a> CompositeProgressNotifier<'a> {
+    pub fn new(delegates: Vec<&'a dyn AgentProgressNotifier>) -> Self {
+        Self { delegates }
+    }
+}
+
+/// Macro to delegate a method call to all inner notifiers.
+macro_rules! delegate {
+    ($self:ident, $method:ident $(, $arg:expr)*) => {
+        for d in &$self.delegates {
+            d.$method($($arg),*);
+        }
+    };
+}
+
+impl AgentProgressNotifier for CompositeProgressNotifier<'_> {
+    fn on_phase_change(&self, phase: &AgentPhase) {
+        delegate!(self, on_phase_change, phase);
+    }
+
+    fn on_thought(&self, thought: &Thought) {
+        delegate!(self, on_thought, thought);
+    }
+
+    fn on_task_start(&self, task: &Task, index: usize, total: usize) {
+        delegate!(self, on_task_start, task, index, total);
+    }
+
+    fn on_task_complete(&self, task: &Task, success: bool, index: usize, total: usize) {
+        delegate!(self, on_task_complete, task, success, index, total);
+    }
+
+    fn on_tool_call(&self, tool_name: &str, args: &str) {
+        delegate!(self, on_tool_call, tool_name, args);
+    }
+
+    fn on_tool_result(&self, tool_name: &str, success: bool) {
+        delegate!(self, on_tool_result, tool_name, success);
+    }
+
+    fn on_tool_error(&self, tool_name: &str, category: ErrorCategory, message: &str) {
+        delegate!(self, on_tool_error, tool_name, category, message);
+    }
+
+    fn on_tool_retry(&self, tool_name: &str, attempt: usize, max_retries: usize, error: &str) {
+        delegate!(self, on_tool_retry, tool_name, attempt, max_retries, error);
+    }
+
+    fn on_tool_not_found(&self, tool_name: &str, available_tools: &[&str]) {
+        delegate!(self, on_tool_not_found, tool_name, available_tools);
+    }
+
+    fn on_tool_resolved(&self, original_name: &str, resolved_name: &str) {
+        delegate!(self, on_tool_resolved, original_name, resolved_name);
+    }
+
+    fn on_tool_execution_created(
+        &self,
+        task_id: &str,
+        execution_id: &str,
+        tool_name: &str,
+        turn: usize,
+        args_preview: &str,
+    ) {
+        delegate!(
+            self,
+            on_tool_execution_created,
+            task_id,
+            execution_id,
+            tool_name,
+            turn,
+            args_preview
+        );
+    }
+
+    fn on_tool_execution_started(&self, task_id: &str, execution_id: &str, tool_name: &str) {
+        delegate!(
+            self,
+            on_tool_execution_started,
+            task_id,
+            execution_id,
+            tool_name
+        );
+    }
+
+    fn on_tool_execution_completed(
+        &self,
+        task_id: &str,
+        execution_id: &str,
+        tool_name: &str,
+        duration_ms: u64,
+        output_preview: &str,
+    ) {
+        delegate!(
+            self,
+            on_tool_execution_completed,
+            task_id,
+            execution_id,
+            tool_name,
+            duration_ms,
+            output_preview
+        );
+    }
+
+    fn on_tool_execution_failed(
+        &self,
+        task_id: &str,
+        execution_id: &str,
+        tool_name: &str,
+        error: &str,
+    ) {
+        delegate!(
+            self,
+            on_tool_execution_failed,
+            task_id,
+            execution_id,
+            tool_name,
+            error
+        );
+    }
+
+    fn on_llm_chunk(&self, chunk: &str) {
+        delegate!(self, on_llm_chunk, chunk);
+    }
+
+    fn on_llm_stream_start(&self, purpose: &str) {
+        delegate!(self, on_llm_stream_start, purpose);
+    }
+
+    fn on_llm_stream_end(&self) {
+        delegate!(self, on_llm_stream_end);
+    }
+
+    fn on_plan_created(&self, plan: &Plan) {
+        delegate!(self, on_plan_created, plan);
+    }
+
+    fn on_plan_revision(&self, revision: usize, feedback: &str) {
+        delegate!(self, on_plan_revision, revision, feedback);
+    }
+
+    fn on_action_retry(&self, task: &Task, attempt: usize, feedback: &str) {
+        delegate!(self, on_action_retry, task, attempt, feedback);
+    }
+
+    fn on_quorum_start(&self, phase: &str, model_count: usize) {
+        delegate!(self, on_quorum_start, phase, model_count);
+    }
+
+    fn on_quorum_model_complete(&self, model: &Model, approved: bool) {
+        delegate!(self, on_quorum_model_complete, model, approved);
+    }
+
+    fn on_quorum_complete(&self, phase: &str, approved: bool, feedback: Option<&str>) {
+        delegate!(self, on_quorum_complete, phase, approved, feedback);
+    }
+
+    fn on_quorum_complete_with_votes(
+        &self,
+        phase: &str,
+        approved: bool,
+        votes: &[(String, bool, String)],
+        feedback: Option<&str>,
+    ) {
+        delegate!(
+            self,
+            on_quorum_complete_with_votes,
+            phase,
+            approved,
+            votes,
+            feedback
+        );
+    }
+
+    fn on_human_intervention_required(
+        &self,
+        request: &str,
+        plan: &Plan,
+        review_history: &[ReviewRound],
+        max_revisions: usize,
+    ) {
+        delegate!(
+            self,
+            on_human_intervention_required,
+            request,
+            plan,
+            review_history,
+            max_revisions
+        );
+    }
+
+    fn on_execution_confirmation_required(&self, request: &str, plan: &Plan) {
+        delegate!(self, on_execution_confirmation_required, request, plan);
+    }
+
+    fn on_ensemble_start(&self, model_count: usize) {
+        delegate!(self, on_ensemble_start, model_count);
+    }
+
+    fn on_ensemble_plan_generated(&self, model: &Model) {
+        delegate!(self, on_ensemble_plan_generated, model);
+    }
+
+    fn on_ensemble_voting_start(&self, plan_count: usize) {
+        delegate!(self, on_ensemble_voting_start, plan_count);
+    }
+
+    fn on_ensemble_model_failed(&self, model: &Model, error: &str) {
+        delegate!(self, on_ensemble_model_failed, model, error);
+    }
+
+    fn on_ensemble_complete(&self, selected_model: &Model, score: f64) {
+        delegate!(self, on_ensemble_complete, selected_model, score);
+    }
+
+    fn on_ensemble_fallback(&self, reason: &str) {
+        delegate!(self, on_ensemble_fallback, reason);
+    }
+
+    fn on_model_stream_start(&self, model: &str, context: &StreamContext) {
+        delegate!(self, on_model_stream_start, model, context);
+    }
+
+    fn on_model_stream_chunk(&self, model: &str, chunk: &str) {
+        delegate!(self, on_model_stream_chunk, model, chunk);
+    }
+
+    fn on_model_stream_end(&self, model: &str) {
+        delegate!(self, on_model_stream_end, model);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingNotifier {
+        phase_count: AtomicUsize,
+        plan_count: AtomicUsize,
+        tool_completed_count: AtomicUsize,
+        tool_failed_count: AtomicUsize,
+    }
+
+    impl CountingNotifier {
+        fn new() -> Self {
+            Self {
+                phase_count: AtomicUsize::new(0),
+                plan_count: AtomicUsize::new(0),
+                tool_completed_count: AtomicUsize::new(0),
+                tool_failed_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl AgentProgressNotifier for CountingNotifier {
+        fn on_phase_change(&self, _phase: &AgentPhase) {
+            self.phase_count.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_plan_created(&self, _plan: &Plan) {
+            self.plan_count.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_tool_execution_completed(
+            &self,
+            _task_id: &str,
+            _execution_id: &str,
+            _tool_name: &str,
+            _duration_ms: u64,
+            _output_preview: &str,
+        ) {
+            self.tool_completed_count.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_tool_execution_failed(
+            &self,
+            _task_id: &str,
+            _execution_id: &str,
+            _tool_name: &str,
+            _error: &str,
+        ) {
+            self.tool_failed_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn test_composite_delegates_to_all_notifiers() {
+        let n1 = CountingNotifier::new();
+        let n2 = CountingNotifier::new();
+
+        let composite = CompositeProgressNotifier::new(vec![&n1, &n2]);
+
+        composite.on_phase_change(&AgentPhase::Planning);
+        composite.on_phase_change(&AgentPhase::Executing);
+        composite.on_plan_created(&Plan::new("objective", "reasoning"));
+        composite.on_tool_execution_completed("t1", "e1", "read_file", 100, "ok");
+        composite.on_tool_execution_failed("t1", "e2", "write_file", "permission denied");
+
+        assert_eq!(n1.phase_count.load(Ordering::Relaxed), 2);
+        assert_eq!(n2.phase_count.load(Ordering::Relaxed), 2);
+        assert_eq!(n1.plan_count.load(Ordering::Relaxed), 1);
+        assert_eq!(n2.plan_count.load(Ordering::Relaxed), 1);
+        assert_eq!(n1.tool_completed_count.load(Ordering::Relaxed), 1);
+        assert_eq!(n1.tool_failed_count.load(Ordering::Relaxed), 1);
+    }
+}

--- a/application/src/ports/mod.rs
+++ b/application/src/ports/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod action_reviewer;
 pub mod agent_progress;
+pub mod composite_progress;
 pub mod config_accessor;
 pub mod context_loader;
 pub mod conversation_logger;
@@ -11,6 +12,7 @@ pub mod human_intervention;
 pub mod llm_gateway;
 pub mod progress;
 pub mod reference_resolver;
+pub mod script_progress_bridge;
 pub mod scripting_engine;
 pub mod tool_executor;
 pub mod tool_schema;

--- a/application/src/ports/script_progress_bridge.rs
+++ b/application/src/ports/script_progress_bridge.rs
@@ -1,0 +1,208 @@
+//! Script progress bridge — maps AgentProgressNotifier callbacks to ScriptEventType emissions.
+//!
+//! This bridge translates agent lifecycle events into scripting events,
+//! allowing Lua scripts to react to agent execution progress.
+//!
+//! # Event Mapping
+//!
+//! | AgentProgressNotifier callback | ScriptEventType |
+//! |-------------------------------|-----------------|
+//! | `on_phase_change(phase)` | `PhaseChanged` { phase } |
+//! | `on_plan_created(plan)` | `PlanCreated` { objective, task_count } |
+//! | `on_tool_execution_completed(...)` | `ToolCallAfter` { tool_name, success: true, ... } |
+//! | `on_tool_execution_failed(...)` | `ToolCallAfter` { tool_name, success: false, ... } |
+//!
+//! Note: `ToolCallBefore` is NOT emitted through this bridge because it requires
+//! a return value (cancellation). It's called directly by `ExecuteTaskUseCase`.
+
+use super::agent_progress::AgentProgressNotifier;
+use super::scripting_engine::ScriptingEnginePort;
+use quorum_domain::scripting::{ScriptEventData, ScriptEventType, ScriptValue};
+use quorum_domain::{AgentPhase, Plan};
+use std::sync::Arc;
+
+/// Bridge that translates agent progress callbacks into scripting events.
+pub struct ScriptProgressBridge {
+    engine: Arc<dyn ScriptingEnginePort>,
+}
+
+impl ScriptProgressBridge {
+    pub fn new(engine: Arc<dyn ScriptingEnginePort>) -> Self {
+        Self { engine }
+    }
+}
+
+impl AgentProgressNotifier for ScriptProgressBridge {
+    fn on_phase_change(&self, phase: &AgentPhase) {
+        let data =
+            ScriptEventData::new().with_field("phase", ScriptValue::String(phase.to_string()));
+        let _ = self.engine.emit_event(ScriptEventType::PhaseChanged, data);
+    }
+
+    fn on_plan_created(&self, plan: &Plan) {
+        let data = ScriptEventData::new()
+            .with_field("objective", ScriptValue::String(plan.objective.clone()))
+            .with_field("task_count", ScriptValue::Integer(plan.tasks.len() as i64));
+        let _ = self.engine.emit_event(ScriptEventType::PlanCreated, data);
+    }
+
+    fn on_tool_execution_completed(
+        &self,
+        _task_id: &str,
+        _execution_id: &str,
+        tool_name: &str,
+        duration_ms: u64,
+        output_preview: &str,
+    ) {
+        let data = ScriptEventData::new()
+            .with_field("tool_name", ScriptValue::String(tool_name.to_string()))
+            .with_field("success", ScriptValue::Boolean(true))
+            .with_field("duration_ms", ScriptValue::Integer(duration_ms as i64))
+            .with_field(
+                "output_preview",
+                ScriptValue::String(output_preview.to_string()),
+            );
+        let _ = self.engine.emit_event(ScriptEventType::ToolCallAfter, data);
+    }
+
+    fn on_tool_execution_failed(
+        &self,
+        _task_id: &str,
+        _execution_id: &str,
+        tool_name: &str,
+        error: &str,
+    ) {
+        let data = ScriptEventData::new()
+            .with_field("tool_name", ScriptValue::String(tool_name.to_string()))
+            .with_field("success", ScriptValue::Boolean(false))
+            .with_field("duration_ms", ScriptValue::Integer(0))
+            .with_field("error", ScriptValue::String(error.to_string()));
+        let _ = self.engine.emit_event(ScriptEventType::ToolCallAfter, data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::scripting_engine::{EventOutcome, NoScriptingEngine, ScriptError};
+    use quorum_domain::scripting::ScriptEventData;
+    use std::sync::Mutex;
+
+    struct RecordingEngine {
+        events: Mutex<Vec<(ScriptEventType, Vec<String>)>>,
+    }
+
+    impl RecordingEngine {
+        fn new() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn recorded_events(&self) -> Vec<(ScriptEventType, Vec<String>)> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl ScriptingEnginePort for RecordingEngine {
+        fn emit_event(
+            &self,
+            event: ScriptEventType,
+            data: ScriptEventData,
+        ) -> Result<EventOutcome, ScriptError> {
+            let field_keys: Vec<String> = {
+                let mut keys: Vec<_> = data.fields().keys().cloned().collect();
+                keys.sort();
+                keys
+            };
+            self.events.lock().unwrap().push((event, field_keys));
+            Ok(EventOutcome::Continue)
+        }
+
+        fn load_script(&self, _path: &std::path::Path) -> Result<(), ScriptError> {
+            Ok(())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn registered_keymaps(
+            &self,
+        ) -> Vec<(String, String, crate::ports::scripting_engine::KeymapAction)> {
+            Vec::new()
+        }
+
+        fn execute_callback(&self, _callback_id: u64) -> Result<(), ScriptError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_bridge_emits_phase_changed() {
+        let engine = Arc::new(RecordingEngine::new());
+        let bridge = ScriptProgressBridge::new(engine.clone());
+
+        bridge.on_phase_change(&AgentPhase::Planning);
+
+        let events = engine.recorded_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, ScriptEventType::PhaseChanged);
+        assert!(events[0].1.contains(&"phase".to_string()));
+    }
+
+    #[test]
+    fn test_bridge_emits_plan_created() {
+        let engine = Arc::new(RecordingEngine::new());
+        let bridge = ScriptProgressBridge::new(engine.clone());
+
+        let plan = Plan::new("Test objective", "reasoning");
+        bridge.on_plan_created(&plan);
+
+        let events = engine.recorded_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, ScriptEventType::PlanCreated);
+        assert!(events[0].1.contains(&"objective".to_string()));
+        assert!(events[0].1.contains(&"task_count".to_string()));
+    }
+
+    #[test]
+    fn test_bridge_emits_tool_call_after_success() {
+        let engine = Arc::new(RecordingEngine::new());
+        let bridge = ScriptProgressBridge::new(engine.clone());
+
+        bridge.on_tool_execution_completed("t1", "e1", "read_file", 42, "file contents...");
+
+        let events = engine.recorded_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, ScriptEventType::ToolCallAfter);
+        assert!(events[0].1.contains(&"tool_name".to_string()));
+        assert!(events[0].1.contains(&"success".to_string()));
+        assert!(events[0].1.contains(&"duration_ms".to_string()));
+    }
+
+    #[test]
+    fn test_bridge_emits_tool_call_after_failure() {
+        let engine = Arc::new(RecordingEngine::new());
+        let bridge = ScriptProgressBridge::new(engine.clone());
+
+        bridge.on_tool_execution_failed("t1", "e2", "write_file", "permission denied");
+
+        let events = engine.recorded_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, ScriptEventType::ToolCallAfter);
+        assert!(events[0].1.contains(&"error".to_string()));
+    }
+
+    #[test]
+    fn test_bridge_with_no_scripting_engine() {
+        let engine: Arc<dyn ScriptingEnginePort> = Arc::new(NoScriptingEngine);
+        let bridge = ScriptProgressBridge::new(engine);
+
+        // Should not panic even with NoScriptingEngine
+        bridge.on_phase_change(&AgentPhase::Planning);
+        bridge.on_plan_created(&Plan::new("test", "reasoning"));
+        bridge.on_tool_execution_completed("t1", "e1", "read_file", 0, "");
+        bridge.on_tool_execution_failed("t1", "e2", "write_file", "err");
+    }
+}

--- a/application/src/ports/scripting_engine.rs
+++ b/application/src/ports/scripting_engine.rs
@@ -64,6 +64,30 @@ pub trait ScriptingEnginePort: Send + Sync {
     ///
     /// Called by the presentation layer when `KeyAction::LuaCallback(id)` is triggered.
     fn execute_callback(&self, callback_id: u64) -> Result<(), ScriptError>;
+
+    /// Check if a tool call should proceed (ToolCallBefore event).
+    ///
+    /// Returns `true` if the tool call should continue, `false` to cancel it.
+    /// Called by `ExecuteTaskUseCase` before each tool execution.
+    fn on_tool_call_before(&self, _tool_name: &str, _args_json: &str) -> bool {
+        true
+    }
+
+    /// Retrieve registered custom commands.
+    ///
+    /// Returns a list of `(name, description, usage, callback_id)` tuples.
+    /// The `AgentController` checks this when encountering unknown slash commands.
+    fn registered_commands(&self) -> Vec<(String, String, String, u64)> {
+        Vec::new()
+    }
+
+    /// Execute a command callback by its registry ID, passing user-provided args.
+    ///
+    /// Called by `AgentController` when a registered Lua command is invoked.
+    fn execute_command_callback(&self, callback_id: u64, args: &str) -> Result<(), ScriptError> {
+        let _ = (callback_id, args);
+        Ok(())
+    }
 }
 
 /// Action bound to a custom keymap entry.

--- a/docs/systems/scripting-system.md
+++ b/docs/systems/scripting-system.md
@@ -1,0 +1,223 @@
+# Scripting System / スクリプティングシステム
+
+> Lua-based extensibility for configuration, keybindings, plugins, commands, and agent event hooks
+>
+> 設定・キーバインド・プラグイン・コマンド・エージェントイベントフックのための Lua 拡張基盤
+
+---
+
+## Overview / 概要
+
+スクリプティングシステムは、copilot-quorum を Lua スクリプトでカスタマイズ可能にする拡張基盤です。
+Vim/Neovim のプラグインエコシステムに倣い、段階的に構築されています。
+
+**3 フェーズ構成**:
+1. **Phase 1**: `init.lua` + Config/Keymap API（基本設定）
+2. **Phase 2**: TUI Route/Layout/Content API（UI カスタマイズ）
+3. **Phase 3**: Plugin System + Agent Events + User Commands（拡張性）
+
+---
+
+## Quick Start / クイックスタート
+
+```lua
+-- ~/.config/copilot-quorum/init.lua
+
+-- 設定変更
+quorum.config.set("agent.hil_mode", "auto_approve")
+quorum.config["models.exploration"] = "gpt-5.2-codex"
+
+-- キーバインド
+quorum.keymap.set("normal", "q", "quit")
+quorum.keymap.set("normal", "r", function()
+    quorum.config.set("agent.hil_mode", "interactive")
+end)
+
+-- イベント購読
+quorum.on("PhaseChanged", function(data)
+    print("Phase: " .. data.phase)
+end)
+
+-- ツール実行の制御（false でキャンセル）
+quorum.on("ToolCallBefore", function(data)
+    if data.tool_name == "run_command" then
+        return false  -- コマンド実行をブロック
+    end
+    return true
+end)
+
+-- ユーザー定義コマンド
+quorum.command.register("greet", {
+    fn = function(args)
+        print("Hello, " .. args .. "!")
+    end,
+    description = "Greet someone",
+    usage = "/greet <name>"
+})
+```
+
+---
+
+## Architecture / アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    CLI (main.rs)                         │
+│  init.lua ロード → plugins/*.lua ロード → DI 組み立て     │
+└────────────────────────┬────────────────────────────────┘
+                         │ Arc<dyn ScriptingEnginePort>
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│              Application Layer (Ports)                    │
+│                                                          │
+│  ScriptingEnginePort        AgentProgressNotifier        │
+│  ├── emit_event()           ├── on_phase_change()        │
+│  ├── on_tool_call_before()  ├── on_plan_created()        │
+│  ├── registered_commands()  ├── on_tool_execution_*()    │
+│  └── execute_command_cb()   └── ...                      │
+│                                                          │
+│  CompositeProgressNotifier<'a>   ScriptProgressBridge    │
+│  └── [TuiProgress, ScriptBridge] └── progress → events   │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│           Infrastructure Layer (Lua Runtime)              │
+│                                                          │
+│  LuaScriptingEngine (mlua)                               │
+│  ├── EventBus      (quorum.on)                           │
+│  ├── ConfigAPI     (quorum.config)                       │
+│  ├── KeymapAPI     (quorum.keymap)                       │
+│  ├── CommandAPI    (quorum.command)                       │
+│  └── Sandbox       (C module blocking)                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Plugin System
+
+### ロード順序
+
+```
+~/.config/copilot-quorum/
+├── init.lua              ← 最初にロード（グローバル設定）
+└── plugins/
+    ├── 01_core.lua       ← アルファベット順にロード
+    ├── 02_lsp.lua
+    └── 99_experimental.lua
+```
+
+- Vim native packages 方式（アルファベット順、数字プレフィックスで順序制御）
+- ディレクトリ不在は silent skip
+- 個別ファイルの失敗は `eprintln!` Warning で続行（他プラグインをブロックしない）
+- `load_script()` を再利用（新トレイトメソッド不要）
+
+---
+
+## User Commands / ユーザー定義コマンド
+
+```lua
+quorum.command.register("deploy", {
+    fn = function(args)
+        print("Deploying to: " .. args)
+    end,
+    description = "Deploy to environment",
+    usage = "/deploy <env>"
+})
+```
+
+### 設計
+
+- `CommandRegistry` が名前 → callback_id マッピングを管理
+- `AgentController.handle_command()` で未知コマンド → Lua コマンド検索 → 見つかれば実行
+- 同名の再登録は last-write-wins（上書き）
+- 名前の先頭 `/` は自動ストリップ
+
+---
+
+## Agent Events / エージェントイベント
+
+### イベント一覧
+
+| Event | Cancellable | Data Fields |
+|-------|-------------|-------------|
+| `ToolCallBefore` | **Yes** | tool_name, args (JSON) |
+| `ToolCallAfter` | No | tool_name, success, duration_ms, output_preview/error |
+| `PhaseChanged` | No | phase (string) |
+| `PlanCreated` | No | objective, task_count |
+
+### ToolCallBefore キャンセルフロー
+
+```
+ToolCall 受信
+  → ScriptingEnginePort::on_tool_call_before(tool_name, args_json)
+    → false: ToolResultMessage { is_rejected: true } で即返却、HiL スキップ
+    → true: 通常フロー継続
+      → Low-risk: parallel execute → ToolCallAfter (via ScriptProgressBridge)
+      → High-risk: HiL review → execute → ToolCallAfter
+```
+
+**設計根拠**: Vim の `BufWritePre`（実行前に割り込むタイミング）と `BufWriteCmd`（本体処理をキャンセルできる能力）のハイブリッド。Lua フィルタ先 → HiL 後方式により、プログラマティックポリシーレイヤーとして機能する。
+
+### CompositeProgressNotifier
+
+```
+RunAgentUseCase.execute_with_progress(input, &composite_progress)
+                                                |
+                    +---------------------------+---------------------------+
+                    |                                                       |
+        TuiProgressBridge (既存)                        ScriptProgressBridge (新規)
+        → TuiEvent channel                              → ScriptingEnginePort::emit_event()
+```
+
+- `CompositeProgressNotifier<'a>` は借用参照ベース（`Vec<&'a dyn AgentProgressNotifier>`）
+- `ScriptProgressBridge` が `AgentProgressNotifier` コールバックを `ScriptEventType` に変換
+- `ToolCallBefore` は戻り値が必要なため、`ScriptProgressBridge` 経由ではなく `ExecuteTaskUseCase` が直接呼び出し
+
+---
+
+## Event Reference / 全イベント一覧
+
+| Event | Phase | Cancellable | Description |
+|-------|-------|-------------|-------------|
+| `ScriptLoading` | 1 | No | スクリプトロード開始 |
+| `ScriptLoaded` | 1 | No | スクリプトロード完了 |
+| `ConfigChanged` | 1 | No | 設定変更 |
+| `ModeChanged` | 1 | No | モード変更 |
+| `SessionStarted` | 1 | No | セッション開始 |
+| `RouteChanged` | 2 | No | ルート変更 |
+| `ToolCallBefore` | 3 | **Yes** | ツール実行前（false でキャンセル） |
+| `ToolCallAfter` | 3 | No | ツール実行後 |
+| `PhaseChanged` | 3 | No | エージェントフェーズ変更 |
+| `PlanCreated` | 3 | No | プラン作成 |
+| `ContentRegistered` | 2 | No | コンテンツ登録 |
+
+---
+
+## Sandbox / サンドボックス
+
+- `package.loadlib = nil` — C モジュール読み込みをブロック
+- `package.cpath = ""` — C パス検索を無効化
+- 標準 Lua ライブラリ（string, table, math, io, os）は利用可能
+- `require()` は Lua モジュールのみ対応
+
+---
+
+## Key Files / 主要ファイル
+
+| File | Description |
+|------|-------------|
+| `domain/src/scripting/mod.rs` | ScriptEventType (11 variants), ScriptEventData, ScriptValue |
+| `application/src/ports/scripting_engine.rs` | ScriptingEnginePort trait, NoScriptingEngine |
+| `application/src/ports/composite_progress.rs` | CompositeProgressNotifier<'a> |
+| `application/src/ports/script_progress_bridge.rs` | ScriptProgressBridge |
+| `infrastructure/src/scripting/lua_engine.rs` | LuaScriptingEngine (mlua) |
+| `infrastructure/src/scripting/event_bus.rs` | EventBus (event → callback dispatch) |
+| `infrastructure/src/scripting/config_api.rs` | ConfigAPI (quorum.config) |
+| `infrastructure/src/scripting/keymap_api.rs` | KeymapAPI (quorum.keymap) |
+| `infrastructure/src/scripting/command_api.rs` | CommandAPI (quorum.command) |
+| `infrastructure/src/scripting/sandbox.rs` | Sandbox (C module blocking) |
+| `cli/src/main.rs` | DI wiring, init.lua + plugins/ loading |
+
+<!-- LLM Context: Scripting system Phase 1-3. Events: 11 types (ScriptLoading, ScriptLoaded, ConfigChanged, ModeChanged, SessionStarted, RouteChanged, ToolCallBefore, ToolCallAfter, PhaseChanged, PlanCreated, ContentRegistered). ToolCallBefore is cancellable. Plugin loading: alphabetical order in ~/.config/copilot-quorum/plugins/. Commands: quorum.command.register(name, opts). CompositeProgressNotifier delegates to TUI + ScriptProgressBridge. -->

--- a/infrastructure/src/scripting/command_api.rs
+++ b/infrastructure/src/scripting/command_api.rs
@@ -1,0 +1,275 @@
+//! `quorum.command` Lua API — user-defined command registration.
+//!
+//! Allows users to register custom slash commands from Lua:
+//!
+//! ```lua
+//! quorum.command.register("hello", {
+//!     fn = function(args) print("Hello " .. args) end,
+//!     description = "Say hello to someone",
+//!     usage = "/hello <name>"
+//! })
+//! ```
+//!
+//! Registered commands are discovered by `AgentController` at runtime.
+//! When an unknown `/command` is entered, the controller checks
+//! `ScriptingEnginePort::registered_commands()` before emitting
+//! `UiEvent::UnknownCommand`.
+
+use mlua::prelude::*;
+use std::sync::{Arc, Mutex};
+
+/// A registered command entry from Lua.
+#[derive(Debug, Clone)]
+pub struct CommandEntry {
+    pub name: String,
+    pub description: String,
+    pub usage: String,
+    pub callback_id: u64,
+}
+
+/// Storage for custom commands registered from Lua.
+pub struct CommandRegistry {
+    entries: Vec<CommandEntry>,
+    next_callback_id: u64,
+}
+
+impl CommandRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            next_callback_id: 1,
+        }
+    }
+
+    pub fn register(&mut self, entry: CommandEntry) {
+        // Remove any existing command with the same name (last-write-wins)
+        self.entries.retain(|e| e.name != entry.name);
+        self.entries.push(entry);
+    }
+
+    pub fn next_id(&mut self) -> u64 {
+        let id = self.next_callback_id;
+        self.next_callback_id += 1;
+        id
+    }
+
+    pub fn entries(&self) -> &[CommandEntry] {
+        &self.entries
+    }
+
+    #[allow(dead_code)]
+    pub fn find_by_name(&self, name: &str) -> Option<&CommandEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+}
+
+/// Register the `quorum.command` table on the given `quorum` global.
+pub fn register_command_api(
+    lua: &Lua,
+    quorum: &LuaTable,
+    registry: Arc<Mutex<CommandRegistry>>,
+    callback_store: Arc<Mutex<Vec<(u64, LuaRegistryKey)>>>,
+) -> LuaResult<()> {
+    let command_table = lua.create_table()?;
+
+    // quorum.command.register(name, opts)
+    // opts = { fn = function(args), description = "...", usage = "/name ..." }
+    let reg = Arc::clone(&registry);
+    let store = Arc::clone(&callback_store);
+    let register_fn = lua.create_function(move |lua, (name, opts): (String, LuaTable)| {
+        // Validate command name (no leading slash, no spaces)
+        if name.is_empty() {
+            return Err(LuaError::external("command name cannot be empty"));
+        }
+        if name.contains(' ') {
+            return Err(LuaError::external("command name cannot contain spaces"));
+        }
+        let name = name.strip_prefix('/').unwrap_or(&name).to_string();
+
+        // Extract callback function (required)
+        let callback: LuaFunction = opts
+            .get("fn")
+            .map_err(|_| LuaError::external("command opts must include 'fn' (a function)"))?;
+
+        // Extract optional metadata
+        let description: String = opts.get("description").unwrap_or_default();
+        let usage: String = opts.get("usage").unwrap_or_else(|_| format!("/{}", name));
+
+        let mut reg = reg
+            .lock()
+            .map_err(|e| LuaError::external(format!("command registry lock poisoned: {}", e)))?;
+
+        let id = reg.next_id();
+        let key = lua.create_registry_value(callback)?;
+        let mut store = store
+            .lock()
+            .map_err(|e| LuaError::external(format!("callback store lock poisoned: {}", e)))?;
+        store.push((id, key));
+
+        reg.register(CommandEntry {
+            name,
+            description,
+            usage,
+            callback_id: id,
+        });
+
+        Ok(())
+    })?;
+
+    command_table.set("register", register_fn)?;
+    quorum.set("command", command_table)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_registry_register_and_find() {
+        let mut reg = CommandRegistry::new();
+
+        reg.register(CommandEntry {
+            name: "hello".to_string(),
+            description: "Say hello".to_string(),
+            usage: "/hello <name>".to_string(),
+            callback_id: 1,
+        });
+
+        assert_eq!(reg.entries().len(), 1);
+        let entry = reg.find_by_name("hello").unwrap();
+        assert_eq!(entry.description, "Say hello");
+    }
+
+    #[test]
+    fn test_command_registry_replaces_duplicate() {
+        let mut reg = CommandRegistry::new();
+
+        reg.register(CommandEntry {
+            name: "hello".to_string(),
+            description: "Old".to_string(),
+            usage: "/hello".to_string(),
+            callback_id: 1,
+        });
+
+        reg.register(CommandEntry {
+            name: "hello".to_string(),
+            description: "New".to_string(),
+            usage: "/hello".to_string(),
+            callback_id: 2,
+        });
+
+        assert_eq!(reg.entries().len(), 1);
+        assert_eq!(reg.find_by_name("hello").unwrap().description, "New");
+    }
+
+    #[test]
+    fn test_command_registry_callback_ids_increment() {
+        let mut reg = CommandRegistry::new();
+        assert_eq!(reg.next_id(), 1);
+        assert_eq!(reg.next_id(), 2);
+        assert_eq!(reg.next_id(), 3);
+    }
+
+    #[test]
+    fn test_command_registry_find_nonexistent() {
+        let reg = CommandRegistry::new();
+        assert!(reg.find_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_lua_command_register() {
+        let lua = Lua::new();
+        let quorum = lua.create_table().unwrap();
+        let registry = Arc::new(Mutex::new(CommandRegistry::new()));
+        let callback_store = Arc::new(Mutex::new(Vec::new()));
+
+        register_command_api(&lua, &quorum, Arc::clone(&registry), callback_store).unwrap();
+        lua.globals().set("quorum", &quorum).unwrap();
+
+        lua.load(
+            r#"
+            quorum.command.register("hello", {
+                fn = function(args) end,
+                description = "Say hello",
+                usage = "/hello <name>"
+            })
+        "#,
+        )
+        .exec()
+        .unwrap();
+
+        let reg = registry.lock().unwrap();
+        assert_eq!(reg.entries().len(), 1);
+        let entry = reg.find_by_name("hello").unwrap();
+        assert_eq!(entry.description, "Say hello");
+        assert_eq!(entry.usage, "/hello <name>");
+    }
+
+    #[test]
+    fn test_lua_command_register_strips_leading_slash() {
+        let lua = Lua::new();
+        let quorum = lua.create_table().unwrap();
+        let registry = Arc::new(Mutex::new(CommandRegistry::new()));
+        let callback_store = Arc::new(Mutex::new(Vec::new()));
+
+        register_command_api(&lua, &quorum, Arc::clone(&registry), callback_store).unwrap();
+        lua.globals().set("quorum", &quorum).unwrap();
+
+        lua.load(
+            r#"
+            quorum.command.register("/test", {
+                fn = function() end
+            })
+        "#,
+        )
+        .exec()
+        .unwrap();
+
+        let reg = registry.lock().unwrap();
+        assert!(reg.find_by_name("test").is_some());
+    }
+
+    #[test]
+    fn test_lua_command_register_missing_fn_errors() {
+        let lua = Lua::new();
+        let quorum = lua.create_table().unwrap();
+        let registry = Arc::new(Mutex::new(CommandRegistry::new()));
+        let callback_store = Arc::new(Mutex::new(Vec::new()));
+
+        register_command_api(&lua, &quorum, registry, callback_store).unwrap();
+        lua.globals().set("quorum", &quorum).unwrap();
+
+        let result = lua
+            .load(
+                r#"
+            quorum.command.register("test", {
+                description = "no fn field"
+            })
+        "#,
+            )
+            .exec();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_lua_command_register_empty_name_errors() {
+        let lua = Lua::new();
+        let quorum = lua.create_table().unwrap();
+        let registry = Arc::new(Mutex::new(CommandRegistry::new()));
+        let callback_store = Arc::new(Mutex::new(Vec::new()));
+
+        register_command_api(&lua, &quorum, registry, callback_store).unwrap();
+        lua.globals().set("quorum", &quorum).unwrap();
+
+        let result = lua
+            .load(
+                r#"
+            quorum.command.register("", { fn = function() end })
+        "#,
+            )
+            .exec();
+        assert!(result.is_err());
+    }
+}

--- a/infrastructure/src/scripting/mod.rs
+++ b/infrastructure/src/scripting/mod.rs
@@ -9,8 +9,10 @@
 //! - `sandbox` — C module blocking for safety
 //! - `config_api` — `quorum.config` get/set/keys + metatable proxy
 //! - `keymap_api` — `quorum.keymap.set(mode, key, action)`
+//! - `command_api` — `quorum.command.register(name, opts)`
 //! - `lua_engine` — Main engine struct tying everything together
 
+mod command_api;
 mod config_api;
 mod event_bus;
 mod keymap_api;

--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -216,6 +216,10 @@ impl TuiApp {
     ) -> Self {
         let keymaps = engine.registered_keymaps();
         self.custom_keymap = mode::CustomKeymap::from_registered(&keymaps);
+        // Share scripting engine with the controller for Lua command dispatch
+        let _ = self
+            .cmd_tx
+            .send(TuiCommand::SetScriptingEngine(engine.clone()));
         self.scripting_engine = engine;
         self
     }

--- a/presentation/src/tui/app_controller.rs
+++ b/presentation/src/tui/app_controller.rs
@@ -98,6 +98,9 @@ pub(super) async fn controller_task(
                     TuiCommand::SetReferenceResolver(resolver) => {
                         controller.set_reference_resolver(resolver);
                     }
+                    TuiCommand::SetScriptingEngine(engine) => {
+                        controller.set_scripting_engine(engine);
+                    }
                     TuiCommand::SpawnInteraction {
                         form,
                         query,

--- a/presentation/src/tui/event.rs
+++ b/presentation/src/tui/event.rs
@@ -50,6 +50,8 @@ pub enum TuiCommand {
     SetCancellation(tokio_util::sync::CancellationToken),
     /// Set reference resolver for automatic reference resolution
     SetReferenceResolver(std::sync::Arc<dyn quorum_application::ReferenceResolverPort>),
+    /// Set scripting engine for Lua command dispatch
+    SetScriptingEngine(std::sync::Arc<dyn quorum_application::ScriptingEnginePort>),
     /// Spawn a new interaction
     SpawnInteraction {
         form: InteractionForm,


### PR DESCRIPTION
## Summary

Lua Scripting Platform の Phase 3 実装。Plugin ディレクトリ自動読み込み、ユーザー定義コマンド (`quorum.command.register`)、Agent ライフサイクルイベント (ToolCallBefore/After, PhaseChanged, PlanCreated) を追加。

### Features

- **Plugin System**: `~/.config/copilot-quorum/plugins/*.lua` をアルファベット順に自動ロード（Vim native packages style）
- **User Commands**: `quorum.command.register(name, opts)` で Lua からスラッシュコマンドを定義。AgentController が未知コマンドを Lua 側に委譲
- **Agent Events**: 4 新 ScriptEventType — `ToolCallBefore`（cancellable）, `ToolCallAfter`, `PhaseChanged`, `PlanCreated`
- **CompositeProgressNotifier<'a>**: 借用参照ベースの委譲パターンで TUI + ScriptProgressBridge に同時通知
- **ToolCallBefore cancellation**: Lua フィルタが false を返すとツール実行をスキップ（HiL 前のプログラマティックポリシーレイヤー）

### Architecture

```
RunAgentUseCase.execute_with_progress(input, &composite)
                                               |
                   +---------------------------+---------------------------+
                   |                                                       |
       TuiProgressBridge (既存)                        ScriptProgressBridge (新規)
       → TuiEvent channel                              → ScriptingEnginePort::emit_event()
```

### Changed Files (19 files, +1451/-14)

| Layer | Files | Changes |
|-------|-------|---------|
| domain | `scripting/mod.rs` | 4 new ScriptEventType variants (11 total), is_cancellable() |
| application | `agent_progress.rs`, `scripting_engine.rs` | on_plan_created(), on_tool_call_before(), registered_commands(), execute_command_callback() |
| application | `composite_progress.rs`, `script_progress_bridge.rs` | **NEW** — CompositeProgressNotifier<'a>, ScriptProgressBridge |
| application | `execute_task.rs`, `run_agent/mod.rs`, `agent_controller.rs` | ToolCallBefore injection, scripting_engine propagation, Lua command dispatch |
| infrastructure | `command_api.rs` | **NEW** — CommandRegistry + register_command_api() |
| infrastructure | `lua_engine.rs` | command_registry, on_tool_call_before(), plugin tests |
| presentation | `app.rs`, `app_controller.rs`, `event.rs` | SetScriptingEngine TuiCommand |
| cli | `main.rs` | plugins/ directory scanning |
| docs | `scripting-system.md` | **NEW** — Phase 1–3 comprehensive docs |

## Test plan

- [x] `cargo build` — clean compile
- [x] `cargo test --workspace` — 908 passed, 0 failed
- [x] Plugin loading: alphabetical order + failure isolation (2 tests)
- [x] CommandRegistry: register, find, duplicate replace, callback IDs (4 tests)
- [x] Lua command API: register, empty name error, missing fn error, slash strip (4 tests)
- [x] CompositeProgressNotifier: delegation to multiple notifiers
- [x] ScriptProgressBridge: PhaseChanged, PlanCreated, ToolCallAfter success/failure, NoScriptingEngine (5 tests)
- [x] Domain scripting: event_type_roundtrip (11 events), cancellable_events
- [ ] Manual: init.lua + plugins/*.lua loading in TUI
- [ ] Manual: `/hello` custom command via `quorum.command.register()`
- [ ] Manual: ToolCallBefore cancellation with `quorum.on("ToolCallBefore", ...)`

Closes #231