### PR TITLE
fix(copilot): restore Copilot CLI 1.0.25+ compatibility (external_tool + session.start race + permission auto-reply)

### DIFF
--- a/application/src/use_cases/run_agent/mod.rs
+++ b/application/src/use_cases/run_agent/mod.rs
@@ -967,10 +967,10 @@ mod tests {
 
         fn get_session_responses(&self, model: &str) -> Vec<ScriptedResponse> {
             // Try model-specific queue first
-            if let Some(queue) = self.session_queues.lock().unwrap().get_mut(model) {
-                if let Some(responses) = queue.pop_front() {
-                    return responses;
-                }
+            if let Some(queue) = self.session_queues.lock().unwrap().get_mut(model)
+                && let Some(responses) = queue.pop_front()
+            {
+                return responses;
             }
             // Try fallback
             if let Some(responses) = self.fallback_responses.lock().unwrap().pop_front() {

--- a/domain/src/util.rs
+++ b/domain/src/util.rs
@@ -145,7 +145,7 @@ mod tests {
     fn head_tail_small_budget_falls_back() {
         let s = "hello world, this is a test";
         // Budget too small for marker, falls back to head truncation
-        let result = truncate_head_tail(&s, 40);
+        let result = truncate_head_tail(s, 40);
         assert!(result.len() <= 40);
     }
 

--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -305,6 +305,52 @@ pub enum PermissionResult {
     },
 }
 
+/// Params for the `session.tools.handlePendingToolCall` RPC request (SDK → CLI).
+///
+/// Copilot CLI 1.0.25 delivers user-defined tool invocations through the
+/// `external_tool.requested` session event instead of the legacy `tool.call`
+/// JSON-RPC request.  After executing the tool, the SDK must send this RPC
+/// to hand back the result so the LLM can continue.  Without a reply the
+/// CLI pauses indefinitely (observed: 10 min+ hangs during Planning).
+///
+/// Exactly one of `result` / `error` must be set; `result` wins if both are
+/// provided.  A missing `result` and missing `error` is rejected by the CLI.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandlePendingToolCallParams {
+    pub session_id: String,
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<ExternalToolResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Payload for a successfully executed external tool.
+///
+/// Copilot CLI accepts either a bare string (the simple case — just the text
+/// to feed back to the LLM) or a richer object with telemetry.  We expose
+/// both forms via an untagged enum so a caller can opt into metadata when
+/// it's available without paying a JSON overhead in the common case.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum ExternalToolResult {
+    /// Simplest form — treated by the CLI as the full tool output text.
+    Text(String),
+    /// Expanded form matching the CLI schema's `Fos` object.
+    #[serde(rename_all = "camelCase")]
+    Structured {
+        /// Text shown to the LLM as the tool's output.
+        text_result_for_llm: String,
+        /// Optional tag describing the kind of result (free-form).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        result_type: Option<String>,
+        /// Optional human-readable error message associated with the result.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+}
+
 /// JSON-RPC response sent from SDK → CLI (e.g., `tool.call` result).
 ///
 /// Used by **Native Tool Use** — after executing a tool,
@@ -580,5 +626,39 @@ mod tests {
 
         let rpc_err = ToolCallResult::error("boom").into_rpc_value();
         assert_eq!(rpc_err["result"]["resultType"], "failure");
+    }
+
+    #[test]
+    fn handle_pending_tool_call_success_wire_format() {
+        // `session.tools.handlePendingToolCall` expects camelCase fields with
+        // the tool text at `result` as a plain string (untagged Text variant).
+        let params = HandlePendingToolCallParams {
+            session_id: "sess-1".to_string(),
+            request_id: "req-uuid-abc".to_string(),
+            result: Some(ExternalToolResult::Text("plan saved".to_string())),
+            error: None,
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["sessionId"], "sess-1");
+        assert_eq!(json["requestId"], "req-uuid-abc");
+        assert_eq!(json["result"], "plan saved");
+        // `error` must be omitted (skip_serializing_if) so the CLI treats
+        // this as a success — sending `null` could be interpreted as "no
+        // error info" alongside a missing result.
+        assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn handle_pending_tool_call_error_wire_format() {
+        let params = HandlePendingToolCallParams {
+            session_id: "sess-1".to_string(),
+            request_id: "req-uuid-xyz".to_string(),
+            result: None,
+            error: Some("tool exploded".to_string()),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["error"], "tool exploded");
+        // `result` must be omitted so the CLI's union type picks the error path.
+        assert!(json.get("result").is_none());
     }
 }

--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -267,6 +267,44 @@ pub struct IncomingJsonRpcRequest {
     pub params: Option<serde_json::Value>,
 }
 
+/// Params for the `session.permissions.handlePendingPermissionRequest` RPC
+/// request (SDK → CLI).
+///
+/// When the Copilot CLI emits a `permission.requested` session event (e.g.
+/// the LLM wants to run a shell command or write a file), the SDK must
+/// respond by invoking this method with the matching `requestId`.  Without
+/// a response the CLI side pauses indefinitely, blocking the tool loop.
+///
+/// The SDK's `approveAll` helper in the official Node.js SDK sends a payload
+/// equivalent to `PermissionResult::Approved` here.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandlePermissionRequestParams {
+    pub session_id: String,
+    pub request_id: String,
+    pub result: PermissionResult,
+}
+
+/// Response variants for a permission request, matching the `anyOf` union in
+/// `schemas/api.schema.json` → `session.permissions.handlePendingPermissionRequest`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum PermissionResult {
+    /// Permission granted — the CLI may proceed with the requested action.
+    Approved,
+    /// Denied because one or more approval rules explicitly blocked it.
+    DeniedByRules { rules: Vec<serde_json::Value> },
+    /// Denied because no approval rule matched and interactive user
+    /// confirmation was unavailable.
+    DeniedNoApprovalRuleAndCouldNotRequestFromUser,
+    /// Denied through an interactive prompt by the user, optionally with
+    /// human-readable feedback.
+    DeniedInteractivelyByUser {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        feedback: Option<String>,
+    },
+}
+
 /// JSON-RPC response sent from SDK → CLI (e.g., `tool.call` result).
 ///
 /// Used by **Native Tool Use** — after executing a tool,

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -2096,7 +2096,10 @@ mod tests {
             Some(RoutedMessage::ExternalToolCall { arguments, .. }) => {
                 assert_eq!(arguments, serde_json::Value::Null);
             }
-            other => panic!("expected Some(ExternalToolCall) with Null args, got {:?}", other),
+            other => panic!(
+                "expected Some(ExternalToolCall) with Null args, got {:?}",
+                other
+            ),
         }
 
         // ケース3: data自体が無い

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -19,8 +19,9 @@
 
 use crate::copilot::error::{CopilotError, Result};
 use crate::copilot::protocol::{
-    CreateSessionParams, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseOut,
-    ToolCallParams, ToolCallResult,
+    CreateSessionParams, CreateSessionResult, HandlePermissionRequestParams, JsonRpcNotification,
+    JsonRpcRequest, JsonRpcResponse, JsonRpcResponseOut, PermissionResult, ToolCallParams,
+    ToolCallResult,
 };
 use crate::copilot::transport::{MessageKind, StreamingOutcome, classify_message};
 use quorum_application::ports::conversation_logger::{
@@ -38,8 +39,58 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
-/// Timeout for session creation (waiting for `session.start` event).
+/// Timeout for `session.create` — waiting for the JSON-RPC response
+/// (which carries `result.sessionId`).
+///
+/// The Copilot CLI typically replies within ~1.5s. This cap protects
+/// against pathological hangs without punishing slow first-boots. We do
+/// **not** wait for the `session.start` notification — session_id comes
+/// back in the response envelope directly, so there is nothing to
+/// correlate against the notification.
 const SESSION_CREATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Decide how to respond to a `permission.requested` event from Copilot CLI.
+///
+/// The CLI side hands us the `kind` of the requested action (from the
+/// `permissionRequest.kind` field of the event) and blocks the tool loop
+/// until we reply via `session.permissions.handlePendingPermissionRequest`.
+///
+/// This router-level policy runs **before** any higher-level HiL or Lua
+/// hook, so it should be conservative but non-blocking: pick an
+/// `approved` / `denied-*` variant synchronously from the event kind alone.
+fn decide_permission_result(kind: &str) -> PermissionResult {
+    match kind {
+        // Read-only actions — no side effects, safe to auto-approve.
+        "read" | "url" => PermissionResult::Approved,
+
+        // `shell` is needed by ensemble planning to run git/grep/ls for
+        // context gathering, and the Copilot CLI's internal skills are
+        // forwarded as `custom-tool` permission requests. Approved here
+        // until per-command HiL wiring lands.
+        "shell" | "custom-tool" => PermissionResult::Approved,
+
+        // Mutating side effects on the user's environment / external
+        // systems. Deny with feedback so the LLM knows to take another
+        // path instead of retrying the same action.
+        "write" | "mcp" => PermissionResult::DeniedInteractivelyByUser {
+            feedback: Some(format!(
+                "Permission kind '{kind}' is blocked at the router level. \
+                 Use read-only tools (read_file, grep_search, glob_search) \
+                 or surface the change to the user for manual application."
+            )),
+        },
+
+        // Unknown future kinds — deny conservatively so a new CLI version
+        // can't surprise us with unreviewed side-effecting actions.
+        _ => PermissionResult::DeniedInteractivelyByUser {
+            feedback: Some(format!(
+                "Unknown permission kind '{kind}' was denied by the default \
+                 router policy. This kind is not recognised by the current \
+                 quorum version."
+            )),
+        },
+    }
+}
 
 /// A message routed to a specific session's channel.
 ///
@@ -64,12 +115,6 @@ pub enum RoutedMessage {
         request_id: u64,
         params: ToolCallParams,
     },
-}
-
-/// Information extracted from a `session.start` event.
-#[derive(Debug)]
-struct SessionStartEvent {
-    session_id: String,
 }
 
 /// Try to extract text content from a session event's data payload.
@@ -348,7 +393,9 @@ impl SessionChannel {
                     | "session.usage_info"
                     | "assistant.usage"
                     | "assistant.reasoning"
-                    | "tool.execution_partial_result" => {
+                    | "tool.execution_partial_result"
+                    | "permission.requested"
+                    | "permission.completed" => {
                         trace!("Stream: {}", event_type);
                     }
                     "tool.execution_start" => {
@@ -493,7 +540,9 @@ impl SessionChannel {
                     | "session.usage_info"
                     | "assistant.usage"
                     | "assistant.reasoning"
-                    | "tool.execution_partial_result" => {
+                    | "tool.execution_partial_result"
+                    | "permission.requested"
+                    | "permission.completed" => {
                         trace!("Tool stream: {}", event_type);
                     }
                     "tool.execution_start" => {
@@ -619,7 +668,9 @@ impl SessionChannel {
                     | "session.usage_info"
                     | "assistant.usage"
                     | "assistant.reasoning"
-                    | "tool.execution_partial_result" => {
+                    | "tool.execution_partial_result"
+                    | "permission.requested"
+                    | "permission.completed" => {
                         trace!("Stream: {}", event_type);
                     }
                     "tool.execution_start" => {
@@ -682,9 +733,23 @@ impl Drop for SessionChannel {
 /// 3. **Route** incoming JSON-RPC messages by `session_id` to per-session
 ///    [`SessionChannel`]s via `mpsc::UnboundedSender`.
 /// 4. **Correlate** request–response pairs via `oneshot` channels (used by
-///    [`request`](Self::request)).
-/// 5. **Serialize** session creation through [`create_lock`](Self) to prevent
-///    `session.start` event mix-ups.
+///    [`request`](Self::request)) — this includes `session.create`, whose
+///    response envelope carries `result.sessionId` directly.
+///
+/// # Session creation
+///
+/// `session.create` is a plain JSON-RPC request–response: the response
+/// body contains `result.sessionId`, which we register in [`routes`](Self)
+/// before returning the [`SessionChannel`] to the caller.
+///
+/// The `session.start` **notification** that the CLI also emits is
+/// informational only (lifecycle hook) — we no longer use it for session
+/// identification. Earlier versions of this router correlated callers to
+/// the notification via a FIFO queue, which broke when Copilot CLI
+/// v1.0.25 began processing `session.create` requests in parallel and
+/// emitting `session.start` events out-of-order. The response-based
+/// path is order-independent and handles CLI error responses (e.g.
+/// "Model X is not available") surfaced as [`CopilotError::InvalidModel`].
 ///
 /// # Feature usage
 ///
@@ -708,12 +773,16 @@ pub struct MessageRouter {
     /// Request-response correlation (request_id -> oneshot sender).
     pending_responses: Arc<RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>>,
 
-    /// Channel for session.start events (consumed during session creation).
-    _session_start_tx: mpsc::UnboundedSender<SessionStartEvent>,
-    session_start_rx: Mutex<mpsc::UnboundedReceiver<SessionStartEvent>>,
-
-    /// Serializes session creation (prevent concurrent session.start confusion).
-    create_lock: Mutex<()>,
+    /// In-flight `session.create` calls (request_id -> mpsc sender).
+    ///
+    /// Holds the route tx for each pending `session.create` so the reader
+    /// loop can register `routes[session_id] = tx` **atomically** with
+    /// response delivery — before the next notification iteration can run.
+    /// This closes the race where `session.start` (or any early event) is
+    /// emitted before `create_session()` has learnt its session_id from
+    /// the response and would otherwise arrive at a still-empty routes map.
+    pending_session_creations:
+        Arc<std::sync::RwLock<HashMap<u64, mpsc::UnboundedSender<RoutedMessage>>>>,
 
     /// Writer (serialized writes, independent of reader).
     ///
@@ -815,26 +884,26 @@ impl MessageRouter {
             Arc::new(std::sync::RwLock::new(HashMap::new()));
         let pending_responses: Arc<RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>> =
             Arc::new(RwLock::new(HashMap::new()));
-        let (session_start_tx, session_start_rx) = mpsc::unbounded_channel();
+        let pending_session_creations: Arc<
+            std::sync::RwLock<HashMap<u64, mpsc::UnboundedSender<RoutedMessage>>>,
+        > = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let writer = Arc::new(Mutex::new(BufWriter::new(write_half)));
 
-        // Clone refs for the background reader task
         let routes_bg = Arc::clone(&routes);
         let pending_bg = Arc::clone(&pending_responses);
-        let start_tx_bg = session_start_tx.clone();
+        let pending_creations_bg = Arc::clone(&pending_session_creations);
         let writer_bg = Arc::clone(&writer);
 
         let reader_handle = tokio::spawn(async move {
-            Self::reader_loop(read_half, routes_bg, pending_bg, start_tx_bg, writer_bg).await;
+            Self::reader_loop(read_half, routes_bg, pending_bg, pending_creations_bg, writer_bg)
+                .await;
         });
 
         let router = Arc::new(Self {
             _reader_handle: reader_handle,
             routes,
             pending_responses,
-            _session_start_tx: session_start_tx,
-            session_start_rx: Mutex::new(session_start_rx),
-            create_lock: Mutex::new(()),
+            pending_session_creations,
             writer,
             child,
             conversation_logger,
@@ -849,9 +918,11 @@ impl MessageRouter {
     /// occurs. Each incoming JSON-RPC message is classified by
     /// [`classify_message`] and dispatched:
     ///
-    /// - **Response** → `pending_responses` oneshot (request correlation)
-    /// - **Notification `session.start`** → `session_start_tx` (session creation)
-    /// - **Notification (other)** → `routes[session_id]` → [`SessionChannel`]
+    /// - **Response** → `pending_responses` oneshot (request correlation,
+    ///   including `session.create` responses that carry `result.sessionId`)
+    /// - **Notification (all)** → `routes[session_id]` → [`SessionChannel`]
+    ///   (including `session.start`, which is just informational — the
+    ///   session_id is already known from the `session.create` response)
     /// - **IncomingRequest `tool.call`** → `routes[session_id]` → [`SessionChannel`]
     ///
     /// When the loop exits, all senders are dropped so that receivers observe
@@ -860,7 +931,9 @@ impl MessageRouter {
         read_half: OwnedReadHalf,
         routes: Arc<std::sync::RwLock<HashMap<String, mpsc::UnboundedSender<RoutedMessage>>>>,
         pending_responses: Arc<RwLock<HashMap<u64, oneshot::Sender<JsonRpcResponse>>>>,
-        session_start_tx: mpsc::UnboundedSender<SessionStartEvent>,
+        pending_session_creations: Arc<
+            std::sync::RwLock<HashMap<u64, mpsc::UnboundedSender<RoutedMessage>>>,
+        >,
         writer: Arc<Mutex<BufWriter<OwnedWriteHalf>>>,
     ) {
         let mut reader = BufReader::new(read_half);
@@ -926,6 +999,44 @@ impl MessageRouter {
                                 continue;
                             }
                         };
+
+                        // If this is a `session.create` response, register the
+                        // route BEFORE delivering to the oneshot. This closes
+                        // the race where a subsequent notification iteration
+                        // would see an empty routes map and drop the event.
+                        let creation_tx = {
+                            let mut pending = pending_session_creations
+                                .write()
+                                .unwrap_or_else(|e| e.into_inner());
+                            pending.remove(&id)
+                        };
+                        if let Some(tx) = creation_tx {
+                            if let Some(result) = response.result.as_ref() {
+                                if let Some(sid) = result
+                                    .get("sessionId")
+                                    .and_then(|v| v.as_str())
+                                {
+                                    let mut routes_w =
+                                        routes.write().unwrap_or_else(|e| e.into_inner());
+                                    routes_w.insert(sid.to_string(), tx);
+                                    debug!(
+                                        "Router: route pre-registered for session {} \
+                                         (before response delivery)",
+                                        sid
+                                    );
+                                } else {
+                                    debug!(
+                                        "Router: session.create response id={} \
+                                         missing result.sessionId — tx dropped",
+                                        id
+                                    );
+                                }
+                            }
+                            // Error responses: tx is simply dropped; caller
+                            // will get the error via oneshot below and treat
+                            // the session as never-created.
+                        }
+
                         let sender = {
                             let mut pending = pending_responses.write().await;
                             pending.remove(&id)
@@ -1019,12 +1130,14 @@ impl MessageRouter {
                                     .unwrap_or("")
                                     .to_string();
 
-                                // Check for session.start
-                                if event_type == "session.start" {
-                                    debug!("Router: session.start for {}", sid);
-                                    let _ = session_start_tx
-                                        .send(SessionStartEvent { session_id: sid });
-                                    continue;
+                                // Auto-respond to permission requests so the
+                                // CLI's built-in skills (shell / write / read /
+                                // mcp / url / custom-tool) don't block waiting
+                                // for a handler we never had wired up.
+                                if event_type == "permission.requested" {
+                                    Self::handle_permission_request(&sid, &ev, Arc::clone(&writer));
+                                    // Fall through so the event still reaches
+                                    // the session channel for observability.
                                 }
 
                                 // Route to session channel
@@ -1064,6 +1177,12 @@ impl MessageRouter {
             let mut pending_w = pending_responses.write().await;
             pending_w.clear();
         }
+        {
+            let mut creations_w = pending_session_creations
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            creations_w.clear();
+        }
     }
 
     /// Helper: read the Content-Length header value.
@@ -1093,9 +1212,16 @@ impl MessageRouter {
 
     /// Create a new Copilot session and return its ID + channel.
     ///
-    /// Session creation is serialized via `create_lock` to prevent
-    /// concurrent `session.create` requests from confusing which
-    /// `session.start` event belongs to which caller.
+    /// Multiple `session.create` calls run in **parallel** without any
+    /// router-level serialization: each call sends a JSON-RPC request
+    /// and awaits its own response (correlated by request `id`). The
+    /// response carries `result.sessionId` directly, so there is no
+    /// dependency on the order of subsequent `session.start` events —
+    /// which the CLI (≥ 1.0.25) emits out-of-order under parallel load.
+    ///
+    /// Surfaces CLI error responses (e.g. `"Model X is not available"`)
+    /// as [`CopilotError::InvalidModel`] so callers can distinguish
+    /// configuration mistakes from transport faults.
     ///
     /// Called by [`CopilotSession::new`](super::session::CopilotSession::new)
     /// for the main session, and again by
@@ -1105,8 +1231,6 @@ impl MessageRouter {
         self: &Arc<Self>,
         params: CreateSessionParams,
     ) -> Result<(String, SessionChannel)> {
-        let _guard = self.create_lock.lock().await;
-
         let params_value = serde_json::to_value(&params)?;
         let params_size = serde_json::to_string(&params_value)
             .map(|s| s.len())
@@ -1117,32 +1241,89 @@ impl MessageRouter {
             serde_json::to_string(&params_value).unwrap_or_default()
         );
         let request = JsonRpcRequest::new("session.create", Some(params_value));
+        let request_id = request.id;
 
-        self.send_request(&request).await?;
+        // Pre-register the route sender keyed by request_id. When the reader
+        // loop receives the session.create response, it will move this tx
+        // into routes[session_id] **before** delivering the response — so by
+        // the time we get the sessionId back here, any events already
+        // received for that session are safely routed to our channel.
+        let (tx, rx) = mpsc::unbounded_channel();
+        {
+            let mut pending = self
+                .pending_session_creations
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            pending.insert(request_id, tx);
+        }
 
-        // Wait for session.start event with timeout
-        let start_event = {
-            let mut rx = self.session_start_rx.lock().await;
-            match tokio::time::timeout(SESSION_CREATE_TIMEOUT, rx.recv()).await {
-                Ok(Some(event)) => event,
-                Ok(None) => return Err(CopilotError::RouterStopped),
-                Err(_) => {
-                    return Err(CopilotError::Timeout(
-                        "session.create timed out waiting for session.start".into(),
-                    ));
-                }
+        let response = match tokio::time::timeout(
+            SESSION_CREATE_TIMEOUT,
+            self.request(&request),
+        )
+        .await
+        {
+            Ok(res) => res,
+            Err(_) => {
+                // Timeout: reclaim the pre-registered tx so it doesn't leak.
+                let mut pending = self
+                    .pending_session_creations
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                pending.remove(&request_id);
+                return Err(CopilotError::Timeout(
+                    "session.create timed out waiting for response".into(),
+                ));
+            }
+        };
+        let response = match response {
+            Ok(r) => r,
+            Err(e) => {
+                let mut pending = self
+                    .pending_session_creations
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                pending.remove(&request_id);
+                return Err(e);
             }
         };
 
-        let session_id = start_event.session_id;
+        if let Some(err) = response.error {
+            // Reader loop didn't register the route (no result.sessionId on
+            // error), but defensively clean up in case the race went the
+            // other way.
+            {
+                let mut pending = self
+                    .pending_session_creations
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                pending.remove(&request_id);
+            }
+            // Copilot CLI surfaces unknown / deprecated model names as
+            // messages like `Model "gemini-3.1-pro-preview" is not available`.
+            // Surface a dedicated variant so the caller can show a clear
+            // "fix your config" hint instead of a generic transport error.
+            if err.message.contains("not available") || err.message.contains("not supported") {
+                return Err(CopilotError::InvalidModel(err.message));
+            }
+            return Err(CopilotError::RpcError {
+                code: err.code,
+                message: err.message,
+            });
+        }
+
+        let result_value = response.result.ok_or_else(|| {
+            CopilotError::UnexpectedResponse(
+                "session.create response missing result field".into(),
+            )
+        })?;
+        let result: CreateSessionResult = serde_json::from_value(result_value)?;
+        let session_id = result.session_id;
         debug!("Router: session created: {}", session_id);
 
-        // Create the channel pair and register
-        let (tx, rx) = mpsc::unbounded_channel();
-        {
-            let mut routes = self.routes.write().unwrap_or_else(|e| e.into_inner());
-            routes.insert(session_id.clone(), tx);
-        }
+        // Route registration was already done by the reader loop when it
+        // processed the response — we just construct the SessionChannel
+        // that owns the receiver end of the channel we pre-registered.
 
         let channel = SessionChannel {
             rx,
@@ -1215,6 +1396,90 @@ impl MessageRouter {
         Ok(())
     }
 
+    /// Respond to a `permission.requested` session event.
+    ///
+    /// Parses `data.requestId` and `data.permissionRequest.kind` from the
+    /// event body, runs [`decide_permission_result`], and spawns a task
+    /// that writes `session.permissions.handlePendingPermissionRequest` on
+    /// the shared writer. The reply is fire-and-forget because the CLI
+    /// answers with a plain response we don't need to correlate — and the
+    /// subsequent `permission.completed` event confirms the outcome.
+    ///
+    /// Called from the reader loop (static context), hence an associated
+    /// function that takes the writer by `Arc` instead of `&self`.
+    fn handle_permission_request(
+        session_id: &str,
+        event: &serde_json::Value,
+        writer: Arc<Mutex<BufWriter<OwnedWriteHalf>>>,
+    ) {
+        let data = match event.get("data") {
+            Some(d) => d,
+            None => {
+                warn!("permission.requested without data field");
+                return;
+            }
+        };
+        let request_id = match data.get("requestId").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => {
+                warn!("permission.requested without data.requestId");
+                return;
+            }
+        };
+        let kind = data
+            .get("permissionRequest")
+            .and_then(|pr| pr.get("kind"))
+            .and_then(|k| k.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let result = decide_permission_result(&kind);
+        info!(
+            "permission.requested session={} kind={} request_id={} → {:?}",
+            session_id, kind, request_id, result
+        );
+
+        let params = HandlePermissionRequestParams {
+            session_id: session_id.to_string(),
+            request_id,
+            result,
+        };
+        let params_value = match serde_json::to_value(&params) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Failed to serialize permission response: {}", e);
+                return;
+            }
+        };
+        let request = JsonRpcRequest::new(
+            "session.permissions.handlePendingPermissionRequest",
+            Some(params_value),
+        );
+
+        tokio::spawn(async move {
+            let json = match serde_json::to_string(&request) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Failed to serialize permission RPC: {}", e);
+                    return;
+                }
+            };
+            let header = format!("Content-Length: {}\r\n\r\n", json.len());
+            let mut w = writer.lock().await;
+            if let Err(e) = w.write_all(header.as_bytes()).await {
+                warn!("Failed to write permission header: {}", e);
+                return;
+            }
+            if let Err(e) = w.write_all(json.as_bytes()).await {
+                warn!("Failed to write permission body: {}", e);
+                return;
+            }
+            if let Err(e) = w.flush().await {
+                warn!("Failed to flush permission response: {}", e);
+            }
+        });
+    }
+
     /// Deregister a session from the routing table.
     ///
     /// Automatically called by [`SessionChannel::drop`] — callers do not
@@ -1237,6 +1502,45 @@ impl Drop for MessageRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn permission_policy_matches_intent() {
+        assert!(matches!(
+            decide_permission_result("read"),
+            PermissionResult::Approved
+        ));
+        assert!(matches!(
+            decide_permission_result("url"),
+            PermissionResult::Approved
+        ));
+        assert!(matches!(
+            decide_permission_result("shell"),
+            PermissionResult::Approved
+        ));
+        assert!(matches!(
+            decide_permission_result("custom-tool"),
+            PermissionResult::Approved
+        ));
+
+        let result = decide_permission_result("write");
+        if let PermissionResult::DeniedInteractivelyByUser { feedback } = result {
+            assert!(feedback.unwrap().contains("write"));
+        } else {
+            panic!("expected DeniedInteractivelyByUser, got {:?}", result);
+        }
+        let result = decide_permission_result("mcp");
+        if let PermissionResult::DeniedInteractivelyByUser { feedback } = result {
+            assert!(feedback.unwrap().contains("mcp"));
+        } else {
+            panic!("expected DeniedInteractivelyByUser, got {:?}", result);
+        }
+        let result = decide_permission_result("zz-yy-xx");
+        if let PermissionResult::DeniedInteractivelyByUser { feedback } = result {
+            assert!(feedback.unwrap().contains("zz-yy-xx"));
+        } else {
+            panic!("expected DeniedInteractivelyByUser, got {:?}", result);
+        }
+    }
 
     #[test]
     fn extract_text_from_string_content() {

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -1121,25 +1121,24 @@ impl MessageRouter {
                                 .unwrap_or_else(|e| e.into_inner());
                             pending.remove(&id)
                         };
-                        if let Some(tx) = creation_tx {
-                            if let Some(result) = response.result.as_ref() {
-                                if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str())
-                                {
-                                    let mut routes_w =
-                                        routes.write().unwrap_or_else(|e| e.into_inner());
-                                    routes_w.insert(sid.to_string(), tx);
-                                    debug!(
-                                        "Router: route pre-registered for session {} \
-                                         (before response delivery)",
-                                        sid
-                                    );
-                                } else {
-                                    debug!(
-                                        "Router: session.create response id={} \
-                                         missing result.sessionId — tx dropped",
-                                        id
-                                    );
-                                }
+                        if let Some(tx) = creation_tx
+                            && let Some(result) = response.result.as_ref()
+                        {
+                            if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str()) {
+                                let mut routes_w =
+                                    routes.write().unwrap_or_else(|e| e.into_inner());
+                                routes_w.insert(sid.to_string(), tx);
+                                debug!(
+                                    "Router: route pre-registered for session {} \
+                                     (before response delivery)",
+                                    sid
+                                );
+                            } else {
+                                debug!(
+                                    "Router: session.create response id={} \
+                                     missing result.sessionId — tx dropped",
+                                    id
+                                );
                             }
                             // Error responses: tx is simply dropped; caller
                             // will get the error via oneshot below and treat

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -19,9 +19,9 @@
 
 use crate::copilot::error::{CopilotError, Result};
 use crate::copilot::protocol::{
-    CreateSessionParams, CreateSessionResult, HandlePermissionRequestParams, JsonRpcNotification,
-    JsonRpcRequest, JsonRpcResponse, JsonRpcResponseOut, PermissionResult, ToolCallParams,
-    ToolCallResult,
+    CreateSessionParams, CreateSessionResult, ExternalToolResult, HandlePendingToolCallParams,
+    HandlePermissionRequestParams, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    JsonRpcResponseOut, PermissionResult, ToolCallParams, ToolCallResult,
 };
 use crate::copilot::transport::{MessageKind, StreamingOutcome, classify_message};
 use quorum_application::ports::conversation_logger::{
@@ -111,9 +111,29 @@ pub enum RoutedMessage {
     ///
     /// Used by **Native Tool Use** and the **Agent System** — the LLM decides
     /// to invoke a tool, and the CLI forwards the request to us for execution.
+    ///
+    /// **Legacy path** — CLI 1.0.25 now uses `external_tool.requested` events
+    /// for user-defined tools (see [`ExternalToolCall`](Self::ExternalToolCall));
+    /// this path is retained for built-in tools and backwards compatibility.
     ToolCall {
         request_id: u64,
         params: ToolCallParams,
+    },
+    /// An `external_tool.requested` session event from CLI 1.0.25+.
+    ///
+    /// User-defined tools (registered via `session.create`'s `tools` field)
+    /// are invoked through this path instead of the legacy `tool.call` RPC.
+    /// The `request_id` is a **UUID string** (not a JSON-RPC numeric id);
+    /// the response must be sent via
+    /// [`MessageRouter::respond_to_external_tool`].
+    ExternalToolCall {
+        /// UUID string — correlates the CLI's `external_tool.requested` with
+        /// our `session.tools.handlePendingToolCall` reply.
+        request_id: String,
+        session_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
     },
 }
 
@@ -231,6 +251,33 @@ fn extract_tool_call_id(event: &serde_json::Value) -> Option<&str> {
         .get("data")
         .and_then(|d| d.get("toolCallId"))
         .and_then(|v| v.as_str())
+}
+
+/// Parse an `external_tool.requested` event into a routable message.
+///
+/// Returns `None` when any required field (`requestId`, `toolCallId`,
+/// `toolName`, `arguments`) is missing so the caller can fall back to the
+/// generic `SessionEvent` routing.  `session_id` is passed in rather than
+/// pulled from the event because the outer routing layer already tracks it.
+fn parse_external_tool_requested(
+    session_id: &str,
+    event: &serde_json::Value,
+) -> Option<RoutedMessage> {
+    let data = event.get("data")?;
+    let request_id = data.get("requestId").and_then(|v| v.as_str())?.to_string();
+    let tool_call_id = data.get("toolCallId").and_then(|v| v.as_str())?.to_string();
+    let tool_name = data.get("toolName").and_then(|v| v.as_str())?.to_string();
+    let arguments = data
+        .get("arguments")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    Some(RoutedMessage::ExternalToolCall {
+        request_id,
+        session_id: session_id.to_string(),
+        tool_call_id,
+        tool_name,
+        arguments,
+    })
 }
 
 impl SessionChannel {
@@ -431,6 +478,25 @@ impl SessionChannel {
                     let response = JsonRpcResponseOut::new(request_id, result.into_rpc_value());
                     let _ = self.router.send_response(&response).await;
                 }
+                RoutedMessage::ExternalToolCall {
+                    request_id,
+                    session_id,
+                    tool_name,
+                    ..
+                } => {
+                    warn!(
+                        "Unexpected external_tool.requested in read_streaming: {}, rejecting",
+                        tool_name
+                    );
+                    let _ = self
+                        .router
+                        .respond_to_external_tool(
+                            &session_id,
+                            &request_id,
+                            Err("Tool not available in this session context".to_string()),
+                        )
+                        .await;
+                }
             }
         }
     }
@@ -570,6 +636,26 @@ impl SessionChannel {
                         params,
                     });
                 }
+                RoutedMessage::ExternalToolCall {
+                    request_id,
+                    session_id,
+                    tool_call_id,
+                    tool_name,
+                    arguments,
+                } => {
+                    debug!(
+                        "External tool call received: {} (request_id={})",
+                        tool_name, request_id
+                    );
+                    return Ok(StreamingOutcome::ExternalToolCall {
+                        text_so_far: full_content,
+                        request_id,
+                        session_id,
+                        tool_call_id,
+                        tool_name,
+                        arguments,
+                    });
+                }
             }
         }
     }
@@ -705,6 +791,25 @@ impl SessionChannel {
                         ToolCallResult::error("Tool not available in this session context");
                     let response = JsonRpcResponseOut::new(request_id, result.into_rpc_value());
                     let _ = self.router.send_response(&response).await;
+                }
+                RoutedMessage::ExternalToolCall {
+                    request_id,
+                    session_id,
+                    tool_name,
+                    ..
+                } => {
+                    warn!(
+                        "Unexpected external_tool.requested in read_streaming_with_cancellation: {}, rejecting",
+                        tool_name
+                    );
+                    let _ = self
+                        .router
+                        .respond_to_external_tool(
+                            &session_id,
+                            &request_id,
+                            Err("Tool not available in this session context".to_string()),
+                        )
+                        .await;
                 }
             }
         }
@@ -895,8 +1000,14 @@ impl MessageRouter {
         let writer_bg = Arc::clone(&writer);
 
         let reader_handle = tokio::spawn(async move {
-            Self::reader_loop(read_half, routes_bg, pending_bg, pending_creations_bg, writer_bg)
-                .await;
+            Self::reader_loop(
+                read_half,
+                routes_bg,
+                pending_bg,
+                pending_creations_bg,
+                writer_bg,
+            )
+            .await;
         });
 
         let router = Arc::new(Self {
@@ -1012,9 +1123,7 @@ impl MessageRouter {
                         };
                         if let Some(tx) = creation_tx {
                             if let Some(result) = response.result.as_ref() {
-                                if let Some(sid) = result
-                                    .get("sessionId")
-                                    .and_then(|v| v.as_str())
+                                if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str())
                                 {
                                     let mut routes_w =
                                         routes.write().unwrap_or_else(|e| e.into_inner());
@@ -1140,13 +1249,29 @@ impl MessageRouter {
                                     // the session channel for observability.
                                 }
 
-                                // Route to session channel
+                                // Route to session channel.  User-defined tool
+                                // invocations (CLI 1.0.25+) arrive as
+                                // `external_tool.requested` events and are
+                                // promoted to a dedicated RoutedMessage variant
+                                // so callers can dispatch them distinctly from
+                                // the legacy `tool.call` path.
+                                let routed_message = if event_type == "external_tool.requested" {
+                                    parse_external_tool_requested(&sid, &ev).unwrap_or_else(|| {
+                                        RoutedMessage::SessionEvent {
+                                            event_type: event_type.clone(),
+                                            event: ev.clone(),
+                                        }
+                                    })
+                                } else {
+                                    RoutedMessage::SessionEvent {
+                                        event_type: event_type.clone(),
+                                        event: ev,
+                                    }
+                                };
+
                                 let routes_read = routes.read().unwrap_or_else(|e| e.into_inner());
                                 if let Some(tx) = routes_read.get(&sid) {
-                                    let _ = tx.send(RoutedMessage::SessionEvent {
-                                        event_type,
-                                        event: ev,
-                                    });
+                                    let _ = tx.send(routed_message);
                                 } else {
                                     debug!(
                                         "Router: no route for session_id={}, dropping event type={}",
@@ -1257,25 +1382,21 @@ impl MessageRouter {
             pending.insert(request_id, tx);
         }
 
-        let response = match tokio::time::timeout(
-            SESSION_CREATE_TIMEOUT,
-            self.request(&request),
-        )
-        .await
-        {
-            Ok(res) => res,
-            Err(_) => {
-                // Timeout: reclaim the pre-registered tx so it doesn't leak.
-                let mut pending = self
-                    .pending_session_creations
-                    .write()
-                    .unwrap_or_else(|e| e.into_inner());
-                pending.remove(&request_id);
-                return Err(CopilotError::Timeout(
-                    "session.create timed out waiting for response".into(),
-                ));
-            }
-        };
+        let response =
+            match tokio::time::timeout(SESSION_CREATE_TIMEOUT, self.request(&request)).await {
+                Ok(res) => res,
+                Err(_) => {
+                    // Timeout: reclaim the pre-registered tx so it doesn't leak.
+                    let mut pending = self
+                        .pending_session_creations
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner());
+                    pending.remove(&request_id);
+                    return Err(CopilotError::Timeout(
+                        "session.create timed out waiting for response".into(),
+                    ));
+                }
+            };
         let response = match response {
             Ok(r) => r,
             Err(e) => {
@@ -1313,9 +1434,7 @@ impl MessageRouter {
         }
 
         let result_value = response.result.ok_or_else(|| {
-            CopilotError::UnexpectedResponse(
-                "session.create response missing result field".into(),
-            )
+            CopilotError::UnexpectedResponse("session.create response missing result field".into())
         })?;
         let result: CreateSessionResult = serde_json::from_value(result_value)?;
         let session_id = result.session_id;
@@ -1393,6 +1512,52 @@ impl MessageRouter {
         writer.write_all(header.as_bytes()).await?;
         writer.write_all(response_json.as_bytes()).await?;
         writer.flush().await?;
+        Ok(())
+    }
+
+    /// Reply to an `external_tool.requested` event via
+    /// `session.tools.handlePendingToolCall` (Copilot CLI 1.0.25+).
+    ///
+    /// `result` is `Ok(text)` for a successful tool execution — the string is
+    /// fed back to the LLM verbatim — or `Err(message)` to signal failure via
+    /// the CLI's `error` field.  The RPC is sent with a fresh request id and
+    /// the `{success: true}` response is awaited to surface transport errors
+    /// early; the outgoing `external_tool.completed` event then unblocks the
+    /// LLM.
+    pub async fn respond_to_external_tool(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        result: std::result::Result<String, String>,
+    ) -> Result<()> {
+        let (tool_result, error) = match result {
+            Ok(text) => (Some(ExternalToolResult::Text(text)), None),
+            Err(message) => (None, Some(message)),
+        };
+        let params = HandlePendingToolCallParams {
+            session_id: session_id.to_string(),
+            request_id: request_id.to_string(),
+            result: tool_result,
+            error,
+        };
+        let params_value = serde_json::to_value(&params)?;
+        let request =
+            JsonRpcRequest::new("session.tools.handlePendingToolCall", Some(params_value));
+        let response = self.request(&request).await?;
+        if let Some(err) = response.error {
+            warn!(
+                "session.tools.handlePendingToolCall rejected (request_id={}): code={} message={}",
+                request_id, err.code, err.message
+            );
+            return Err(CopilotError::RpcError {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        debug!(
+            "external tool responded: session_id={} request_id={}",
+            session_id, request_id
+        );
         Ok(())
     }
 
@@ -1874,5 +2039,72 @@ mod tests {
 
         // Also verify that extract_tool_name_from_event finds nothing in the complete event
         assert_eq!(extract_tool_name_from_event(&complete), None);
+    }
+
+    #[test]
+    fn parse_external_tool_requested_happy_path() {
+        let event = serde_json::json!({
+            "type": "external_tool.requested",
+            "data": {
+                "requestId": "req-uuid-123",
+                "toolCallId": "call_abc",
+                "toolName": "create_plan",
+                "arguments": { "objective": "ship it", "tasks": [] }
+            }
+        });
+        let routed = parse_external_tool_requested("sess-1", &event).expect("parse ok");
+        match routed {
+            RoutedMessage::ExternalToolCall {
+                request_id,
+                session_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                assert_eq!(request_id, "req-uuid-123");
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(tool_call_id, "call_abc");
+                assert_eq!(tool_name, "create_plan");
+                assert_eq!(arguments["objective"], "ship it");
+            }
+            other => panic!("expected ExternalToolCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_external_tool_requested_missing_fields() {
+        // ケース1: requestId が無い
+        let event_no_request_id = serde_json::json!({
+            "type": "external_tool.requested",
+            "data": {
+                "toolCallId": "call_abc",
+                "toolName": "create_plan",
+                "arguments": {}
+            }
+        });
+        assert!(parse_external_tool_requested("sess-1", &event_no_request_id).is_none());
+
+        // ケース2: arguments はオプショナル — 欠損時は Value::Null にフォールバック
+        let event_no_args = serde_json::json!({
+            "type": "external_tool.requested",
+            "data": {
+                "requestId": "req-123",
+                "toolCallId": "call_abc",
+                "toolName": "create_plan"
+            }
+        });
+        match parse_external_tool_requested("sess-1", &event_no_args) {
+            Some(RoutedMessage::ExternalToolCall { arguments, .. }) => {
+                assert_eq!(arguments, serde_json::Value::Null);
+            }
+            other => panic!("expected Some(ExternalToolCall) with Null args, got {:?}", other),
+        }
+
+        // ケース3: data自体が無い
+        let event_no_data = serde_json::json!({
+            "type": "external_tool.requested",
+        });
+
+        assert!(parse_external_tool_requested("sess-1", &event_no_data).is_none())
     }
 }

--- a/infrastructure/src/copilot/session.rs
+++ b/infrastructure/src/copilot/session.rs
@@ -669,8 +669,7 @@ impl LlmSession for CopilotSession {
                     None => ToolCallResult::success(""),
                 };
                 let result_type = tool_result.result_type.clone();
-                let response =
-                    JsonRpcResponseOut::new(request_id, tool_result.into_rpc_value());
+                let response = JsonRpcResponseOut::new(request_id, tool_result.into_rpc_value());
                 let response_json = serde_json::to_string(&response).unwrap_or_default();
 
                 self.router

--- a/infrastructure/src/copilot/session.rs
+++ b/infrastructure/src/copilot/session.rs
@@ -60,10 +60,29 @@ struct ToolSessionState {
     pending_tool_call: Option<PendingToolCall>,
 }
 
-/// A pending tool.call request that we need to respond to.
-struct PendingToolCall {
-    /// The JSON-RPC request ID we must echo back.
-    request_id: u64,
+/// A pending tool invocation awaiting our result.
+///
+/// Copilot CLI delivers tool calls through two distinct mechanisms depending
+/// on how the tool was registered and the CLI version:
+///
+/// - `Legacy` — built-in tools (and pre-1.0.25 user tools) arrive as a
+///   JSON-RPC `tool.call` request; the reply is a JSON-RPC response with the
+///   matching numeric id.
+/// - `External` — user-defined tools on Copilot CLI 1.0.25+ arrive as
+///   `external_tool.requested` session events; the reply is an outgoing
+///   `session.tools.handlePendingToolCall` RPC keyed by a UUID string.
+///
+/// The variant determines which [`MessageRouter`](super::router::MessageRouter)
+/// method `send_tool_results` dispatches to.
+enum PendingToolCall {
+    /// Legacy `tool.call` — respond via `send_response(JsonRpcResponseOut)`.
+    Legacy { request_id: u64 },
+    /// CLI 1.0.25+ `external_tool.requested` — respond via
+    /// `respond_to_external_tool(session_id, request_id, result)`.
+    External {
+        session_id: String,
+        request_id: String,
+    },
 }
 
 /// An active conversation session with a specific Copilot model.
@@ -493,35 +512,106 @@ impl CopilotSession {
                     *tool_session = Some(ToolSessionState {
                         session_id: tool_session_id,
                         channel: tool_channel,
-                        pending_tool_call: Some(PendingToolCall { request_id }),
+                        pending_tool_call: Some(PendingToolCall::Legacy { request_id }),
                     });
                 }
 
-                // Build response with text (if any) + tool use block
-                let mut content = Vec::new();
-                if !text_so_far.is_empty() {
-                    content.push(ContentBlock::Text(text_so_far));
+                Ok(build_tool_use_response(
+                    text_so_far,
+                    params.tool_call_id,
+                    params.tool_name,
+                    params.arguments,
+                    self.model.to_string(),
+                ))
+            }
+            StreamingOutcome::ExternalToolCall {
+                text_so_far,
+                request_id,
+                session_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                debug!(
+                    "External tool call received: {} (request_id={})",
+                    tool_name, request_id
+                );
+
+                {
+                    let mut tool_session = self.tool_session.lock().await;
+                    *tool_session = Some(ToolSessionState {
+                        session_id: tool_session_id,
+                        channel: tool_channel,
+                        pending_tool_call: Some(PendingToolCall::External {
+                            session_id,
+                            request_id,
+                        }),
+                    });
                 }
 
-                let input = if let Some(obj) = params.arguments.as_object() {
-                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-                } else {
-                    std::collections::HashMap::new()
-                };
-
-                content.push(ContentBlock::ToolUse {
-                    id: params.tool_call_id,
-                    name: params.tool_name,
-                    input,
-                });
-
-                Ok(LlmResponse {
-                    content,
-                    stop_reason: Some(StopReason::ToolUse),
-                    model: Some(self.model.to_string()),
-                })
+                Ok(build_tool_use_response(
+                    text_so_far,
+                    tool_call_id,
+                    tool_name,
+                    arguments,
+                    self.model.to_string(),
+                ))
             }
         }
+    }
+}
+
+/// Assemble an [`LlmResponse`] that carries any pre-tool-call text followed
+/// by a [`ContentBlock::ToolUse`] block.
+///
+/// Shared between the legacy `tool.call` path and the CLI 1.0.25+
+/// `external_tool.requested` path, which only differ in how the reply is
+/// sent back (see [`PendingToolCall`]).
+fn build_tool_use_response(
+    text_so_far: String,
+    tool_call_id: String,
+    tool_name: String,
+    arguments: serde_json::Value,
+    model: String,
+) -> LlmResponse {
+    let mut content = Vec::new();
+    if !text_so_far.is_empty() {
+        content.push(ContentBlock::Text(text_so_far));
+    }
+    let input = if let Some(obj) = arguments.as_object() {
+        obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    } else {
+        std::collections::HashMap::new()
+    };
+    content.push(ContentBlock::ToolUse {
+        id: tool_call_id,
+        name: tool_name,
+        input,
+    });
+    LlmResponse {
+        content,
+        stop_reason: Some(StopReason::ToolUse),
+        model: Some(model),
+    }
+}
+
+/// Map a batch of tool-execution results into the single `Result<String, String>`
+/// that `session.tools.handlePendingToolCall` expects for CLI 1.0.25+ external
+/// tools. Only the first message is considered because a single
+/// `external_tool.requested` event corresponds to exactly one tool call.
+///
+/// - rejected → `Err("Tool rejected: ...")` so the LLM sees a distinct message
+/// - error    → `Err(output)`
+/// - success  → `Ok(output)`
+/// - empty    → `Ok("")` (keeps the turn alive rather than stalling the LLM)
+fn tool_results_to_external_outcome(
+    results: &[ToolResultMessage],
+) -> std::result::Result<String, String> {
+    match results.first() {
+        Some(r) if r.is_rejected => Err(format!("Tool rejected: {}", r.output)),
+        Some(r) if r.is_error => Err(r.output.clone()),
+        Some(r) => Ok(r.output.clone()),
+        None => Ok(String::new()),
     }
 }
 
@@ -563,54 +653,58 @@ impl LlmSession for CopilotSession {
             GatewayError::RequestFailed("No pending tool call to respond to".to_string())
         })?;
 
-        let request_id = pending.request_id;
+        let first = results.first();
+        let first_tool_name = first.map(|r| r.tool_name.as_str()).unwrap_or("unknown");
+        let first_output_bytes = first.map(|r| r.output.len()).unwrap_or(0);
 
-        // Build the tool call result from the first result
-        // (Copilot CLI sends one tool.call at a time)
-        let tool_result = if let Some(result) = results.first() {
-            if result.is_rejected {
-                ToolCallResult::rejected(&result.output)
-            } else if result.is_error {
-                ToolCallResult::error(&result.output)
-            } else {
-                ToolCallResult::success(&result.output)
+        // Dispatch by pending variant: legacy `tool.call` goes back as a
+        // JSON-RPC response, while CLI 1.0.25+ `external_tool.requested`
+        // needs `session.tools.handlePendingToolCall` with the UUID.
+        match pending {
+            PendingToolCall::Legacy { request_id } => {
+                let tool_result = match first {
+                    Some(r) if r.is_rejected => ToolCallResult::rejected(&r.output),
+                    Some(r) if r.is_error => ToolCallResult::error(&r.output),
+                    Some(r) => ToolCallResult::success(&r.output),
+                    None => ToolCallResult::success(""),
+                };
+                let result_type = tool_result.result_type.clone();
+                let response =
+                    JsonRpcResponseOut::new(request_id, tool_result.into_rpc_value());
+                let response_json = serde_json::to_string(&response).unwrap_or_default();
+
+                self.router
+                    .send_response(&response)
+                    .await
+                    .map_err(|e| GatewayError::RequestFailed(e.to_string()))?;
+
+                debug!(
+                    "Tool result sent for request_id={}: tool={}, type={}, output_bytes={}",
+                    request_id, first_tool_name, result_type, first_output_bytes,
+                );
+                trace!(
+                    "Tool result payload for request_id={}: {}",
+                    request_id,
+                    truncate_str(&response_json, 2048),
+                );
             }
-        } else {
-            ToolCallResult::success("")
-        };
+            PendingToolCall::External {
+                session_id,
+                request_id,
+            } => {
+                let outcome = tool_results_to_external_outcome(results);
 
-        // Extract logging values before moving tool_result
-        let first_tool_name = results
-            .first()
-            .map(|r| r.tool_name.as_str())
-            .unwrap_or("unknown");
-        let first_output_bytes = results.first().map(|r| r.output.len()).unwrap_or(0);
-        let result_type = tool_result.result_type.clone();
+                self.router
+                    .respond_to_external_tool(&session_id, &request_id, outcome)
+                    .await
+                    .map_err(|e| GatewayError::RequestFailed(e.to_string()))?;
 
-        // Send the JSON-RPC response back to the CLI
-        // Wrap in { "result": ... } envelope per official Copilot SDK wire format
-        let response = JsonRpcResponseOut::new(request_id, tool_result.into_rpc_value());
-
-        let response_json = serde_json::to_string(&response).unwrap_or_default();
-
-        self.router
-            .send_response(&response)
-            .await
-            .map_err(|e| GatewayError::RequestFailed(e.to_string()))?;
-
-        debug!(
-            "Tool result sent for request_id={}: tool={}, type={}, output_bytes={}",
-            request_id, first_tool_name, result_type, first_output_bytes,
-        );
-        debug!(
-            "Tool result JSON for request_id={} (truncated): {}",
-            request_id,
-            truncate_str(&response_json, 512),
-        );
-        trace!(
-            "Tool result payload for request_id={}: {}",
-            request_id, response_json,
-        );
+                debug!(
+                    "External tool result sent for request_id={}: tool={}, output_bytes={}",
+                    request_id, first_tool_name, first_output_bytes,
+                );
+            }
+        }
 
         // Read the next streaming response — forward chunks to observer if present
         let observer = self.stream_observer.clone();
@@ -642,35 +736,107 @@ impl LlmSession for CopilotSession {
                     "Tool call received: {} (request_id={})",
                     params.tool_name, new_request_id
                 );
-
-                // Store the new pending tool call
-                state.pending_tool_call = Some(PendingToolCall {
+                state.pending_tool_call = Some(PendingToolCall::Legacy {
                     request_id: new_request_id,
                 });
-
-                let mut content = Vec::new();
-                if !text_so_far.is_empty() {
-                    content.push(ContentBlock::Text(text_so_far));
-                }
-
-                let input = if let Some(obj) = params.arguments.as_object() {
-                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-                } else {
-                    std::collections::HashMap::new()
-                };
-
-                content.push(ContentBlock::ToolUse {
-                    id: params.tool_call_id,
-                    name: params.tool_name,
-                    input,
+                Ok(build_tool_use_response(
+                    text_so_far,
+                    params.tool_call_id,
+                    params.tool_name,
+                    params.arguments,
+                    self.model.to_string(),
+                ))
+            }
+            StreamingOutcome::ExternalToolCall {
+                text_so_far,
+                request_id: new_request_id,
+                session_id: new_session_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                debug!(
+                    "External tool call received: {} (request_id={})",
+                    tool_name, new_request_id
+                );
+                state.pending_tool_call = Some(PendingToolCall::External {
+                    session_id: new_session_id,
+                    request_id: new_request_id,
                 });
-
-                Ok(LlmResponse {
-                    content,
-                    stop_reason: Some(StopReason::ToolUse),
-                    model: Some(self.model.to_string()),
-                })
+                Ok(build_tool_use_response(
+                    text_so_far,
+                    tool_call_id,
+                    tool_name,
+                    arguments,
+                    self.model.to_string(),
+                ))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(output: &str, is_error: bool, is_rejected: bool) -> ToolResultMessage {
+        ToolResultMessage {
+            tool_use_id: "call_x".to_string(),
+            tool_name: "create_plan".to_string(),
+            output: output.to_string(),
+            is_error,
+            is_rejected,
+        }
+    }
+
+    #[test]
+    fn external_outcome_success() {
+        let results = vec![msg("plan saved", false, false)];
+        assert_eq!(
+            tool_results_to_external_outcome(&results),
+            Ok("plan saved".to_string())
+        );
+    }
+
+    #[test]
+    fn external_outcome_error_maps_to_err() {
+        let results = vec![msg("boom", true, false)];
+        assert_eq!(
+            tool_results_to_external_outcome(&results),
+            Err("boom".to_string())
+        );
+    }
+
+    #[test]
+    fn external_outcome_rejected_is_prefixed() {
+        let results = vec![msg("user said no", false, true)];
+        // Rejection deserves a distinct prefix so the LLM can distinguish
+        // "I declined" from "the tool crashed".
+        assert_eq!(
+            tool_results_to_external_outcome(&results),
+            Err("Tool rejected: user said no".to_string())
+        );
+    }
+
+    #[test]
+    fn external_outcome_empty_is_ok_empty() {
+        // An empty results slice shouldn't stall the turn — send Ok("") to
+        // let the LLM continue reasoning with a blank tool response.
+        let results: Vec<ToolResultMessage> = vec![];
+        assert_eq!(
+            tool_results_to_external_outcome(&results),
+            Ok(String::new())
+        );
+    }
+
+    #[test]
+    fn external_outcome_rejected_beats_error() {
+        // Guard the precedence: if both flags somehow got set, rejected wins
+        // because it carries more user-intent than a generic error.
+        let results = vec![msg("weird", true, true)];
+        assert_eq!(
+            tool_results_to_external_outcome(&results),
+            Err("Tool rejected: weird".to_string())
+        );
     }
 }

--- a/infrastructure/src/copilot/transport.rs
+++ b/infrastructure/src/copilot/transport.rs
@@ -68,10 +68,30 @@ pub enum StreamingOutcome {
     /// `text_so_far` contains any text the LLM emitted before the tool call.
     /// The caller should execute the tool and send results back via
     /// [`MessageRouter::send_response`](super::router::MessageRouter::send_response).
+    ///
+    /// **Legacy path** — used by built-in tools (`report_intent`, `create_plan`
+    /// pre-1.0.25).  For user-defined tools in Copilot CLI 1.0.25+, see
+    /// [`ExternalToolCall`](Self::ExternalToolCall) instead.
     ToolCall {
         text_so_far: String,
         request_id: u64,
         params: ToolCallParams,
+    },
+    /// An `external_tool.requested` session event was received — the LLM
+    /// wants a **user-defined** tool invoked via the CLI 1.0.25+ path.
+    ///
+    /// Unlike [`ToolCall`](Self::ToolCall), the `request_id` here is a UUID
+    /// string assigned by the CLI, and the response must be sent via
+    /// [`MessageRouter::respond_to_external_tool`](super::router::MessageRouter::respond_to_external_tool)
+    /// rather than a JSON-RPC response.
+    ExternalToolCall {
+        text_so_far: String,
+        /// UUID assigned by the CLI for this external tool request.
+        request_id: String,
+        session_id: String,
+        tool_call_id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
     },
 }
 

--- a/infrastructure/src/providers/routing.rs
+++ b/infrastructure/src/providers/routing.rs
@@ -143,6 +143,9 @@ mod tests {
     }
 
     impl MockProvider {
+        // TODO(#249): rename to `new_arc` and drop this allow — this returns
+        // `Arc<dyn ProviderAdapter>` for test-mock convenience, not `Self`.
+        #[allow(clippy::new_ret_no_self)]
         fn new(kind: ProviderKind) -> Arc<dyn ProviderAdapter> {
             Arc::new(Self {
                 kind,


### PR DESCRIPTION
## Summary

Copilot CLI 1.0.25 ships three protocol changes that together silently broke every Copilot-backed planning flow. Agents would emit a `create_plan` tool call and then hang for 10+ minutes with no observable progress. This PR restores compatibility.

### Changes

- **`external_tool.requested` support** — CLI 1.0.25 replaced the legacy `tool.call` JSON-RPC request with an `external_tool.requested` session event for user-defined tools, expecting the SDK to reply via `session.tools.handlePendingToolCall`. Added the full round-trip (new `StreamingOutcome::ExternalToolCall` variant, `MessageRouter::respond_to_external_tool`, and `PendingToolCall::{Legacy, External}` session-level sticky state).
- **`session.start` race fix** — ensure the session channel is registered before the first frame can arrive.
- **`permission.requested` auto-reply** — respond via `session.permissions.handlePendingPermissionRequest` with a policy-driven decision, so the CLI doesn't stall waiting for a permission answer.

### Provider isolation

Bedrock / Anthropic / OpenAI / Azure are unaffected — each lives behind its own `LlmSession` impl. Only the Copilot transport needed changes.

### Why the legacy and external tool paths are kept separate

CLI 1.0.25 still uses the u64-id `tool.call` path for built-in tools (`report_intent`, etc.), while user-defined tools go through the UUID-string `external_tool.requested` path. The new `StreamingOutcome::ExternalToolCall` variant keeps the two wire formats type-separated rather than union-ing request ids — the `PendingToolCall` enum then routes the response back down the correct channel.

## Test plan

- [x] `cargo test -p quorum-infrastructure --lib` — 138 tests pass, including:
  - `parse_external_tool_requested_{happy_path, missing_fields}`
  - `external_outcome_{success, error_maps_to_err, rejected_is_prefixed, empty_is_ok_empty, rejected_beats_error}`
  - `handle_pending_tool_call_{success, error}_wire_format`
- [x] End-to-end run against real `copilot --server`: plan generation + Quorum review loop completes in ~1 minute (vs. 10+ min hang before). Log shows `Plan rejected (attempt 1), retrying...` → `(attempt 2)`, confirming `create_plan` tool calls round-trip successfully.
- [x] No `ERROR` / `WARN` / `RpcError` / `RouterStopped` in the session log.

Fixes #245
Fixes #246
Fixes #247