### PR TITLE
chore: mise タスク定義を追加 (build / install)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,12 @@
+[tasks.build]
+description = "Build release binary"
+run = "cargo build --release --features bedrock"
+
+[tasks.install]
+description = "Build and install to ~/.local/bin"
+depends = ["build"]
+run = """
+mkdir -p ~/.local/bin
+ln -sf "$(pwd)/target/release/copilot-quorum" ~/.local/bin/copilot-quorum
+echo "Installed: ~/.local/bin/copilot-quorum -> $(pwd)/target/release/copilot-quorum"
+"""


### PR DESCRIPTION
## Summary

`.mise.toml` をリポジトリに追加します。これまでローカルにのみ存在して untracked だったため、git 管理下に入れて共有できるようにします。

追加されるタスク:

- `mise run build` — `cargo build --release --features bedrock` で release バイナリをビルド
- `mise run install` — build 後、`~/.local/bin/copilot-quorum` へシンボリックリンクを作成

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [ ] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [x] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

なし

## Checklist

- [ ] `cargo build` が成功する
- [ ] `cargo test --workspace` が成功する
- [ ] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた

## Additional Notes

Rust コードには一切触れていない設定ファイル追加のみの PR です（Checklist は CI での確認に委ねます）。mise はリポジトリ内の設定ファイルを実行する前に `mise trust` による承認を求めるため、clone 直後は trust 操作が必要になる点だけ留意してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)