### PR TITLE
fix(tui): Ctrl+[ を Esc として扱う — kitty keyboard protocol 対応

### DIFF
--- a/presentation/src/tui/mode.rs
+++ b/presentation/src/tui/mode.rs
@@ -274,6 +274,16 @@ pub fn handle_key_event(mode: InputMode, key: KeyEvent, pending_key: Option<char
         return KeyAction::Quit;
     }
 
+    // Global: Ctrl+[ is Esc (Vim compatible). Legacy terminals send the same
+    // byte (0x1b) for both, but with the kitty keyboard protocol's
+    // DISAMBIGUATE_ESCAPE_CODES flag (enabled for Shift+Enter support),
+    // Ctrl+[ arrives as a distinct Char('[') + CONTROL event.
+    let key = if key.code == KeyCode::Char('[') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+    } else {
+        key
+    };
+
     match mode {
         InputMode::Normal => handle_normal(key, pending_key),
         InputMode::Insert => handle_insert(key),
@@ -464,6 +474,32 @@ mod tests {
         assert_eq!(
             handle_key_event(InputMode::Insert, key, None),
             KeyAction::ExitToNormal
+        );
+    }
+
+    #[test]
+    fn test_ctrl_bracket_is_esc() {
+        // With kitty DISAMBIGUATE_ESCAPE_CODES, Ctrl+[ arrives as
+        // Char('[') + CONTROL instead of Esc. It must behave as Esc (Vim
+        // compatible) in every mode that maps Esc.
+        let key = KeyEvent::new(KeyCode::Char('['), KeyModifiers::CONTROL);
+        for mode in [InputMode::Insert, InputMode::Command, InputMode::Visual] {
+            assert_eq!(
+                handle_key_event(mode, key, None),
+                KeyAction::ExitToNormal,
+                "Ctrl+[ should exit to normal from {:?}",
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn test_plain_bracket_still_inserts() {
+        // '[' without CONTROL must remain a normal character in Insert mode
+        let key = KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE);
+        assert_eq!(
+            handle_key_event(InputMode::Insert, key, None),
+            KeyAction::InsertChar('[')
         );
     }
 


### PR DESCRIPTION
## Summary

kitty keyboard protocol 対応端末（Alacritty, kitty, WezTerm, foot 等）で **Ctrl+[ が Esc として機能しない** 問題の修正です。

### 原因

- レガシー端末では Ctrl+[ と Esc は同じバイト（0x1b）なので自動的に同一視される
- しかし TUI は Shift+Enter（マルチライン改行）対応のために `DISAMBIGUATE_ESCAPE_CODES` を有効化しており（`app.rs:362`）、このフラグ下では **Ctrl+[ が `Char('[') + CONTROL` の独立イベント**として届く
- `mode.rs` は `KeyCode::Esc` しかマッピングしていなかったため、Ctrl+[ はどのモードでも無視されていた

### 修正

`handle_key_event()` の入口で Ctrl+[ を Esc に正規化（Vim 互換）。これで Insert / Command / Visual すべてのモードで Ctrl+[ = Esc になります。

- カスタムキーマップの照合（`app.rs:70`）は正規化**前**の raw キーで行われるため、Lua で `ctrl+[` に独自バインドする自由は維持されます
- 修飾なしの `[` は Insert モードで通常の文字入力のままです（テストあり）

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

なし（会話ベースの報告から直接修正）

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する（958 passed / 0 failed）
- [x] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた（該当なし）

## Additional Notes

**E2E 検証済み**: Remote Control API（`--listen` + `keys.feed`）で実機確認。`keys.feed` はキーボードと同一のディスパッチ経路で、kitty protocol が届けるのと同じ `Char('[') + CONTROL` を注入します:

```
after 'i':      insert
after 'Ctrl+[': normal   ← 修正後は Esc と同じ挙動
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)