### PR TITLE
fix(copilot): Copilot CLI プロセスを working directory で起動 (#240)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -396,8 +396,23 @@ async fn main() -> Result<()> {
         .unwrap_or(provider_config);
     let custom_tools = scripting_engine.registered_custom_tools();
 
+    // Resolve working directory before spawning providers — the Copilot CLI
+    // process must start in the project directory so its built-in tools
+    // resolve relative paths there instead of its session-state dir (#240)
+    let working_dir = cli
+        .working_dir
+        .as_ref()
+        .map(|p| p.to_string_lossy().to_string())
+        .or_else(|| {
+            std::env::current_dir()
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+        });
+
     // 5. Build providers
-    let copilot = CopilotLlmGateway::new_with_logger(conversation_logger.clone()).await?;
+    let copilot =
+        CopilotLlmGateway::new_with_logger(conversation_logger.clone(), working_dir.as_deref())
+            .await?;
     #[allow(unused_mut)]
     let mut providers: Vec<Arc<dyn ProviderAdapter>> =
         vec![Arc::new(CopilotProviderAdapter::new(copilot))];
@@ -413,16 +428,6 @@ async fn main() -> Result<()> {
     let gateway: Arc<dyn LlmGateway> = Arc::new(RoutingGateway::new(providers, &provider_config));
 
     // 6. Build tool executor (custom tools from Lua)
-    let working_dir = cli
-        .working_dir
-        .as_ref()
-        .map(|p| p.to_string_lossy().to_string())
-        .or_else(|| {
-            std::env::current_dir()
-                .ok()
-                .map(|p| p.to_string_lossy().to_string())
-        });
-
     let mut tool_executor = LocalToolExecutor::new();
     if let Some(ref dir) = working_dir {
         tool_executor = tool_executor.with_working_dir(dir);

--- a/infrastructure/src/copilot/gateway.rs
+++ b/infrastructure/src/copilot/gateway.rs
@@ -54,10 +54,15 @@ impl CopilotLlmGateway {
     /// Like [`new`](Self::new), but passes the logger through to the
     /// [`MessageRouter`] so that Copilot CLI internal tool events
     /// (e.g. `apply_patch`) are recorded in the conversation JSONL.
+    ///
+    /// `working_dir` sets the Copilot CLI process's working directory so its
+    /// built-in tools resolve relative paths against the project instead of
+    /// the CLI's session-state directory (#240).
     pub async fn new_with_logger(
         logger: Arc<dyn ConversationLogger>,
+        working_dir: Option<&str>,
     ) -> Result<Self, GatewayError> {
-        let router = MessageRouter::spawn_with_logger(logger)
+        let router = MessageRouter::spawn_with_logger(logger, working_dir)
             .await
             .map_err(|e| GatewayError::ConnectionError(e.to_string()))?;
 

--- a/infrastructure/src/copilot/router.rs
+++ b/infrastructure/src/copilot/router.rs
@@ -909,23 +909,32 @@ impl MessageRouter {
     /// during application startup. The returned `Arc<Self>` is shared by all
     /// [`CopilotSession`](super::session::CopilotSession)s.
     pub async fn spawn() -> Result<Arc<Self>> {
-        Self::spawn_internal("copilot", Arc::new(NoConversationLogger)).await
+        Self::spawn_internal("copilot", Arc::new(NoConversationLogger), None).await
     }
 
     /// Spawn with a custom command (useful for testing).
     pub async fn spawn_with_command(cmd: &str) -> Result<Arc<Self>> {
-        Self::spawn_internal(cmd, Arc::new(NoConversationLogger)).await
+        Self::spawn_internal(cmd, Arc::new(NoConversationLogger), None).await
     }
 
     /// Spawn with a conversation logger for recording internal tool executions.
-    pub async fn spawn_with_logger(logger: Arc<dyn ConversationLogger>) -> Result<Arc<Self>> {
-        Self::spawn_internal("copilot", logger).await
+    ///
+    /// `working_dir` sets the CLI process's working directory. The Copilot CLI
+    /// resolves relative paths from its built-in tools (e.g. `write_file`)
+    /// against this directory — without it, files land in the CLI's own
+    /// session-state directory (`~/.local/state/.copilot/session-state/…`, #240).
+    pub async fn spawn_with_logger(
+        logger: Arc<dyn ConversationLogger>,
+        working_dir: Option<&str>,
+    ) -> Result<Arc<Self>> {
+        Self::spawn_internal("copilot", logger, working_dir).await
     }
 
     /// Internal spawn implementation shared by all public constructors.
     async fn spawn_internal(
         cmd: &str,
         conversation_logger: Arc<dyn ConversationLogger>,
+        working_dir: Option<&str>,
     ) -> Result<Arc<Self>> {
         debug!("Spawning Copilot CLI: {} --server", cmd);
 
@@ -934,6 +943,11 @@ impl MessageRouter {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
+
+        if let Some(dir) = working_dir {
+            debug!("Copilot CLI working directory: {}", dir);
+            cmd.current_dir(dir);
+        }
 
         // Linux: request kernel to send SIGTERM to child when parent dies.
         // This catches cases where Drop doesn't run (SIGKILL, OOM kill).


### PR DESCRIPTION
## Summary

Agent の plan.md が Quorum の working directory ではなく Copilot CLI のセッションステートディレクトリ(`~/.local/state/.copilot/session-state/{session-id}/plan.md`)に保存される問題の修正(Issue #240 の対策案 1・最小修正)。

原因: `working_dir` の解決(`--working-dir` 引数 or カレントディレクトリ)が provider 構築より**後**にあり、Copilot CLI の spawn に一切渡っていなかった。

- `MessageRouter::spawn_internal` に `working_dir` パラメータを追加し、spawn 時に `Command::current_dir()` を設定
- `cli/src/main.rs` で `working_dir` の解決を provider 構築より前に移動し、`CopilotLlmGateway::new_with_logger` 経由で spawn まで伝播

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #240

関連: #218 / #219(直接 API プロバイダーが入れば Copilot CLI 依存自体が緩和される)

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた(該当なし)

## Additional Notes

⚠️ **マージ前に実機確認推奨**: 子プロセスは本来親の cwd を継承するため、もし Copilot CLI が cwd を無視して自身のセッションステートディレクトリ基準でパス解決している場合、この修正だけでは不十分な可能性があります。Ensemble モードでタスクを実行し、plan.md がプロジェクトディレクトリに保存されることを確認してください。ダメだった場合の次の一手は `session.create` に `workingDirectory` を渡す案(対策案 3 に近い方向)です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)