### PR TITLE
fix(copilot): web_fetch/web_search の組み込みツール衝突を解消 (#250)

### DIFF
--- a/infrastructure/src/copilot/protocol.rs
+++ b/infrastructure/src/copilot/protocol.rs
@@ -169,6 +169,11 @@ pub struct CopilotToolDefinition {
     /// official Copilot SDK wire format (Go: `Tool.Parameters`,
     /// Node.js: `tool.parameters`).
     pub parameters: serde_json::Value,
+    /// Copilot CLI 1.0.25+ ships built-in tools (e.g. `web_fetch`,
+    /// `web_search`). Setting this to `true` tells the daemon to let
+    /// our external tool replace the built-in of the same name instead
+    /// of rejecting the registration.
+    pub overrides_built_in_tool: bool,
 }
 
 impl CopilotToolDefinition {
@@ -181,6 +186,7 @@ impl CopilotToolDefinition {
             name: value.get("name")?.as_str()?.to_string(),
             description: value.get("description")?.as_str()?.to_string(),
             parameters: value.get("input_schema")?.clone(),
+            overrides_built_in_tool: true,
         })
     }
 }
@@ -452,6 +458,7 @@ mod tests {
                     },
                     "required": ["path"]
                 }),
+                overrides_built_in_tool: true,
             }]),
             available_tools: None,
         };
@@ -521,12 +528,25 @@ mod tests {
         assert_eq!(tool.name, "read_file");
         assert_eq!(tool.description, "Read file contents");
         assert_eq!(tool.parameters["type"], "object");
+        assert!(tool.overrides_built_in_tool);
     }
 
     #[test]
     fn copilot_tool_definition_from_api_tool_missing_field() {
         let bad = serde_json::json!({"name": "foo"});
         assert!(CopilotToolDefinition::from_api_tool(&bad).is_none());
+    }
+
+    #[test]
+    fn copilot_tool_definition_serializes_overrides_built_in_tool() {
+        let api_tool = serde_json::json!({
+            "name": "web_fetch",
+            "description": "Fetch a URL",
+            "input_schema": {"type": "object"}
+        });
+        let tool = CopilotToolDefinition::from_api_tool(&api_tool).unwrap();
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json["overridesBuiltInTool"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Copilot CLI 1.0.25+ が `web_fetch` / `web_search` を組み込みツールとして実装した結果、外部ツール登録時に名前衝突で reject され、Agent 実行の全タスクが FAILED になっていた問題を修正。

`CopilotToolDefinition` に `overrides_built_in_tool: bool` フィールドを追加し、`from_api_tool()` で常に `true` を送信する。これにより Copilot daemon が外部ツールに組み込みを上書きさせるようになる。

Issue #250 の対応案 **A**（最小差分・全ツール一律 `true`）を採用。`web_fetch` はリスク分類・ログ統合・結果フォーマットを既にカスタム実装しているため、Anthropic/Bedrock 直叩き時との挙動一貫性を保つ判断。

## Changes

- `infrastructure/src/copilot/protocol.rs`
  - `CopilotToolDefinition` に `overrides_built_in_tool: bool` を追加
  - `from_api_tool()` で `true` を設定
  - シリアライズ確認のテスト追加（`overridesBuiltInTool` キー）

## Test plan

- [x] `cargo test -p quorum-infrastructure copilot::protocol`
- [x] Copilot CLI 1.0.25+ 環境で `cargo run -p copilot-quorum -- --ensemble "任意のタスク"` を実行し、Agent タスクが FAILED にならず実行されることを確認
- [x] ログに `External tool "web_fetch" conflicts with a built-in tool` エラーが出ないことを確認

Closes #250