### PR TITLE
feat(tui): Remote Control API — --listen で外部プロセスから TUI を操作可能に

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -496,6 +496,9 @@ async fn main() -> Result<()> {
         if let Some(resolver) = reference_resolver {
             tui_app = tui_app.with_reference_resolver(Arc::new(resolver));
         }
+        if let Some(listen_path) = &cli.listen {
+            tui_app = tui_app.with_listen(listen_path.clone());
+        }
         tui_app.run().await?;
         return Ok(());
     }

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -336,6 +336,52 @@ TUI は以下のウィジェットで構成されます:
 
 ---
 
+## Remote Control API / リモート操作 API
+
+`--listen <PATH>` で起動すると、Unix ドメインソケット上に JSON-RPC サーバーが公開され、
+外部プロセス（コーディングエージェント等）がキーボードと対等に TUI を操作できます。
+Neovim の `nvim --listen` に相当する機能です。
+
+```bash
+# TUI をソケット付きで起動
+copilot-quorum --listen /tmp/quorum.sock
+
+# 別プロセスから操作（scripts/tui-rpc.py はリファレンスクライアント）
+scripts/tui-rpc.py /tmp/quorum.sock state.get
+scripts/tui-rpc.py /tmp/quorum.sock input.send '{"text": "Fix the bug in login.rs"}'
+scripts/tui-rpc.py /tmp/quorum.sock pane.read '{"last": 5}'
+scripts/tui-rpc.py /tmp/quorum.sock hil.respond '{"decision": "approve"}'
+```
+
+### Methods
+
+| Method | Params | 説明 |
+|--------|--------|------|
+| `state.get` | — | モード、モデル、タブ数、保留中 HiL(プラン内容含む) |
+| `panes.list` | — | 全タブ/ペインのメタデータ(form, title, message_count, streaming) |
+| `pane.read` | `{tab?, last?}` | 会話メッセージを構造化 JSON で取得(画面スクレイピング不要) |
+| `input.send` | `{text}` | アクティブペインへプロンプト送信(`SubmitInput` と同一経路) |
+| `command.exec` | `{command}` | `:` コマンド実行(`solo`, `tabnew ask`, `q` 等) |
+| `interaction.spawn` | `{form, query}` | Agent/Ask/Discuss タブを生成 |
+| `interaction.activate` | `{interaction_id}` | 指定インタラクションのタブへフォーカス |
+| `hil.respond` | `{decision}` | 保留中の HiL モーダルに approve/reject を返す |
+
+### Design / 設計
+
+- **ワイヤ形式**: LSP スタイルの `Content-Length` フレーミング + JSON-RPC 2.0
+  （`copilot --server` と同一形式）
+- **実行モデル**: 各リクエストは `remote_rx` チャネル経由でメインの `select!`
+  ループ内で処理される。`&mut TuiState` へのアクセスはキーボード入力と完全に
+  同一のコードパス（`input.send` = `KeyAction::SubmitInput` 相当）
+- **セキュリティ**: ソケットは `0600` パーミッション、TCP リスナーなし
+- **HiL 連携**: `state.get` で保留中プランを確認 → `hil.respond` で承認/却下。
+  エージェントが TUI を運転しつつ承認だけ人間（または別エージェント）が返す
+  非同期 HiL（Discussion #42 の方向性）の土台
+
+実装: `presentation/src/tui/remote.rs`
+
+---
+
 ## Related / 関連
 
 - [architecture.md - TUI Design Philosophy](../reference/architecture.md#tui-design-philosophy--tui-設計思想) — 設計思想の詳細

--- a/presentation/Cargo.toml
+++ b/presentation/Cargo.toml
@@ -15,6 +15,7 @@ quorum-application = { workspace = true }
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 # Terminal UI
 indicatif = { workspace = true }

--- a/presentation/src/cli/commands.rs
+++ b/presentation/src/cli/commands.rs
@@ -127,4 +127,11 @@ pub struct Cli {
     /// Show init.lua and plugin paths and exit
     #[arg(long)]
     pub show_config: bool,
+
+    /// Expose a JSON-RPC remote control socket at PATH (TUI mode only)
+    ///
+    /// External processes (e.g. coding agents) can inspect panes and
+    /// inject input over this Unix socket. See docs/guides/tui.md.
+    #[arg(long, value_name = "PATH")]
+    pub listen: Option<PathBuf>,
 }

--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -317,8 +317,7 @@ impl TuiApp {
         // Remote control socket (--listen). The receiver participates in the
         // select! loop below; without a listener the channel simply never
         // yields (all senders dropped → branch disabled).
-        let (remote_tx, mut remote_rx) =
-            mpsc::unbounded_channel::<super::remote::RemoteRequest>();
+        let (remote_tx, mut remote_rx) = mpsc::unbounded_channel::<super::remote::RemoteRequest>();
         if let Some(path) = &self.listen_path {
             super::remote::spawn_listener(path.clone(), remote_tx)?;
         } else {

--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -86,6 +86,9 @@ pub struct TuiApp {
 
     // -- Clipboard (for yank/copy operations) --
     clipboard: Arc<dyn ClipboardPort>,
+
+    // -- Remote control socket path (--listen) --
+    listen_path: Option<std::path::PathBuf>,
 }
 
 impl TuiApp {
@@ -164,6 +167,7 @@ impl TuiApp {
             custom_keymap: mode::CustomKeymap::new(),
             tui_accessor: None,
             clipboard: Arc::new(NoClipboard),
+            listen_path: None,
         }
     }
 
@@ -173,6 +177,12 @@ impl TuiApp {
     /// Pass an `ArboardClipboard` (or similar) to enable actual copying.
     pub fn with_clipboard(mut self, clipboard: Arc<dyn ClipboardPort>) -> Self {
         self.clipboard = clipboard;
+        self
+    }
+
+    /// Expose a JSON-RPC remote control socket at `path` (see `tui::remote`).
+    pub fn with_listen(mut self, path: std::path::PathBuf) -> Self {
+        self.listen_path = Some(path);
         self
     }
 
@@ -304,6 +314,17 @@ impl TuiApp {
         let mut event_stream = EventStream::new();
         let mut tick = tokio::time::interval(Duration::from_millis(250));
 
+        // Remote control socket (--listen). The receiver participates in the
+        // select! loop below; without a listener the channel simply never
+        // yields (all senders dropped → branch disabled).
+        let (remote_tx, mut remote_rx) =
+            mpsc::unbounded_channel::<super::remote::RemoteRequest>();
+        if let Some(path) = &self.listen_path {
+            super::remote::spawn_listener(path.clone(), remote_tx)?;
+        } else {
+            drop(remote_tx);
+        }
+
         // Send welcome
         let _ = self.cmd_tx.send(TuiCommand::HandleCommand {
             interaction_id: None,
@@ -360,6 +381,16 @@ impl TuiApp {
                         &mut state,
                         &self.pending_hil_tx,
                         hil_request,
+                    );
+                }
+
+                // Remote control requests (--listen socket)
+                Some(remote_request) = remote_rx.recv() => {
+                    super::remote::handle_request(
+                        &mut state,
+                        &self.cmd_tx,
+                        &self.pending_hil_tx,
+                        remote_request,
                     );
                 }
 

--- a/presentation/src/tui/mod.rs
+++ b/presentation/src/tui/mod.rs
@@ -20,6 +20,7 @@ pub mod layout;
 mod mode;
 mod presenter;
 mod progress;
+mod remote;
 mod route;
 mod state;
 mod surface;

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -1,0 +1,545 @@
+//! Remote Control API — drive the TUI from an external process.
+//!
+//! When the TUI is started with `--listen <PATH>`, a JSON-RPC server is
+//! exposed on a Unix domain socket (LSP-style `Content-Length` framing,
+//! the same wire format as `copilot --server`). External agents can
+//! inspect state and inject input as a peer of the keyboard:
+//!
+//! ```text
+//! agent ──JSON-RPC──> UnixListener task ──remote_tx──> TuiApp select! loop
+//!                                                        │  (&mut TuiState)
+//! agent <──response── oneshot reply <─────────────────────┘
+//! ```
+//!
+//! Every request is handled *inside* the main event loop with full access
+//! to `TuiState` and the controller `cmd_tx`, so remote operations follow
+//! exactly the same code paths as keyboard input (`KeyAction::SubmitInput`
+//! → `TuiCommand::ProcessRequest`, etc.).
+//!
+//! # Methods (Phase 1)
+//!
+//! | method                 | params                                | effect |
+//! |------------------------|---------------------------------------|--------|
+//! | `state.get`            | —                                     | mode, models, tabs, pending HiL |
+//! | `panes.list`           | —                                     | all tabs/panes with metadata |
+//! | `pane.read`            | `{tab?: usize, last?: usize}`         | conversation messages (structured) |
+//! | `input.send`           | `{text: string}`                      | submit prompt to active pane |
+//! | `command.exec`         | `{command: string}`                   | run `:command` (e.g. "solo", "tabnew ask") |
+//! | `interaction.spawn`    | `{form: "agent"\|"ask"\|"discuss", query: string}` | spawn interaction (new tab) |
+//! | `interaction.activate` | `{interaction_id: usize}`             | focus an interaction's tab |
+//! | `hil.respond`          | `{decision: "approve"\|"reject"}`     | answer a pending HiL modal |
+//!
+//! Security: the socket is created with `0600` permissions and no TCP
+//! listener is offered — same trust model as `nvim --listen`.
+
+use super::event::TuiCommand;
+use super::state::{DisplayMessage, MessageRole, TuiState};
+use super::tab::PaneKind;
+use quorum_domain::interaction::InteractionForm;
+use quorum_domain::HumanDecision;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, warn};
+
+/// A remote JSON-RPC request forwarded into the TUI main loop.
+///
+/// `reply` is `None` for JSON-RPC notifications (requests without `id`).
+pub struct RemoteRequest {
+    pub method: String,
+    pub params: Value,
+    pub reply: Option<oneshot::Sender<Result<Value, RemoteError>>>,
+}
+
+/// JSON-RPC error (code + message) returned to the remote client.
+pub struct RemoteError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl RemoteError {
+    fn method_not_found(method: &str) -> Self {
+        Self {
+            code: -32601,
+            message: format!("Method not found: {method}"),
+        }
+    }
+
+    fn invalid_params(msg: impl Into<String>) -> Self {
+        Self {
+            code: -32602,
+            message: msg.into(),
+        }
+    }
+
+    fn failed(msg: impl Into<String>) -> Self {
+        Self {
+            code: -32000,
+            message: msg.into(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Socket listener
+// ---------------------------------------------------------------------------
+
+/// Bind the Unix socket and spawn the accept loop.
+///
+/// A stale socket file from a previous run is removed before binding.
+/// The socket is chmod'ed to `0600` so only the owning user can connect.
+pub fn spawn_listener(
+    path: PathBuf,
+    tx: mpsc::UnboundedSender<RemoteRequest>,
+) -> std::io::Result<()> {
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    let listener = UnixListener::bind(&path)?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    debug!("Remote control listening on {}", path.display());
+
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _addr)) => {
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = handle_connection(stream, tx).await {
+                            debug!("Remote connection closed: {}", e);
+                        }
+                    });
+                }
+                Err(e) => {
+                    warn!("Remote accept failed: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+/// Serve one client connection: read framed requests, forward each into
+/// the main loop, and write the framed response back. Requests on a single
+/// connection are processed sequentially.
+async fn handle_connection(
+    stream: UnixStream,
+    tx: mpsc::UnboundedSender<RemoteRequest>,
+) -> std::io::Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    loop {
+        let body = match read_frame(&mut reader).await? {
+            Some(b) => b,
+            None => return Ok(()), // clean EOF
+        };
+
+        let msg: Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                write_frame(
+                    &mut write_half,
+                    &json!({
+                        "jsonrpc": "2.0",
+                        "id": null,
+                        "error": {"code": -32700, "message": format!("Parse error: {e}")},
+                    }),
+                )
+                .await?;
+                continue;
+            }
+        };
+
+        let id = msg.get("id").cloned();
+        let method = msg
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let is_notification = id.is_none();
+        let request = RemoteRequest {
+            method,
+            params,
+            reply: if is_notification {
+                None
+            } else {
+                Some(reply_tx)
+            },
+        };
+
+        if tx.send(request).is_err() {
+            // Main loop is gone — shut the connection down.
+            return Ok(());
+        }
+        if is_notification {
+            continue;
+        }
+
+        let response = match reply_rx.await {
+            Ok(Ok(result)) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+            Ok(Err(e)) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": e.code, "message": e.message},
+            }),
+            Err(_) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {"code": -32000, "message": "TUI dropped the request"},
+            }),
+        };
+        write_frame(&mut write_half, &response).await?;
+    }
+}
+
+/// Read one `Content-Length`-framed JSON body. Returns `None` on clean EOF.
+async fn read_frame<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if content_length.is_some() {
+                break;
+            }
+            continue; // stray blank line before headers
+        }
+        if let Some(rest) = trimmed
+            .strip_prefix("Content-Length:")
+            .or_else(|| trimmed.strip_prefix("content-length:"))
+        {
+            content_length = rest.trim().parse::<usize>().ok();
+        }
+        // other headers (Content-Type etc.) are ignored
+    }
+    let len = content_length.ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "missing Content-Length")
+    })?;
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).await?;
+    Ok(Some(body))
+}
+
+/// Write one `Content-Length`-framed JSON message.
+async fn write_frame<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    msg: &Value,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(msg)?;
+    writer
+        .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+        .await?;
+    writer.write_all(&body).await?;
+    writer.flush().await
+}
+
+// ---------------------------------------------------------------------------
+// Request handling (runs inside the TuiApp select! loop)
+// ---------------------------------------------------------------------------
+
+/// Dispatch a remote request with full access to the TUI state.
+///
+/// Called from the main event loop, so mutations here are exactly as safe
+/// (and as visible) as those triggered by keyboard input.
+pub(super) fn handle_request(
+    state: &mut TuiState,
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    request: RemoteRequest,
+) {
+    let result = dispatch(state, cmd_tx, pending_hil_tx, &request.method, &request.params);
+    if let Some(reply) = request.reply {
+        let _ = reply.send(result);
+    }
+}
+
+fn dispatch(
+    state: &mut TuiState,
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    method: &str,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    match method {
+        "state.get" => Ok(state_snapshot(state)),
+        "panes.list" => Ok(panes_list(state)),
+        "pane.read" => pane_read(state, params),
+        "input.send" => input_send(state, cmd_tx, params),
+        "command.exec" => command_exec(state, cmd_tx, params),
+        "interaction.spawn" => interaction_spawn(cmd_tx, params),
+        "interaction.activate" => interaction_activate(cmd_tx, params),
+        "hil.respond" => hil_respond(state, pending_hil_tx, params),
+        other => Err(RemoteError::method_not_found(other)),
+    }
+}
+
+fn role_label(role: MessageRole) -> &'static str {
+    match role {
+        MessageRole::User => "user",
+        MessageRole::Assistant => "assistant",
+        MessageRole::System => "system",
+    }
+}
+
+fn pane_kind_json(kind: &PaneKind) -> Value {
+    match kind {
+        PaneKind::Interaction(form, id) => json!({
+            "form": format!("{form:?}").to_lowercase(),
+            "interaction_id": id.map(|i| i.0),
+        }),
+    }
+}
+
+fn state_snapshot(state: &TuiState) -> Value {
+    json!({
+        "mode": format!("{:?}", state.mode).to_lowercase(),
+        "consensus_level": state.consensus_level.to_string(),
+        "phase_scope": state.phase_scope.to_string(),
+        "model": state.model_name,
+        "tab_count": state.tabs.len(),
+        "active_tab": state.tabs.active_index(),
+        "hil_pending": state.hil_prompt.is_some(),
+        "hil": state.hil_prompt.as_ref().map(|h| json!({
+            "title": h.title,
+            "objective": h.objective,
+            "tasks": h.tasks,
+            "message": h.message,
+        })),
+    })
+}
+
+fn panes_list(state: &TuiState) -> Value {
+    let tabs: Vec<Value> = state
+        .tabs
+        .tabs()
+        .iter()
+        .enumerate()
+        .map(|(idx, tab)| {
+            let pane = &tab.pane;
+            let mut entry = json!({
+                "tab": idx,
+                "tab_id": tab.id.0,
+                "pane_id": pane.id.0,
+                "title": pane.display_title(),
+                "active": idx == state.tabs.active_index(),
+                "message_count": pane.conversation.messages.len(),
+                "is_streaming": !pane.conversation.streaming_text.is_empty(),
+                "input_draft_len": pane.input.len(),
+            });
+            if let (Value::Object(map), Value::Object(kind)) =
+                (&mut entry, pane_kind_json(&pane.kind))
+            {
+                map.extend(kind);
+            }
+            entry
+        })
+        .collect();
+    json!({ "tabs": tabs })
+}
+
+fn pane_read(state: &TuiState, params: &Value) -> Result<Value, RemoteError> {
+    let tabs = state.tabs.tabs();
+    let index = params
+        .get("tab")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize)
+        .unwrap_or_else(|| state.tabs.active_index());
+    let tab = tabs
+        .get(index)
+        .ok_or_else(|| RemoteError::invalid_params(format!("no such tab: {index}")))?;
+    let pane = &tab.pane;
+
+    let messages = &pane.conversation.messages;
+    let skip = params
+        .get("last")
+        .and_then(|v| v.as_u64())
+        .map(|last| messages.len().saturating_sub(last as usize))
+        .unwrap_or(0);
+
+    let rendered: Vec<Value> = messages[skip..]
+        .iter()
+        .map(|m| json!({"role": role_label(m.role), "content": m.content}))
+        .collect();
+
+    Ok(json!({
+        "tab": index,
+        "title": pane.display_title(),
+        "kind": pane_kind_json(&pane.kind),
+        "total_messages": messages.len(),
+        "messages": rendered,
+        "streaming_text": pane.conversation.streaming_text,
+    }))
+}
+
+/// Submit text to the active pane — mirrors `KeyAction::SubmitInput`.
+fn input_send(
+    state: &mut TuiState,
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let text = params
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'text' (string)"))?
+        .trim()
+        .to_string();
+    if text.is_empty() {
+        return Err(RemoteError::invalid_params("'text' must not be empty"));
+    }
+
+    state.tabs.active_pane_mut().set_title_if_empty(&text);
+    state.push_message(DisplayMessage::user(&text));
+    let interaction_id = state.active_interaction_id();
+    cmd_tx
+        .send(TuiCommand::ProcessRequest {
+            interaction_id,
+            request: text,
+        })
+        .map_err(|_| RemoteError::failed("controller unavailable"))?;
+
+    Ok(json!({
+        "ok": true,
+        "interaction_id": interaction_id.map(|i| i.0),
+    }))
+}
+
+/// Execute a `:command` — mirrors `KeyAction::SubmitCommand`.
+fn command_exec(
+    state: &mut TuiState,
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let cmd = params
+        .get("command")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'command' (string)"))?
+        .trim()
+        .to_string();
+    if cmd.is_empty() {
+        return Err(RemoteError::invalid_params("'command' must not be empty"));
+    }
+
+    if cmd == "q" || cmd == "quit" || cmd == "exit" {
+        state.should_quit = true;
+        return Ok(json!({"ok": true, "quit": true}));
+    }
+    if let Some(flash) = super::app_tab_command::handle_tab_command(state, &cmd, cmd_tx) {
+        state.set_flash(flash.clone());
+        return Ok(json!({"ok": true, "flash": flash}));
+    }
+    let interaction_id = state.active_interaction_id();
+    cmd_tx
+        .send(TuiCommand::HandleCommand {
+            interaction_id,
+            command: cmd,
+        })
+        .map_err(|_| RemoteError::failed("controller unavailable"))?;
+    Ok(json!({"ok": true}))
+}
+
+fn parse_form(s: &str) -> Result<InteractionForm, RemoteError> {
+    match s.to_ascii_lowercase().as_str() {
+        "agent" => Ok(InteractionForm::Agent),
+        "ask" => Ok(InteractionForm::Ask),
+        "discuss" => Ok(InteractionForm::Discuss),
+        other => Err(RemoteError::invalid_params(format!(
+            "unknown form '{other}' (expected agent|ask|discuss)"
+        ))),
+    }
+}
+
+fn interaction_spawn(
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let form = parse_form(
+        params
+            .get("form")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RemoteError::invalid_params("missing 'form' (string)"))?,
+    )?;
+    let query = params
+        .get("query")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'query' (string)"))?
+        .to_string();
+
+    cmd_tx
+        .send(TuiCommand::SpawnInteraction {
+            form,
+            query,
+            context_mode_override: None,
+        })
+        .map_err(|_| RemoteError::failed("controller unavailable"))?;
+    Ok(json!({"ok": true}))
+}
+
+fn interaction_activate(
+    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let id = params
+        .get("interaction_id")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'interaction_id' (number)"))?;
+    cmd_tx
+        .send(TuiCommand::ActivateInteraction(
+            quorum_domain::interaction::InteractionId(id as usize),
+        ))
+        .map_err(|_| RemoteError::failed("controller unavailable"))?;
+    Ok(json!({"ok": true}))
+}
+
+/// Answer a pending HiL modal — mirrors the `y`/`n` keys in `app_hil`.
+fn hil_respond(
+    state: &mut TuiState,
+    pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let decision = match params.get("decision").and_then(|v| v.as_str()) {
+        Some("approve") => HumanDecision::Approve,
+        Some("reject") => HumanDecision::Reject,
+        _ => {
+            return Err(RemoteError::invalid_params(
+                "missing 'decision' (approve|reject)",
+            ))
+        }
+    };
+
+    if state.hil_prompt.is_none() {
+        return Err(RemoteError::failed("no pending HiL prompt"));
+    }
+    let tx = pending_hil_tx
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or_else(|| RemoteError::failed("no pending HiL response channel"))?;
+
+    state.hil_prompt = None;
+    let approved = matches!(decision, HumanDecision::Approve);
+    state.set_flash(if approved {
+        "Plan approved (remote)"
+    } else {
+        "Plan rejected (remote)"
+    });
+    tx.send(decision)
+        .map_err(|_| RemoteError::failed("HiL requester is gone"))?;
+    Ok(json!({"ok": true, "approved": approved}))
+}

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -35,9 +35,9 @@
 use super::event::TuiCommand;
 use super::state::{DisplayMessage, MessageRole, TuiState};
 use super::tab::PaneKind;
-use quorum_domain::interaction::InteractionForm;
 use quorum_domain::HumanDecision;
-use serde_json::{json, Value};
+use quorum_domain::interaction::InteractionForm;
+use serde_json::{Value, json};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -264,7 +264,13 @@ pub(super) fn handle_request(
     pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
     request: RemoteRequest,
 ) {
-    let result = dispatch(state, cmd_tx, pending_hil_tx, &request.method, &request.params);
+    let result = dispatch(
+        state,
+        cmd_tx,
+        pending_hil_tx,
+        &request.method,
+        &request.params,
+    );
     if let Some(reply) = request.reply {
         let _ = reply.send(result);
     }
@@ -519,7 +525,7 @@ fn hil_respond(
         _ => {
             return Err(RemoteError::invalid_params(
                 "missing 'decision' (approve|reject)",
-            ))
+            ));
         }
     };
 

--- a/scripts/tui-rpc.py
+++ b/scripts/tui-rpc.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Minimal JSON-RPC client for the copilot-quorum TUI remote control socket.
+
+Start the TUI with a socket:
+    copilot-quorum --listen /tmp/quorum.sock
+
+Then drive it from another terminal (or from a coding agent):
+    scripts/tui-rpc.py /tmp/quorum.sock state.get
+    scripts/tui-rpc.py /tmp/quorum.sock panes.list
+    scripts/tui-rpc.py /tmp/quorum.sock pane.read '{"last": 5}'
+    scripts/tui-rpc.py /tmp/quorum.sock input.send '{"text": "Fix the bug in login.rs"}'
+    scripts/tui-rpc.py /tmp/quorum.sock command.exec '{"command": "solo"}'
+    scripts/tui-rpc.py /tmp/quorum.sock interaction.spawn '{"form": "ask", "query": "What is DDD?"}'
+    scripts/tui-rpc.py /tmp/quorum.sock hil.respond '{"decision": "approve"}'
+
+Prints the JSON-RPC result (or error) to stdout. Exit 0 on result, 1 on error.
+"""
+
+import json
+import re
+import socket
+import sys
+
+
+def request(sock_path: str, method: str, params):
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.settimeout(30)
+    conn.connect(sock_path)
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+    ).encode()
+    conn.sendall(b"Content-Length: %d\r\n\r\n" % len(body) + body)
+
+    buf = b""
+    while True:
+        if b"\r\n\r\n" in buf:
+            head, rest = buf.split(b"\r\n\r\n", 1)
+            m = re.search(rb"Content-Length: (\d+)", head)
+            n = int(m.group(1))
+            while len(rest) < n:
+                rest += conn.recv(65536)
+            conn.close()
+            return json.loads(rest[:n])
+        chunk = conn.recv(65536)
+        if not chunk:
+            raise ConnectionError("socket closed before response")
+        buf += chunk
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 2
+    sock_path, method = sys.argv[1], sys.argv[2]
+    params = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+    resp = request(sock_path, method, params)
+    if "result" in resp:
+        print(json.dumps(resp["result"], ensure_ascii=False, indent=2))
+        return 0
+    print(json.dumps(resp.get("error", resp), ensure_ascii=False, indent=2))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要

`--listen <PATH>` で TUI 起動時に Unix ドメインソケット上へ JSON-RPC サーバーを公開し、外部プロセス(コーディングエージェント等)がキーボードと対等に TUI を操作できるようにする。**Neovim の `nvim --listen` 相当**。

```bash
copilot-quorum --listen /tmp/quorum.sock

# 別プロセスから
scripts/tui-rpc.py /tmp/quorum.sock input.send '{"text": "Fix the bug in login.rs"}'
scripts/tui-rpc.py /tmp/quorum.sock state.get          # 保留中 HiL がプラン内容ごと見える
scripts/tui-rpc.py /tmp/quorum.sock hil.respond '{"decision": "approve"}'
scripts/tui-rpc.py /tmp/quorum.sock pane.read '{"last": 5}'   # 会話を構造化 JSON で取得
```

## 設計

```
agent ──JSON-RPC──> UnixListener task ──remote_tx──> TuiApp select! loop
                                                       │  (&mut TuiState)
agent <──response── oneshot reply <────────────────────┘
```

- **ワイヤ形式**: LSP スタイル `Content-Length` フレーミング + JSON-RPC 2.0(`copilot --server` と同一形式 — probe 知見・パーサー実装を再利用できる)
- **実行モデル**: 各リクエストは `remote_rx` チャネル経由で**メイン `select!` ループ内**で処理。`&mut TuiState` への変更はキー入力と完全に同一のコードパス(`input.send` = `KeyAction::SubmitInput` 相当、`hil.respond` = HiL モーダルの `y`/`n` 相当)を通るため、レースなし・挙動乖離なし
- **無効時のコスト**: `--listen` 未指定なら全 sender がドロップされ select! ブランチが恒久無効化されるだけ。既存動作への影響ゼロ
- **セキュリティ**: ソケット `0600` パーミッション、TCP リスナーなし(`nvim --listen` と同じ信頼モデル)

## メソッド (Phase 1)

| Method | Params | 説明 |
|--------|--------|------|
| `state.get` | — | モード、モデル、タブ数、**保留中 HiL(プラン内容含む)** |
| `panes.list` | — | 全タブ/ペインのメタデータ |
| `pane.read` | `{tab?, last?}` | 会話を構造化 JSON で取得(画面スクレイピング不要) |
| `input.send` | `{text}` | アクティブペインへプロンプト送信 |
| `command.exec` | `{command}` | `:` コマンド実行(`solo`, `tabnew ask`, `q` 等) |
| `interaction.spawn` | `{form, query}` | Agent/Ask/Discuss タブ生成 |
| `interaction.activate` | `{interaction_id}` | タブフォーカス |
| `hil.respond` | `{decision}` | HiL モーダルへ approve/reject |

## 検証

tmux 内の実 TUI に対する E2E で全メソッド確認済み:

1. `input.send` でエージェント起動 → 2. `state.get` で HiL 待ちとプラン内容を確認 → 3. `hil.respond` でリモート承認 → 4. `pane.read` で完了結果取得 → 5. `interaction.spawn` で Ask タブ生成 → 6. `command.exec {"command": "q"}` でクリーン終了

`cargo test --workspace` 全パス、clippy クリーン。

## 位置づけ・今後

- **Discussion #58**(Neovim-Style Extensible TUI)の延長 — `nvim --listen` 相当のリモート操作層
- **Discussion #98**(Protocol-Based Extension)の Phase 0 — JSON-RPC 基盤の実績づくり
- **Discussion #42**(非同期 HiL)の土台 — `hil.respond` により「エージェントが運転し、承認だけ人間が別チャネルから返す」が可能に
- TUI の E2E テスト自動化にも使える(#212 のような並行性バグの再現テスト)
- Phase 2 候補: `events.subscribe`(進捗ストリーミング)、`keys.feed`(生キー注入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WUNQC7hni1ntkXcyBm6vU