### PR TITLE
fix(copilot): Copilot CLI 1.0.65 対応 — permission ゲートによるカスタムツール全滅を修正

### DIFF
--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -1439,6 +1439,43 @@ impl MessageRouter {
         let session_id = result.session_id;
         debug!("Router: session created: {}", session_id);
 
+        // Copilot CLI 1.0.65+ starts sessions with permission request
+        // events disabled, so custom-tool calls are denied outright
+        // ("Permission denied and could not request permission from user")
+        // before `external_tool.requested` is ever emitted. Quorum runs its
+        // own risk-based review + HiL before any tool call reaches the CLI,
+        // so enable auto-approval — the same policy our
+        // `permission.requested` auto-responder applies on older CLIs.
+        // CLIs without this RPC return an error response, which we tolerate.
+        let approve_all = JsonRpcRequest::new(
+            "session.permissions.setApproveAll",
+            Some(serde_json::json!({
+                "sessionId": session_id,
+                "enabled": true,
+            })),
+        );
+        match tokio::time::timeout(SESSION_CREATE_TIMEOUT, self.request(&approve_all)).await {
+            Ok(Ok(resp)) => {
+                if let Some(err) = resp.error {
+                    debug!(
+                        "Router: permissions.setApproveAll unsupported ({}): {}",
+                        session_id, err.message
+                    );
+                } else {
+                    debug!("Router: permissions.setApproveAll enabled ({})", session_id);
+                }
+            }
+            Ok(Err(e)) => {
+                warn!("Router: permissions.setApproveAll failed ({}): {}", session_id, e);
+            }
+            Err(_) => {
+                warn!(
+                    "Router: permissions.setApproveAll timed out ({})",
+                    session_id
+                );
+            }
+        }
+
         // Route registration was already done by the reader loop when it
         // processed the response — we just construct the SessionChannel
         // that owns the receiver end of the channel we pre-registered.

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -1466,7 +1466,10 @@ impl MessageRouter {
                 }
             }
             Ok(Err(e)) => {
-                warn!("Router: permissions.setApproveAll failed ({}): {}", session_id, e);
+                warn!(
+                    "Router: permissions.setApproveAll failed ({}): {}",
+                    session_id, e
+                );
             }
             Err(_) => {
                 warn!(

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -169,9 +169,17 @@ impl InteractiveHumanIntervention {
         })?;
 
         let mut input = String::new();
-        io::stdin()
+        let bytes_read = io::stdin()
             .read_line(&mut input)
             .map_err(|e| HumanInterventionError::IoError(format!("Failed to read input: {}", e)))?;
+
+        // EOF (closed stdin, e.g. headless/piped runs): without this check
+        // the caller's retry loop re-prompts forever on an empty read.
+        if bytes_read == 0 {
+            return Err(HumanInterventionError::IoError(
+                "stdin closed (EOF) — cannot prompt for human intervention".to_string(),
+            ));
+        }
 
         Ok(input.trim().to_string())
     }

--- a/scripts/probe-copilot-server.py
+++ b/scripts/probe-copilot-server.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Protocol probe for `copilot --server` (JSON-RPC over TCP, LSP framing).
+
+Spawns the Copilot CLI in server mode, registers one custom tool, enables
+permission auto-approval (required on CLI 1.0.65+), sends a prompt that
+forces a tool call, and prints every protocol event — so upstream protocol
+changes can be diagnosed without going through the full Rust stack.
+
+Usage:
+    python3 scripts/probe-copilot-server.py [--model MODEL] [--raw]
+
+    --model MODEL   Model ID to use (default: gpt-5.3-codex)
+    --raw           Print full raw JSON for every message (very verbose)
+    --list-models   Just print the models the CLI offers and exit
+
+Exit codes: 0 = tool round-trip succeeded, 1 = failure (see output).
+
+History: this reproduces the debugging approach used for issue #245
+(CLI 1.0.25 protocol break) and the 1.0.65 permission-gating break.
+"""
+
+import argparse
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+
+TOOL = {
+    "name": "get_magic_number",
+    "description": (
+        "Returns the secret magic number. MUST be called to answer any "
+        "question about the magic number."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+    "overridesBuiltInTool": True,
+}
+
+PROMPT = "What is the magic number? You MUST call the get_magic_number tool."
+
+
+class Rpc:
+    def __init__(self):
+        self.proc = subprocess.Popen(
+            ["copilot", "--server"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        port = None
+        for _ in range(100):
+            line = self.proc.stdout.readline()
+            m = re.search(r"listening on port (\d+)", line)
+            if m:
+                port = int(m.group(1))
+                break
+        if not port:
+            raise RuntimeError("copilot --server did not report a port")
+        self.sock = socket.create_connection(("127.0.0.1", port), timeout=30)
+        self.buf = b""
+        self.next_id = 0
+
+    def send(self, obj):
+        body = json.dumps(obj).encode()
+        self.sock.sendall(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+
+    def recv(self, timeout=60):
+        self.sock.settimeout(timeout)
+        while True:
+            if b"\r\n\r\n" in self.buf:
+                head, rest = self.buf.split(b"\r\n\r\n", 1)
+                n = int(re.search(rb"Content-Length: (\d+)", head).group(1))
+                while len(rest) < n:
+                    rest += self.sock.recv(65536)
+                self.buf = rest[n:]
+                return json.loads(rest[:n])
+            try:
+                chunk = self.sock.recv(65536)
+            except socket.timeout:
+                return None
+            if not chunk:
+                return None
+            self.buf += chunk
+
+    def call(self, method, params, timeout=30):
+        """Send a request and wait for its response, printing events seen."""
+        self.next_id += 1
+        rid = self.next_id
+        self.send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            msg = self.recv(timeout)
+            if msg is None:
+                return None
+            if msg.get("id") == rid and "method" not in msg:
+                return msg
+        return None
+
+    def close(self):
+        self.proc.kill()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="gpt-5.3-codex")
+    ap.add_argument("--raw", action="store_true")
+    ap.add_argument("--list-models", action="store_true")
+    args = ap.parse_args()
+
+    rpc = Rpc()
+    try:
+        if args.list_models:
+            resp = rpc.call("models.list", {})
+            for m in resp["result"]["models"]:
+                sup = m.get("capabilities", {}).get("supports", {})
+                print(f"{m['id']}  tool_calls={sup.get('tool_calls')}")
+            return 0
+
+        resp = rpc.call("session.create", {"model": args.model, "tools": [TOOL]})
+        if not resp or "result" not in resp:
+            print("FAIL: session.create ->", json.dumps(resp))
+            return 1
+        sid = resp["result"]["sessionId"]
+        print("session:", sid)
+
+        # CLI 1.0.65+: permission request events default to OFF and custom
+        # tools are denied outright without this.
+        resp = rpc.call(
+            "session.permissions.setApproveAll", {"sessionId": sid, "enabled": True}
+        )
+        print("setApproveAll ->", json.dumps(resp and resp.get("result")))
+
+        rpc.next_id += 1
+        rpc.send(
+            {
+                "jsonrpc": "2.0",
+                "id": rpc.next_id,
+                "method": "session.send",
+                "params": {"sessionId": sid, "prompt": PROMPT},
+            }
+        )
+
+        tool_ok = False
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            msg = rpc.recv()
+            if msg is None:
+                print("FAIL: timed out waiting for events")
+                return 1
+            if args.raw:
+                print("RAW:", json.dumps(msg)[:2000])
+            if msg.get("method") != "session.event":
+                continue
+            ev = msg["params"]["event"]
+            etype = ev["type"]
+            data = ev.get("data", {})
+            if etype == "external_tool.requested":
+                print("external_tool.requested:", data.get("toolName"))
+                rpc.next_id += 1
+                rpc.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": rpc.next_id,
+                        "method": "session.tools.handlePendingToolCall",
+                        "params": {
+                            "sessionId": sid,
+                            "requestId": data["requestId"],
+                            "result": "42",
+                        },
+                    }
+                )
+            elif etype == "permission.requested":
+                print("permission.requested:", json.dumps(data)[:300])
+            elif etype == "tool.execution_complete":
+                ok = data.get("success")
+                print("tool.execution_complete: success =", ok, data.get("error") or "")
+                tool_ok = tool_ok or bool(ok)
+            elif etype == "assistant.message":
+                content = data.get("content", "")
+                if content:
+                    print("assistant:", content[:200])
+            elif etype == "session.idle":
+                break
+
+        if tool_ok:
+            print("OK: custom tool round-trip succeeded")
+            return 0
+        print("FAIL: custom tool never executed successfully")
+        return 1
+    finally:
+        rpc.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Headless E2E smoke test for copilot-quorum against the real Copilot CLI.
+#
+# Runs the one-shot agent mode with a read-only task and asserts, from the
+# JSONL conversation transcript, that (1) the run completed successfully and
+# (2) the custom-tool path (external_tool.requested → LocalToolExecutor)
+# actually executed — catching "the model answered from context without
+# calling tools" regressions that look like success on stdout.
+#
+# Usage:
+#   scripts/smoke-test.sh [MODEL]        # default: gpt-5.3-codex
+#
+# Output lands in a temp dir (printed at the end). Exit 0 = pass.
+# Designed to be runnable by coding agents: no TTY, no interaction.
+set -uo pipefail
+
+MODEL="${1:-gpt-5.3-codex}"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/quorum-smoke.XXXXXX")"
+PROMPT="Use the read_file tool to read README.md and tell me the project name in one short sentence. Do not modify anything."
+
+echo "== copilot-quorum smoke test (model: $MODEL) =="
+echo "   logs: $OUT"
+
+# Isolated config: auto-approve HiL gates so the run never blocks on stdin.
+mkdir -p "$OUT/config/copilot-quorum"
+cat >"$OUT/config/copilot-quorum/init.lua" <<'LUA'
+quorum.config.set("agent.hil_mode", "auto_approve")
+LUA
+
+timeout 300 env XDG_CONFIG_HOME="$OUT/config" cargo run -q -p copilot-quorum -- \
+    --no-quorum -q -vv -m "$MODEL" --log-dir "$OUT" \
+    "$PROMPT" >"$OUT/stdout.log" 2>"$OUT/stderr.log" </dev/null
+EXIT=$?
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- stderr tail ---"
+    tail -20 "$OUT/stderr.log"
+    exit 1
+}
+
+[ "$EXIT" -eq 0 ] || fail "process exited with $EXIT"
+
+JSONL=$(ls "$OUT"/session-*.conversation.jsonl 2>/dev/null | head -1)
+[ -n "$JSONL" ] || fail "no conversation JSONL produced"
+
+# 1. Run must have completed successfully.
+grep -q '"type":"agent_complete"' "$JSONL" ||
+    grep -q '"agent_complete"' "$JSONL" || fail "no agent_complete event in JSONL"
+
+python3 - "$JSONL" <<'EOF' || exit 1
+import json, sys
+events = [json.loads(l) for l in open(sys.argv[1])]
+complete = [e for e in events if e.get("type") == "agent_complete"]
+if not complete or not complete[-1].get("success"):
+    print("FAIL: agent_complete missing or success=false"); sys.exit(1)
+
+# 2. The external-tool path must have fired: plan must contain real tasks
+#    (create_plan delivered its arguments to us, not just to the CLI).
+if complete[-1].get("total_tasks", 0) < 1:
+    print("FAIL: total_tasks == 0 — custom tool path (external_tool.requested) "
+          "likely broken; run scripts/probe-copilot-server.py to diagnose")
+    sys.exit(1)
+print(f"OK: agent completed, {complete[-1]['total_tasks']} task(s) executed")
+EOF
+
+# 3. The external tool request must appear in the debug log.
+if ! grep -q "External tool call received" "$OUT/stderr.log"; then
+    fail "no 'External tool call received' in debug log — external_tool.requested never arrived"
+fi
+
+echo "PASS ($OUT)"


### PR DESCRIPTION
## 問題

Copilot CLI **1.0.65** でカスタムツール実行が全モデル・全モードで機能しなくなっていた(#245 の 1.0.25 破壊と同系統の上流プロトコル変更)。

表面上は正常に見える(exit 0、テキスト応答あり)が、実際にはモデルが「プランツールが使えない」「ファイルアクセスができない」と述べてコンテキストから推測で回答するだけになる。JSONL では `total_tasks: 0`、`external_tool.requested` は 0 件。

## 根本原因

`copilot --server` への直接 probe と CLI 本体 (`app.js`) の解析で特定:

- 1.0.65 では session の `permissionRequestEventsEnabled` がデフォルト **false**
- この状態でカスタムツールが呼ばれると、CLI は `permission.requested` イベントを発行せずに **即 deny** する
  (`"Permission denied and could not request permission from user"` / kind: `denied-no-approval-rule-and-could-not-request-from-user`)
- `external_tool.requested` に到達する前に落ちるため、#247 の auto-reply では防げない
- 有効化する唯一の口はクライアントからの RPC: `session.permissions.setRequired` または `setApproveAll`
  (`--allow-all-tools` フラグはビルトインツールのみ対象で効果なし)

## 対応

1. **`session.create` 成功直後に `session.permissions.setApproveAll {enabled: true}` を送信** (`router.rs`)
   - Quorum は自前のリスクベース審査 + HiL を通してからツールを CLI に渡すため、CLI 側ゲートの自動承認は #247 と同一ポリシー
   - この RPC を持たない旧 CLI はエラー応答を返すだけ → 警告ログで許容(後方互換)
2. **HiL プロンプトの EOF 無限ループ修正** (`human_intervention.rs`)
   - stdin 非 TTY(ヘッドレス実行)で `read_line` が `Ok(0)` を返し続け、`agent-hil>` を無限に再表示(454MB のログを確認)。EOF でエラー終了するよう修正
3. **デバッグツールの常設化** (`scripts/`)
   - `smoke-test.sh [MODEL]`: ヘッドレス E2E。`XDG_CONFIG_HOME` 隔離 + `hil_mode=auto_approve` 注入。JSONL から agent_complete 成功 / `total_tasks >= 1` / `external_tool.requested` 発火を検証し、「テキストだけで答えて成功に見える」偽陽性を検出
   - `probe-copilot-server.py`: `copilot --server` への直接 JSON-RPC probe(#245 の手法の常設化)。`--list-models` / `--raw` 対応

## 検証

| モデル | 結果 |
|--------|------|
| gpt-5.3-codex | ✅ PASS (3 tasks executed) |
| claude-sonnet-4.6 | ✅ PASS (1 task executed) |

- `cargo test --workspace` 946 件全パス、clippy クリーン
- **claude-sonnet-4.6 がカスタムツールを正常に呼べている** → #107 の実態はこの permission ゲートだった可能性が高い(要追検証だがワークアラウンド「実行系は GPT 限定」は不要になる見込み)

## 関連 Issue

- #245 / #247 / #248: CLI 1.0.25 プロトコル変更対応(今回はその 1.0.65 版)
- #107: Claude モデルがカスタムツールを呼ばない → 本修正で解消の可能性大
- #130: CLI クラッシュ時のリトライ(依存リスクの派生として関連)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WUNQC7hni1ntkXcyBm6vU