### PR TITLE
feat(tui): Remote Control API Phase 2 — AI が画面を見て・レイアウトを調整できるように

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -351,20 +351,49 @@ scripts/tui-rpc.py /tmp/quorum.sock state.get
 scripts/tui-rpc.py /tmp/quorum.sock input.send '{"text": "Fix the bug in login.rs"}'
 scripts/tui-rpc.py /tmp/quorum.sock pane.read '{"last": 5}'
 scripts/tui-rpc.py /tmp/quorum.sock hil.respond '{"decision": "approve"}'
+
+# 画面を「見る」・レイアウトを調整する (Phase 2)
+scripts/tui-rpc.py /tmp/quorum.sock screen.capture '{"width": 120, "height": 40}'
+scripts/tui-rpc.py /tmp/quorum.sock layout.get
+scripts/tui-rpc.py /tmp/quorum.sock layout.set '{"preset": "stacked"}'
+scripts/tui-rpc.py /tmp/quorum.sock keys.feed '{"keys": ["i", "h", "i", "Esc"]}'
 ```
 
 ### Methods
 
 | Method | Params | 説明 |
 |--------|--------|------|
-| `state.get` | — | モード、モデル、タブ数、保留中 HiL(プラン内容含む) |
-| `panes.list` | — | 全タブ/ペインのメタデータ(form, title, message_count, streaming) |
+| `state.get` | — | モード、モデル、タブ数、保留中 HiL、flash、フォーカス、入力下書き、レイアウト |
+| `panes.list` | — | 全タブ/ペインのメタデータ(form, title, message_count, streaming, scroll) |
 | `pane.read` | `{tab?, last?}` | 会話メッセージを構造化 JSON で取得(画面スクレイピング不要) |
 | `input.send` | `{text}` | アクティブペインへプロンプト送信(`SubmitInput` と同一経路) |
 | `command.exec` | `{command}` | `:` コマンド実行(`solo`, `tabnew ask`, `q` 等) |
 | `interaction.spawn` | `{form, query}` | Agent/Ask/Discuss タブを生成 |
 | `interaction.activate` | `{interaction_id}` | 指定インタラクションのタブへフォーカス |
 | `hil.respond` | `{decision}` | 保留中の HiL モーダルに approve/reject を返す |
+| `screen.capture` | `{width?, height?, styles?}` | オフスクリーン描画した画面をテキスト行(+スタイルラン)で取得 |
+| `layout.get` | `{width?, height?}` | Surface ごとの Rect、preset、splits、route table、overlay 位置 |
+| `layout.set` | `{preset}` | レイアウトプリセットをライブ切替(default/minimal/wide/stacked/カスタム) |
+| `route.set` | `{content, surface}` | content slot → surface のルーティングをライブ変更 |
+| `keys.feed` | `{keys: [...]}` | 生キー注入(`"j"`, `"Esc"`, `"Ctrl+w"` — Lua keymap と同じ記法) |
+
+### Screen Visibility / 画面の可視化 (Phase 2)
+
+AI エージェントが「見る → 変更する → 結果を確認する」ループを回すための API 群:
+
+- **`screen.capture`** は現在の `TuiState` を `TestBackend` でオフスクリーン描画するため、
+  ユーザーが見ている画面と同じ内容を任意のサイズで検証できる(実端末に影響なし)。
+  行末の空白は `trim_end()` 済み。`styles: true` で行ごとのスタイルラン
+  (`{start, end, fg, bg, mods}` — 列座標・end-exclusive、トリム前のグリッド基準)を返す。
+  Help や HiL モーダル等のオーバーレイも描画結果に含まれる。
+- **`layout.get`** はレイアウトジオメトリを計算だけして返す(描画なし)。
+  `flex_fallback_active` で狭い端末での Minimal フォールバック発動が分かる。
+- **`layout.set`** は Lua の `quorum.tui` と同じライブ変更パスを通るが、
+  不明な preset 名は明示的にエラーを返す(Lua はサイレントにカスタム扱い)。
+- **`keys.feed`** はキーボードと同一のディスパッチ経路(HiL モーダル、Lua keymap、
+  組み込みバインド)。descriptor が 1 つでも不正ならバッチ全体を拒否。
+  `$EDITOR` 起動(`I`)はリモートでは抑制され `editor_suppressed: true` が返る。
+  `input.send` 同様、送信系の効果は非同期(RPC 応答は効果より先に返る)。
 
 ### Design / 設計
 

--- a/presentation/Cargo.toml
+++ b/presentation/Cargo.toml
@@ -22,6 +22,7 @@ indicatif = { workspace = true }
 colored = { workspace = true }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
+unicode-width = "0.2"
 
 # CLI
 clap = { workspace = true }

--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -23,6 +23,81 @@ use super::state::{TuiInputConfig, TuiState};
 pub(super) enum SideEffect {
     LaunchEditor,
 }
+
+/// Everything needed to process a terminal event outside `&self TuiApp`.
+///
+/// Borrowed from `TuiApp` via [`TuiApp::input_deps`] — lets the same key
+/// dispatch run from the remote `keys.feed` handler and from unit tests
+/// (a full `TuiApp` cannot be constructed in tests: it spawns a controller
+/// task and needs a gateway).
+pub(super) struct InputDeps<'a> {
+    pub cmd_tx: &'a mpsc::UnboundedSender<TuiCommand>,
+    pub pending_hil_tx: &'a Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    pub custom_keymap: &'a mode::CustomKeymap,
+    pub scripting_engine: &'a Arc<dyn quorum_application::ScriptingEnginePort>,
+    pub clipboard: &'a Arc<dyn ClipboardPort>,
+    pub content_registry: &'a std::cell::RefCell<ContentRegistry>,
+}
+
+/// Handle a terminal (crossterm) event — same code path for keyboard input
+/// and remote `keys.feed` injection.
+/// Returns a `SideEffect` if the main loop needs to perform a terminal-level action.
+pub(super) fn dispatch_terminal_event(
+    state: &mut TuiState,
+    event: crossterm::event::Event,
+    deps: &InputDeps<'_>,
+) -> Option<SideEffect> {
+    match event {
+        crossterm::event::Event::Key(key) => {
+            // If HiL modal is showing, handle y/n/Esc
+            if state.hil_prompt.is_some() {
+                super::app_hil::handle_hil_key(state, deps.pending_hil_tx, key);
+                return None;
+            }
+
+            // If help is showing, Esc or ? closes it
+            if state.show_help {
+                match key.code {
+                    crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Char('?') => {
+                        state.show_help = false;
+                        return None;
+                    }
+                    _ => {}
+                }
+            }
+
+            // Check custom keymap (from Lua) before built-in bindings
+            if let Some(custom_action) = deps.custom_keymap.lookup(state.mode, &key) {
+                state.pending_key = None;
+                return super::app_action_handler::handle_action(
+                    state,
+                    custom_action.clone(),
+                    deps.cmd_tx,
+                    deps.scripting_engine,
+                    deps.clipboard,
+                    deps.content_registry,
+                );
+            }
+
+            let action = mode::handle_key_event(state.mode, key, state.pending_key);
+            if let KeyAction::PendingKey(c) = action {
+                state.pending_key = Some(c);
+                return None;
+            }
+            state.pending_key = None;
+            super::app_action_handler::handle_action(
+                state,
+                action,
+                deps.cmd_tx,
+                deps.scripting_engine,
+                deps.clipboard,
+                deps.content_registry,
+            )
+        }
+        crossterm::event::Event::Resize(_, _) => None,
+        _ => None,
+    }
+}
 use crossterm::{
     event::{
         DisableMouseCapture, EnableMouseCapture, EventStream, KeyboardEnhancementFlags,
@@ -385,12 +460,14 @@ impl TuiApp {
 
                 // Remote control requests (--listen socket)
                 Some(remote_request) = remote_rx.recv() => {
-                    super::remote::handle_request(
-                        &mut state,
-                        &self.cmd_tx,
-                        &self.pending_hil_tx,
-                        remote_request,
-                    );
+                    let terminal_size = terminal
+                        .size()
+                        .unwrap_or(ratatui::layout::Size::new(80, 24));
+                    let ctx = super::remote::RemoteContext {
+                        deps: self.input_deps(),
+                        terminal_size,
+                    };
+                    super::remote::handle_request(&mut state, &ctx, remote_request);
                 }
 
                 // Tick for flash expiry, spinner animation, etc.
@@ -484,6 +561,18 @@ impl TuiApp {
         Ok(())
     }
 
+    /// Borrow the dependencies needed for terminal-event dispatch.
+    pub(super) fn input_deps(&self) -> InputDeps<'_> {
+        InputDeps {
+            cmd_tx: &self.cmd_tx,
+            pending_hil_tx: &self.pending_hil_tx,
+            custom_keymap: &self.custom_keymap,
+            scripting_engine: &self.scripting_engine,
+            clipboard: &self.clipboard,
+            content_registry: &self.content_registry,
+        }
+    }
+
     /// Handle a terminal (crossterm) event.
     /// Returns a `SideEffect` if the main loop needs to perform a terminal-level action.
     fn handle_terminal_event(
@@ -491,55 +580,6 @@ impl TuiApp {
         state: &mut TuiState,
         event: crossterm::event::Event,
     ) -> Option<SideEffect> {
-        match event {
-            crossterm::event::Event::Key(key) => {
-                // If HiL modal is showing, handle y/n/Esc
-                if state.hil_prompt.is_some() {
-                    super::app_hil::handle_hil_key(state, &self.pending_hil_tx, key);
-                    return None;
-                }
-
-                // If help is showing, Esc or ? closes it
-                if state.show_help {
-                    match key.code {
-                        crossterm::event::KeyCode::Esc | crossterm::event::KeyCode::Char('?') => {
-                            state.show_help = false;
-                            return None;
-                        }
-                        _ => {}
-                    }
-                }
-
-                // Check custom keymap (from Lua) before built-in bindings
-                if let Some(custom_action) = self.custom_keymap.lookup(state.mode, &key) {
-                    state.pending_key = None;
-                    return super::app_action_handler::handle_action(
-                        state,
-                        custom_action.clone(),
-                        &self.cmd_tx,
-                        &self.scripting_engine,
-                        &self.clipboard,
-                        &self.content_registry,
-                    );
-                }
-
-                let action = mode::handle_key_event(state.mode, key, state.pending_key);
-                if let KeyAction::PendingKey(c) = action {
-                    state.pending_key = Some(c);
-                    return None;
-                }
-                state.pending_key = None;
-                super::app_action_handler::handle_action(
-                    state,
-                    action,
-                    &self.cmd_tx,
-                    &self.scripting_engine,
-                    &self.clipboard,
-                    &self.content_registry,
-                )
-            }
-            crossterm::event::Event::Resize(_, _) => None,
-            _ => None,
-        }
+        dispatch_terminal_event(state, event, &self.input_deps())
     }
 }

--- a/presentation/src/tui/app_render.rs
+++ b/presentation/src/tui/app_render.rs
@@ -22,19 +22,19 @@ pub(super) fn build_default_registry() -> ContentRegistry {
         .register(Box::new(ToolLogRenderer))
 }
 
-/// Render all widgets via registry-driven dispatch.
-pub(super) fn render(
-    frame: &mut ratatui::Frame,
+/// Compute the frame layout for `state` at `area`.
+///
+/// Single source of truth shared by [`render`] (with `frame.area()`) and the
+/// remote `layout.get` / `screen.capture` methods (with an arbitrary size).
+pub(super) fn compute_layout(
     state: &TuiState,
-    content_registry: &RefCell<ContentRegistry>,
-) {
-    use super::surface::SurfaceLayout;
-
+    area: ratatui::layout::Rect,
+) -> (MainLayout, Vec<super::surface::SurfaceId>) {
     let pane_surfaces = state.route.required_pane_surfaces();
     let show_tab_bar = state.tabs.len() > 1;
     let layout = if state.layout_config.preset.is_builtin() {
         MainLayout::compute_with_layout(
-            frame.area(),
+            area,
             state.input_line_count() as u16,
             state.tui_config.max_input_height,
             show_tab_bar,
@@ -46,7 +46,7 @@ pub(super) fn render(
         let splits = state.layout_config.resolve_splits(pane_surfaces.len());
         let direction = state.layout_config.resolve_direction();
         MainLayout::compute_with_splits(
-            frame.area(),
+            area,
             state.input_line_count() as u16,
             state.tui_config.max_input_height,
             show_tab_bar,
@@ -54,6 +54,18 @@ pub(super) fn render(
             direction,
         )
     };
+    (layout, pane_surfaces)
+}
+
+/// Render all widgets via registry-driven dispatch.
+pub(super) fn render(
+    frame: &mut ratatui::Frame,
+    state: &TuiState,
+    content_registry: &RefCell<ContentRegistry>,
+) {
+    use super::surface::SurfaceLayout;
+
+    let (layout, pane_surfaces) = compute_layout(state, frame.area());
 
     // Build surface layout from the computed main layout + pane surfaces
     let surfaces = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);

--- a/presentation/src/tui/mod.rs
+++ b/presentation/src/tui/mod.rs
@@ -21,6 +21,7 @@ mod mode;
 mod presenter;
 mod progress;
 mod remote;
+mod remote_view;
 mod route;
 mod state;
 mod surface;

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -20,14 +20,31 @@
 //!
 //! | method                 | params                                | effect |
 //! |------------------------|---------------------------------------|--------|
-//! | `state.get`            | —                                     | mode, models, tabs, pending HiL |
-//! | `panes.list`           | —                                     | all tabs/panes with metadata |
+//! | `state.get`            | —                                     | mode, models, tabs, pending HiL, flash, focus, input drafts |
+//! | `panes.list`           | —                                     | all tabs/panes with metadata (incl. scroll state) |
 //! | `pane.read`            | `{tab?: usize, last?: usize}`         | conversation messages (structured) |
 //! | `input.send`           | `{text: string}`                      | submit prompt to active pane |
 //! | `command.exec`         | `{command: string}`                   | run `:command` (e.g. "solo", "tabnew ask") |
 //! | `interaction.spawn`    | `{form: "agent"\|"ask"\|"discuss", query: string}` | spawn interaction (new tab) |
 //! | `interaction.activate` | `{interaction_id: usize}`             | focus an interaction's tab |
 //! | `hil.respond`          | `{decision: "approve"\|"reject"}`     | answer a pending HiL modal |
+//!
+//! # Methods (Phase 2 — screen visibility & layout)
+//!
+//! | method           | params                          | effect |
+//! |------------------|---------------------------------|--------|
+//! | `screen.capture` | `{width?, height?, styles?}`    | off-screen render → text lines (+style runs) |
+//! | `layout.get`     | `{width?, height?}`             | surface rects, preset, splits, routes, overlays |
+//! | `layout.set`     | `{preset: string}`              | switch layout preset live |
+//! | `route.set`      | `{content, surface}`            | re-route a content slot live |
+//! | `keys.feed`      | `{keys: ["i", "Esc", "Ctrl+w"]}`| inject synthetic key events |
+//!
+//! `screen.capture` / `layout.get` default to the live terminal size.
+//! Captured lines are `trim_end()`ed; style runs are column-indexed
+//! (end-exclusive) against the untrimmed grid. `layout.set` rejects
+//! unknown preset names (unlike the Lua path, which silently creates a
+//! custom preset). `keys.feed` cannot launch `$EDITOR` — the `I` binding
+//! is swallowed and reported as `editor_suppressed`.
 //!
 //! Security: the socket is created with `0600` permissions and no TCP
 //! listener is offered — same trust model as `nvim --listen`.
@@ -55,6 +72,7 @@ pub struct RemoteRequest {
 }
 
 /// JSON-RPC error (code + message) returned to the remote client.
+#[derive(Debug)]
 pub struct RemoteError {
     pub code: i64,
     pub message: String,
@@ -254,23 +272,26 @@ async fn write_frame<W: tokio::io::AsyncWrite + Unpin>(
 // Request handling (runs inside the TuiApp select! loop)
 // ---------------------------------------------------------------------------
 
+/// Main-loop context handed to each remote request.
+///
+/// `deps` carries the same borrows used for keyboard dispatch;
+/// `terminal_size` is the real terminal size at dispatch time (used as the
+/// default for `screen.capture` / `layout.get`).
+pub(super) struct RemoteContext<'a> {
+    pub deps: super::app::InputDeps<'a>,
+    pub terminal_size: ratatui::layout::Size,
+}
+
 /// Dispatch a remote request with full access to the TUI state.
 ///
 /// Called from the main event loop, so mutations here are exactly as safe
 /// (and as visible) as those triggered by keyboard input.
 pub(super) fn handle_request(
     state: &mut TuiState,
-    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
-    pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    ctx: &RemoteContext<'_>,
     request: RemoteRequest,
 ) {
-    let result = dispatch(
-        state,
-        cmd_tx,
-        pending_hil_tx,
-        &request.method,
-        &request.params,
-    );
+    let result = dispatch(state, ctx, &request.method, &request.params);
     if let Some(reply) = request.reply {
         let _ = reply.send(result);
     }
@@ -278,8 +299,7 @@ pub(super) fn handle_request(
 
 fn dispatch(
     state: &mut TuiState,
-    cmd_tx: &mpsc::UnboundedSender<TuiCommand>,
-    pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+    ctx: &RemoteContext<'_>,
     method: &str,
     params: &Value,
 ) -> Result<Value, RemoteError> {
@@ -287,13 +307,222 @@ fn dispatch(
         "state.get" => Ok(state_snapshot(state)),
         "panes.list" => Ok(panes_list(state)),
         "pane.read" => pane_read(state, params),
-        "input.send" => input_send(state, cmd_tx, params),
-        "command.exec" => command_exec(state, cmd_tx, params),
-        "interaction.spawn" => interaction_spawn(cmd_tx, params),
-        "interaction.activate" => interaction_activate(cmd_tx, params),
-        "hil.respond" => hil_respond(state, pending_hil_tx, params),
+        "input.send" => input_send(state, ctx.deps.cmd_tx, params),
+        "command.exec" => command_exec(state, ctx.deps.cmd_tx, params),
+        "interaction.spawn" => interaction_spawn(ctx.deps.cmd_tx, params),
+        "interaction.activate" => interaction_activate(ctx.deps.cmd_tx, params),
+        "hil.respond" => hil_respond(state, ctx.deps.pending_hil_tx, params),
+        "screen.capture" => screen_capture(state, ctx, params),
+        "layout.get" => layout_get(state, ctx, params),
+        "layout.set" => layout_set(state, params),
+        "route.set" => route_set(state, params),
+        "keys.feed" => keys_feed(state, ctx, params),
         other => Err(RemoteError::method_not_found(other)),
     }
+}
+
+/// Inject synthetic key events — exactly the keyboard dispatch path
+/// (HiL modal keys, help close, Lua keymaps, built-in bindings).
+///
+/// Descriptors use the Lua keymap syntax: `"j"`, `"Esc"`, `"Ctrl+w"`,
+/// `"Shift+Enter"`, `"F5"`. All descriptors are parsed before any is fed,
+/// so one bad descriptor rejects the whole batch without side effects.
+fn keys_feed(
+    state: &mut TuiState,
+    ctx: &RemoteContext<'_>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let keys = params
+        .get("keys")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'keys' (array of key descriptors)"))?;
+
+    let mut events = Vec::with_capacity(keys.len());
+    for (i, k) in keys.iter().enumerate() {
+        let desc = k
+            .as_str()
+            .ok_or_else(|| RemoteError::invalid_params(format!("keys[{i}] must be a string")))?;
+        let (code, mods) = super::mode::parse_key_descriptor(desc).ok_or_else(|| {
+            RemoteError::invalid_params(format!("keys[{i}]: unrecognized descriptor '{desc}'"))
+        })?;
+        events.push(crossterm::event::KeyEvent::new(code, mods));
+    }
+
+    let mut editor_suppressed = false;
+    let mut fed = 0usize;
+    for key in events {
+        if state.should_quit {
+            break;
+        }
+        if let Some(super::app::SideEffect::LaunchEditor) =
+            super::app::dispatch_terminal_event(state, crossterm::event::Event::Key(key), &ctx.deps)
+        {
+            // The terminal cannot be suspended from a remote request — swallow.
+            editor_suppressed = true;
+        }
+        fed += 1;
+    }
+
+    Ok(json!({
+        "ok": true,
+        "fed": fed,
+        "mode": format!("{:?}", state.mode).to_lowercase(),
+        "editor_suppressed": editor_suppressed,
+        "quit": state.should_quit,
+    }))
+}
+
+/// Rebuild the route table after a preset/override change — the live
+/// mutation path shared with the Lua accessor (see `app_tui_changes`).
+fn rebuild_route(state: &mut TuiState) {
+    state.route = super::route::RouteTable::from_preset_and_overrides(
+        state.layout_config.preset.clone(),
+        &state.layout_config.route_overrides,
+    );
+}
+
+/// Current routes with visibility at the live layout — shared by the
+/// mutation methods' responses so agents see the effect immediately.
+fn routes_snapshot(state: &TuiState) -> Value {
+    let area = ratatui::layout::Rect::new(0, 0, 500, 300); // visibility only depends on preset
+    let (layout, pane_surfaces) = super::app_render::compute_layout(state, area);
+    let surfaces = super::surface::SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
+    super::remote_view::routes_json(state, &surfaces)
+}
+
+/// Switch the layout preset live — mirrors the Lua `quorum.tui` path.
+///
+/// Unlike the Lua path (which silently treats any unknown name as a custom
+/// preset), unknown names are rejected unless a custom preset with that
+/// name was previously registered.
+fn layout_set(state: &mut TuiState, params: &Value) -> Result<Value, RemoteError> {
+    let name = params
+        .get("preset")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'preset' (string)"))?;
+
+    let preset = match name.parse::<super::layout::LayoutPreset>() {
+        Ok(p) => p,
+        Err(_) if state.layout_config.custom_presets.contains_key(name) => {
+            super::layout::LayoutPreset::Custom(name.to_string())
+        }
+        Err(e) => return Err(RemoteError::invalid_params(e)),
+    };
+
+    state.layout_config.preset = preset;
+    rebuild_route(state);
+    state.set_flash(format!("Layout: {} (remote)", state.layout_config.preset));
+    Ok(json!({
+        "ok": true,
+        "preset": state.layout_config.preset.to_string(),
+        "routes": routes_snapshot(state),
+    }))
+}
+
+/// Re-route a content slot to a surface live — mirrors the Lua path, but
+/// replaces (rather than appends) any existing override for the same slot.
+fn route_set(state: &mut TuiState, params: &Value) -> Result<Value, RemoteError> {
+    let content_name = params
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'content' (string)"))?;
+    let surface_name = params
+        .get("surface")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RemoteError::invalid_params("missing 'surface' (string)"))?;
+
+    let content = super::layout::parse_content_slot(content_name).ok_or_else(|| {
+        RemoteError::invalid_params(format!(
+            "unknown content slot '{content_name}' (expected conversation|progress|notification|hil_prompt|help|tool_log|model_stream:<name>|lua:<name>)"
+        ))
+    })?;
+    let surface = super::layout::parse_surface_id(surface_name).ok_or_else(|| {
+        RemoteError::invalid_params(format!(
+            "unknown surface '{surface_name}' (expected main_pane|sidebar|overlay|header|input|status_bar|tab_bar|tool_pane|tool_float|dynamic_pane:<name>)"
+        ))
+    })?;
+
+    state
+        .layout_config
+        .route_overrides
+        .retain(|ov| ov.content != content);
+    state
+        .layout_config
+        .route_overrides
+        .push(super::layout::RouteOverride { content, surface });
+    rebuild_route(state);
+    Ok(json!({"ok": true, "routes": routes_snapshot(state)}))
+}
+
+/// Resolve the `{width?, height?}` params against the live terminal size,
+/// with sanity bounds (guards widget panics at degenerate sizes and
+/// multi-MB responses).
+fn capture_size(ctx: &RemoteContext<'_>, params: &Value) -> Result<(u16, u16), RemoteError> {
+    let width = match params.get("width").and_then(|v| v.as_u64()) {
+        Some(w @ 10..=500) => w as u16,
+        Some(w) => {
+            return Err(RemoteError::invalid_params(format!(
+                "'width' must be in 10..=500, got {w}"
+            )));
+        }
+        None => ctx.terminal_size.width,
+    };
+    let height = match params.get("height").and_then(|v| v.as_u64()) {
+        Some(h @ 5..=300) => h as u16,
+        Some(h) => {
+            return Err(RemoteError::invalid_params(format!(
+                "'height' must be in 5..=300, got {h}"
+            )));
+        }
+        None => ctx.terminal_size.height,
+    };
+    Ok((width, height))
+}
+
+/// Off-screen render of the current screen — what the user actually sees.
+fn screen_capture(
+    state: &TuiState,
+    ctx: &RemoteContext<'_>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let (width, height) = capture_size(ctx, params)?;
+    let with_styles = params
+        .get("styles")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let (lines, styles) = super::remote_view::capture_screen(
+        state,
+        ctx.deps.content_registry,
+        width,
+        height,
+        with_styles,
+    )
+    .map_err(|e| RemoteError::failed(format!("render failed: {e}")))?;
+
+    let mut result = json!({"width": width, "height": height, "lines": lines});
+    if let Some(styles) = styles {
+        result["styles"] = Value::Array(
+            styles
+                .iter()
+                .map(|runs| Value::Array(runs.iter().map(|r| r.to_json()).collect()))
+                .collect(),
+        );
+    }
+    Ok(result)
+}
+
+/// Computed layout geometry (surface rects, routes, overlays) at a size.
+fn layout_get(
+    state: &TuiState,
+    ctx: &RemoteContext<'_>,
+    params: &Value,
+) -> Result<Value, RemoteError> {
+    let (width, height) = capture_size(ctx, params)?;
+    Ok(super::remote_view::layout_snapshot(
+        state,
+        ratatui::layout::Rect::new(0, 0, width, height),
+    ))
 }
 
 fn role_label(role: MessageRole) -> &'static str {
@@ -314,6 +543,7 @@ fn pane_kind_json(kind: &PaneKind) -> Value {
 }
 
 fn state_snapshot(state: &TuiState) -> Value {
+    let pane = state.tabs.active_pane();
     json!({
         "mode": format!("{:?}", state.mode).to_lowercase(),
         "consensus_level": state.consensus_level.to_string(),
@@ -327,6 +557,29 @@ fn state_snapshot(state: &TuiState) -> Value {
             "objective": h.objective,
             "tasks": h.tasks,
             "message": h.message,
+        })),
+        "pending_key": state.pending_key.map(String::from),
+        "show_help": state.show_help,
+        "flash": state.flash_message.as_ref().map(|(text, at)| json!({
+            "text": text,
+            "age_ms": at.elapsed().as_millis() as u64,
+        })),
+        "focused_slot": super::layout::content_slot_to_string(&state.focused_slot),
+        "command_input": state.command_input,
+        "command_cursor": state.command_cursor,
+        "active_pane": {
+            "input": pane.input,
+            "cursor_pos": pane.cursor_pos,
+            "scroll_offset": pane.conversation.scroll_offset,
+            "auto_scroll": pane.conversation.auto_scroll,
+        },
+        "layout": {
+            "preset": state.layout_config.preset.to_string(),
+            "flex_threshold": state.layout_config.flex_threshold,
+        },
+        "visual_selection": state.visual_selection.as_ref().map(|v| json!({
+            "anchor_line": v.anchor_line,
+            "cursor_line": v.cursor_line,
         })),
     })
 }
@@ -348,6 +601,9 @@ fn panes_list(state: &TuiState) -> Value {
                 "message_count": pane.conversation.messages.len(),
                 "is_streaming": !pane.conversation.streaming_text.is_empty(),
                 "input_draft_len": pane.input.len(),
+                "cursor_pos": pane.cursor_pos,
+                "scroll_offset": pane.conversation.scroll_offset,
+                "auto_scroll": pane.conversation.auto_scroll,
             });
             if let (Value::Object(map), Value::Object(kind)) =
                 (&mut entry, pane_kind_json(&pane.kind))
@@ -548,4 +804,232 @@ fn hil_respond(
     tx.send(decision)
         .map_err(|_| RemoteError::failed("HiL requester is gone"))?;
     Ok(json!({"ok": true, "approved": approved}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::app::InputDeps;
+    use super::super::app_render::build_default_registry;
+    use super::super::content::{ContentRegistry, ContentSlot};
+    use super::super::layout::LayoutPreset;
+    use super::super::mode::{CustomKeymap, InputMode};
+    use super::super::surface::SurfaceId;
+    use super::*;
+    use quorum_application::{ClipboardPort, NoClipboard, NoScriptingEngine, ScriptingEnginePort};
+    use std::cell::RefCell;
+
+    /// Everything `dispatch()` needs, without constructing a full `TuiApp`
+    /// (which spawns a controller task and needs an LLM gateway).
+    struct TestHarness {
+        cmd_tx: mpsc::UnboundedSender<TuiCommand>,
+        _cmd_rx: mpsc::UnboundedReceiver<TuiCommand>,
+        pending_hil_tx: Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
+        keymap: CustomKeymap,
+        engine: Arc<dyn ScriptingEnginePort>,
+        clipboard: Arc<dyn ClipboardPort>,
+        registry: RefCell<ContentRegistry>,
+    }
+
+    impl TestHarness {
+        fn new() -> Self {
+            let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+            Self {
+                cmd_tx,
+                _cmd_rx: cmd_rx,
+                pending_hil_tx: Arc::new(Mutex::new(None)),
+                keymap: CustomKeymap::new(),
+                engine: Arc::new(NoScriptingEngine),
+                clipboard: Arc::new(NoClipboard),
+                registry: RefCell::new(build_default_registry()),
+            }
+        }
+
+        fn ctx(&self) -> RemoteContext<'_> {
+            RemoteContext {
+                deps: InputDeps {
+                    cmd_tx: &self.cmd_tx,
+                    pending_hil_tx: &self.pending_hil_tx,
+                    custom_keymap: &self.keymap,
+                    scripting_engine: &self.engine,
+                    clipboard: &self.clipboard,
+                    content_registry: &self.registry,
+                },
+                terminal_size: ratatui::layout::Size::new(80, 24),
+            }
+        }
+    }
+
+    #[test]
+    fn screen_capture_via_dispatch() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+
+        // Default size comes from ctx.terminal_size (80x24)
+        let result = dispatch(&mut state, &harness.ctx(), "screen.capture", &json!({})).unwrap();
+        assert_eq!(result["height"], 24);
+        assert_eq!(result["lines"].as_array().unwrap().len(), 24);
+        assert!(result.get("styles").is_none());
+
+        // Explicit size respected, styles included on demand
+        let result = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "screen.capture",
+            &json!({"width": 120, "height": 40, "styles": true}),
+        )
+        .unwrap();
+        assert_eq!(result["width"], 120);
+        assert_eq!(result["lines"].as_array().unwrap().len(), 40);
+        assert_eq!(result["styles"].as_array().unwrap().len(), 40);
+
+        // Degenerate size rejected
+        let err = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "screen.capture",
+            &json!({"width": 2}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32602);
+    }
+
+    #[test]
+    fn layout_get_via_dispatch() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+        let result = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "layout.get",
+            &json!({"width": 190, "height": 45}),
+        )
+        .unwrap();
+        assert_eq!(result["preset"], "default");
+        assert!(result["surfaces"]["main_pane"].is_object());
+        assert!(result["routes"].is_array());
+    }
+
+    #[test]
+    fn layout_set_stacked() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+
+        let result = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "layout.set",
+            &json!({"preset": "stacked"}),
+        )
+        .unwrap();
+        assert_eq!(result["preset"], "stacked");
+        assert_eq!(state.layout_config.preset, LayoutPreset::Stacked);
+        assert_eq!(
+            state.route.surface_for(&ContentSlot::Progress),
+            Some(SurfaceId::Sidebar)
+        );
+
+        // Unknown preset rejected, state unchanged
+        let err = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "layout.set",
+            &json!({"preset": "bogus"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32602);
+        assert_eq!(state.layout_config.preset, LayoutPreset::Stacked);
+    }
+
+    #[test]
+    fn route_set_and_dedupe() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+
+        for _ in 0..2 {
+            dispatch(
+                &mut state,
+                &harness.ctx(),
+                "route.set",
+                &json!({"content": "tool_log", "surface": "main_pane"}),
+            )
+            .unwrap();
+        }
+        assert_eq!(state.layout_config.route_overrides.len(), 1);
+        assert_eq!(
+            state.route.surface_for(&ContentSlot::ToolLog),
+            Some(SurfaceId::MainPane)
+        );
+
+        let err = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "route.set",
+            &json!({"content": "nope", "surface": "main_pane"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32602);
+    }
+
+    #[test]
+    fn keys_feed_insert_roundtrip() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+        assert_eq!(state.mode, InputMode::Insert);
+
+        let result = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "keys.feed",
+            &json!({"keys": ["h", "i", "Esc"]}),
+        )
+        .unwrap();
+        assert_eq!(result["fed"], 3);
+        assert_eq!(result["mode"], "normal");
+        assert_eq!(state.tabs.active_pane().input, "hi");
+
+        // '?' in Normal mode toggles help
+        dispatch(
+            &mut state,
+            &harness.ctx(),
+            "keys.feed",
+            &json!({"keys": ["?"]}),
+        )
+        .unwrap();
+        assert!(state.show_help);
+    }
+
+    #[test]
+    fn keys_feed_invalid_descriptor_is_atomic() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+
+        let err = dispatch(
+            &mut state,
+            &harness.ctx(),
+            "keys.feed",
+            &json!({"keys": ["h", "NotAKey+"]}),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32602);
+        // Nothing was fed: input buffer untouched
+        assert_eq!(state.tabs.active_pane().input, "");
+    }
+
+    #[test]
+    fn state_get_expanded_fields() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+        state.set_flash("hello");
+        state.tabs.active_pane_mut().input = "draft".into();
+
+        let result = dispatch(&mut state, &harness.ctx(), "state.get", &json!({})).unwrap();
+        assert_eq!(result["show_help"], false);
+        assert_eq!(result["flash"]["text"], "hello");
+        assert_eq!(result["focused_slot"], "conversation");
+        assert_eq!(result["active_pane"]["input"], "draft");
+        assert_eq!(result["active_pane"]["auto_scroll"], true);
+        assert_eq!(result["layout"]["preset"], "default");
+        assert_eq!(result["layout"]["flex_threshold"], 120);
+        assert!(result["visual_selection"].is_null());
+    }
 }

--- a/presentation/src/tui/remote_view.rs
+++ b/presentation/src/tui/remote_view.rs
@@ -1,0 +1,324 @@
+//! Off-screen rendering helpers for the Remote Control API.
+//!
+//! Backs `screen.capture` and `layout.get`: renders the live `TuiState`
+//! into a `TestBackend` buffer (so a remote agent sees exactly what the
+//! user sees) and dumps the computed layout geometry as JSON.
+
+use super::app_render;
+use super::content::ContentRegistry;
+use super::state::TuiState;
+use super::surface::{SurfaceId, SurfaceLayout};
+use super::widgets::MainLayout;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use serde_json::{Value, json};
+use std::cell::RefCell;
+use unicode_width::UnicodeWidthStr;
+
+/// One run of identically-styled cells within a captured line.
+///
+/// `start`/`end` are cell-column coordinates (end-exclusive) — independent
+/// of the trimmed line string, which may be shorter.
+#[derive(Debug, PartialEq)]
+pub(super) struct StyleRun {
+    pub start: u16,
+    pub end: u16,
+    pub fg: String,
+    pub bg: String,
+    pub mods: Vec<String>,
+}
+
+impl StyleRun {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "start": self.start,
+            "end": self.end,
+            "fg": self.fg,
+            "bg": self.bg,
+            "mods": self.mods,
+        })
+    }
+}
+
+/// Captured screen: rendered lines + optional per-line style runs.
+pub(super) type Captured = (Vec<String>, Option<Vec<Vec<StyleRun>>>);
+
+/// Render `state` off-screen at `width`×`height`.
+///
+/// Returns the rendered lines (trailing whitespace trimmed) and, when
+/// `with_styles` is set, per-line style runs covering columns `0..width`.
+pub(super) fn capture_screen(
+    state: &TuiState,
+    content_registry: &RefCell<ContentRegistry>,
+    width: u16,
+    height: u16,
+    with_styles: bool,
+) -> std::io::Result<Captured> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = ratatui::Terminal::new(backend)?;
+    terminal.draw(|frame| app_render::render(frame, state, content_registry))?;
+    let buf = terminal.backend().buffer();
+    Ok((
+        buffer_lines(buf),
+        with_styles.then(|| buffer_style_runs(buf)),
+    ))
+}
+
+/// Convert a rendered buffer to one string per row.
+///
+/// Cells hidden behind a wide grapheme (e.g. CJK) are skipped using the
+/// same algorithm as ratatui's own `Buffer` Debug impl — without this,
+/// the reset cells following a double-width char would shift the rest of
+/// the line right of the real grid.
+fn buffer_lines(buf: &Buffer) -> Vec<String> {
+    let width = buf.area.width as usize;
+    if width == 0 {
+        return Vec::new();
+    }
+    buf.content
+        .chunks(width)
+        .map(|row| {
+            let mut line = String::new();
+            let mut skip = 0usize;
+            for cell in row {
+                if skip == 0 {
+                    line.push_str(cell.symbol());
+                }
+                skip = skip
+                    .max(UnicodeWidthStr::width(cell.symbol()))
+                    .saturating_sub(1);
+            }
+            line.trim_end().to_string()
+        })
+        .collect()
+}
+
+/// Run-length encode each row's `(fg, bg, modifiers)` into [`StyleRun`]s.
+///
+/// Runs are contiguous and gap-free: the first run of each line starts at 0
+/// and the last ends at the buffer width, so consumers get full coverage.
+fn buffer_style_runs(buf: &Buffer) -> Vec<Vec<StyleRun>> {
+    let width = buf.area.width as usize;
+    if width == 0 {
+        return Vec::new();
+    }
+    buf.content
+        .chunks(width)
+        .map(|row| {
+            let mut runs: Vec<StyleRun> = Vec::new();
+            for (x, cell) in row.iter().enumerate() {
+                let fg = cell.fg.to_string();
+                let bg = cell.bg.to_string();
+                let mods: Vec<String> = cell
+                    .modifier
+                    .iter_names()
+                    .map(|(name, _)| name.to_string())
+                    .collect();
+                match runs.last_mut() {
+                    Some(run) if run.fg == fg && run.bg == bg && run.mods == mods => {
+                        run.end = (x + 1) as u16;
+                    }
+                    _ => runs.push(StyleRun {
+                        start: x as u16,
+                        end: (x + 1) as u16,
+                        fg,
+                        bg,
+                        mods,
+                    }),
+                }
+            }
+            runs
+        })
+        .collect()
+}
+
+pub(super) fn rect_json(r: Rect) -> Value {
+    json!({"x": r.x, "y": r.y, "width": r.width, "height": r.height})
+}
+
+/// Route table entries as JSON, with per-entry visibility for the given
+/// surface layout (a route is invisible when its surface has no area in
+/// the current preset, e.g. sidebar under Minimal).
+pub(super) fn routes_json(state: &TuiState, surfaces: &SurfaceLayout) -> Value {
+    let entries: Vec<Value> = state
+        .route
+        .entries()
+        .iter()
+        .map(|entry| {
+            json!({
+                "content": super::layout::content_slot_to_string(&entry.content),
+                "surface": super::layout::surface_id_to_string(&entry.surface),
+                "visible": surfaces.area_for(&entry.surface).is_some(),
+            })
+        })
+        .collect();
+    Value::Array(entries)
+}
+
+/// Computed layout geometry for `state` at `area` — backs `layout.get`.
+pub(super) fn layout_snapshot(state: &TuiState, area: Rect) -> Value {
+    let (layout, pane_surfaces) = app_render::compute_layout(state, area);
+    let surfaces = SurfaceLayout::from_main_layout(&layout, &pane_surfaces);
+
+    // Mirrors the fallback logic in MainLayout::compute_with_layout.
+    let flex_fallback_active = state.layout_config.preset.is_builtin()
+        && state.layout_config.flex_threshold > 0
+        && area.width < state.layout_config.flex_threshold;
+
+    let (splits, direction) = if flex_fallback_active {
+        (vec![100u16], ratatui::layout::Direction::Horizontal)
+    } else {
+        (
+            state.layout_config.resolve_splits(pane_surfaces.len()),
+            state.layout_config.resolve_direction(),
+        )
+    };
+
+    let mut surface_map = serde_json::Map::new();
+    let chrome = [
+        SurfaceId::Header,
+        SurfaceId::TabBar,
+        SurfaceId::Input,
+        SurfaceId::StatusBar,
+    ];
+    for id in chrome.iter().chain(pane_surfaces.iter()) {
+        if let Some(rect) = surfaces.area_for(id) {
+            surface_map.insert(super::layout::surface_id_to_string(id), rect_json(rect));
+        }
+    }
+
+    // Overlay rects only when actually shown — mirrors app_render::render.
+    let help_overlay = state
+        .show_help
+        .then(|| rect_json(MainLayout::centered_overlay(70, 70, area)));
+    let hil_overlay = state
+        .hil_prompt
+        .is_some()
+        .then(|| rect_json(MainLayout::centered_overlay(60, 50, area)));
+
+    json!({
+        "terminal": {"width": area.width, "height": area.height},
+        "preset": state.layout_config.preset.to_string(),
+        "is_builtin": state.layout_config.preset.is_builtin(),
+        "flex_threshold": state.layout_config.flex_threshold,
+        "flex_fallback_active": flex_fallback_active,
+        "direction": match direction {
+            ratatui::layout::Direction::Horizontal => "horizontal",
+            ratatui::layout::Direction::Vertical => "vertical",
+        },
+        "splits": splits,
+        "pane_surfaces": pane_surfaces
+            .iter()
+            .map(super::layout::surface_id_to_string)
+            .collect::<Vec<_>>(),
+        "surfaces": Value::Object(surface_map),
+        "routes": routes_json(state, &surfaces),
+        "overlays": {"help": help_overlay, "hil": hil_overlay},
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::app_render::build_default_registry;
+    use super::super::state::{DisplayMessage, HilPrompt};
+    use super::*;
+
+    fn registry() -> RefCell<ContentRegistry> {
+        RefCell::new(build_default_registry())
+    }
+
+    #[test]
+    fn capture_lines_dimensions() {
+        let state = TuiState::new();
+        let (lines, styles) = capture_screen(&state, &registry(), 80, 24, false).unwrap();
+        assert_eq!(lines.len(), 24);
+        for line in &lines {
+            assert!(UnicodeWidthStr::width(line.as_str()) <= 80);
+        }
+        assert!(styles.is_none());
+    }
+
+    #[test]
+    fn capture_wide_chars_no_drift() {
+        let mut state = TuiState::new();
+        state.push_message(DisplayMessage::user("こんにちは世界"));
+        let (lines, _) = capture_screen(&state, &registry(), 80, 24, false).unwrap();
+        let hit: Vec<&String> = lines
+            .iter()
+            .filter(|l| l.contains("こんにちは世界"))
+            .collect();
+        assert_eq!(hit.len(), 1, "message should appear exactly once");
+        assert!(UnicodeWidthStr::width(hit[0].as_str()) <= 80);
+    }
+
+    #[test]
+    fn capture_help_overlay() {
+        let mut state = TuiState::new();
+        state.show_help = true;
+        let (lines, _) = capture_screen(&state, &registry(), 80, 24, false).unwrap();
+        assert!(lines.iter().any(|l| l.contains("Keyboard Shortcuts")));
+    }
+
+    #[test]
+    fn capture_hil_overlay() {
+        let mut state = TuiState::new();
+        state.hil_prompt = Some(HilPrompt {
+            title: "Plan Review".into(),
+            objective: "Fix the bug".into(),
+            tasks: vec!["read file".into()],
+            message: "Approve?".into(),
+        });
+        let (lines, _) = capture_screen(&state, &registry(), 80, 24, false).unwrap();
+        assert!(lines.iter().any(|l| l.contains("Human Intervention")));
+    }
+
+    #[test]
+    fn style_runs_cover_full_width() {
+        let state = TuiState::new();
+        let (_, styles) = capture_screen(&state, &registry(), 80, 24, true).unwrap();
+        let styles = styles.unwrap();
+        assert_eq!(styles.len(), 24);
+        for runs in &styles {
+            assert_eq!(runs.first().unwrap().start, 0);
+            assert_eq!(runs.last().unwrap().end, 80);
+            for pair in runs.windows(2) {
+                assert_eq!(pair[0].end, pair[1].start, "runs must be contiguous");
+            }
+        }
+    }
+
+    #[test]
+    fn layout_snapshot_default_has_sidebar() {
+        let state = TuiState::new();
+        let snap = layout_snapshot(&state, Rect::new(0, 0, 190, 45));
+        assert_eq!(snap["preset"], "default");
+        assert_eq!(snap["flex_fallback_active"], false);
+        assert!(snap["surfaces"]["main_pane"].is_object());
+        assert!(snap["surfaces"]["sidebar"].is_object());
+        // Geometry sanity: main_pane + sidebar tile the full width
+        let main = &snap["surfaces"]["main_pane"];
+        let side = &snap["surfaces"]["sidebar"];
+        assert_eq!(
+            main["width"].as_u64().unwrap() + side["width"].as_u64().unwrap(),
+            190
+        );
+    }
+
+    #[test]
+    fn layout_snapshot_minimal_has_no_sidebar() {
+        let mut state = TuiState::new();
+        state.layout_config.preset = super::super::layout::LayoutPreset::Minimal;
+        let snap = layout_snapshot(&state, Rect::new(0, 0, 190, 45));
+        assert!(snap["surfaces"]["sidebar"].is_null());
+    }
+
+    #[test]
+    fn layout_snapshot_flex_fallback() {
+        let state = TuiState::new(); // flex_threshold = 120
+        let snap = layout_snapshot(&state, Rect::new(0, 0, 100, 30));
+        assert_eq!(snap["flex_fallback_active"], true);
+        assert!(snap["surfaces"]["sidebar"].is_null());
+        assert_eq!(snap["splits"][0], 100);
+    }
+}

--- a/scripts/tui-rpc.py
+++ b/scripts/tui-rpc.py
@@ -13,6 +13,13 @@ Then drive it from another terminal (or from a coding agent):
     scripts/tui-rpc.py /tmp/quorum.sock interaction.spawn '{"form": "ask", "query": "What is DDD?"}'
     scripts/tui-rpc.py /tmp/quorum.sock hil.respond '{"decision": "approve"}'
 
+Screen visibility & layout (Phase 2):
+    scripts/tui-rpc.py /tmp/quorum.sock screen.capture '{"width": 120, "height": 40}'
+    scripts/tui-rpc.py /tmp/quorum.sock layout.get
+    scripts/tui-rpc.py /tmp/quorum.sock layout.set '{"preset": "stacked"}'
+    scripts/tui-rpc.py /tmp/quorum.sock route.set '{"content": "tool_log", "surface": "sidebar"}'
+    scripts/tui-rpc.py /tmp/quorum.sock keys.feed '{"keys": ["i", "h", "i", "Esc"]}'
+
 Prints the JSON-RPC result (or error) to stdout. Exit 0 on result, 1 on error.
 """
 


### PR DESCRIPTION
## 概要

PR #255 の Remote Control API を拡張し、外部エージェントが **TUI の画面そのもの**を把握・調整できるようにする。これまで `pane.read` で会話は読めたが、レンダリング結果やレイアウトジオメトリは見えなかった。本 PR で「見る → 変更する → 結果を確認する」ループが API だけで完結する。

```bash
copilot-quorum --listen /tmp/quorum.sock

# 画面をそのまま見る(ユーザーが見ている内容と同一)
scripts/tui-rpc.py /tmp/quorum.sock screen.capture '{"width": 120, "height": 40}'

# レイアウトを変えて結果を確認
scripts/tui-rpc.py /tmp/quorum.sock layout.set '{"preset": "stacked"}'
scripts/tui-rpc.py /tmp/quorum.sock layout.get

# キー注入で操作(Lua keymap と同じ記法)
scripts/tui-rpc.py /tmp/quorum.sock keys.feed '{"keys": ["Esc", "?"]}'
```

## メソッド (Phase 2)

| Method | Params | 説明 |
|--------|--------|------|
| `screen.capture` | `{width?, height?, styles?}` | `TestBackend` でオフスクリーン描画 → テキスト行(+スタイルラン)。任意サイズ指定で狭い端末のレイアウト検証も可能 |
| `layout.get` | `{width?, height?}` | Surface ごとの Rect、preset、splits/direction、route table(visible フラグ付き)、overlay 位置、`flex_fallback_active` |
| `layout.set` | `{preset}` | プリセットのライブ切替。不明名は明示エラー(Lua のサイレント Custom 扱いと意図的に差別化) |
| `route.set` | `{content, surface}` | content→surface ルーティングのライブ変更(override は dedupe) |
| `keys.feed` | `{keys: [...]}` | 生キー注入。descriptor が 1 つでも不正ならバッチ全体を atomic に拒否。`$EDITOR` 起動は suppress(`editor_suppressed`) |

`state.get` / `panes.list` も後方互換で拡張(flash、focused_slot、入力下書き、スクロール位置、layout preset、visual_selection 等)。

## 設計

- **同一コードパス原則を維持**: `keys.feed` は `handle_terminal_event` を `InputDeps` + free function 化してキーボードと完全に同じディスパッチを通る(HiL モーダル、Lua keymap、組み込みバインドすべて)
- **レイアウト計算の一本化**: `render()` 内のレイアウト計算を `compute_layout()` に抽出し、`layout.get` / `screen.capture` と共有 — 画面と API の乖離が構造的に起きない
- **ワイド文字対応**: バッファ→テキスト変換は ratatui 自身の Debug 実装と同じ skip アルゴリズム(`unicode-width`)で、日本語・絵文字でも行ズレなし
- **ライブ変更パス**: `layout.set`/`route.set` は Lua `quorum.tui` と同じ `RouteTable::from_preset_and_overrides` 再構築(唯一のライブ反映パス)
- **スタイルラン**: `{start, end, fg, bg, mods}` の run-length(列座標・end-exclusive・隙間なし)

## 検証

- `cargo test --workspace` 全 949 件パス(新規: remote_view 8 件 + remote dispatch 7 件)
  - 日本語メッセージがドリフトしないこと、overlay がキャプチャに写ること、スタイルランの全幅カバー等
- clippy / fmt クリーン(残警告 1 件は既存テストコード由来)
- tmux 内の実 TUI に対する E2E で全メソッド確認:
  1. `state.get` で拡張フィールド確認 → 2. `layout.get` で default 70/30 のジオメトリ → 3. `screen.capture` で flex fallback(width 100 < threshold 120 → sidebar 消失)を目視 → 4. `layout.set stacked` → 実画面が縦分割に変化 → 5. `keys.feed ["Esc","?"]` → Help オーバーレイが実画面と capture 両方に出現 → 6. `route.set` → 7. 不正 preset / 極小サイズの reject 確認 → 8. `command.exec q` でクリーン終了

## 位置づけ

- PR #255(Phase 1)の続き — コミットメッセージに記載の「Phase 2 候補: keys.feed」を実装
- TUI 開発を AI に任せる際の検証基盤(レイアウト変更 → screen.capture で表示崩れ確認)
- TUI E2E テスト自動化の部品としても利用可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)