### PR TITLE
feat(tui): Vim スタイルの bang コマンド対応 — :init! で強制再生成

### DIFF
--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -295,6 +295,10 @@ impl AgentController {
         let command = parts.first().copied().unwrap_or("");
         let args = parts.get(1).copied().unwrap_or("").trim();
 
+        // Vim-style bang: `:init!` / `:q!` — strip the trailing `!` and pass
+        // it as a force flag to commands that support it.
+        let (command, bang) = split_bang(command);
+
         match command {
             "/quit" | "/exit" | "/q" => {
                 let _ = self.tx.send(UiEvent::Exit);
@@ -414,7 +418,7 @@ impl AgentController {
                 CommandAction::Continue
             }
             "/init" => {
-                self.run_init_context(args).await;
+                self.run_init_context(args, bang).await;
                 CommandAction::Continue
             }
             "/verbose" => {
@@ -594,8 +598,10 @@ impl AgentController {
     }
 
     /// Run context initialization
-    pub async fn run_init_context(&self, args: &str) {
-        let force = args.contains("--force") || args.contains("-f");
+    ///
+    /// `bang` は Vim スタイルの強制フラグ（`:init!`）。`--force` / `-f` と等価。
+    pub async fn run_init_context(&self, args: &str, bang: bool) {
+        let force = bang || args.contains("--force") || args.contains("-f");
 
         let working_dir = self
             .config()
@@ -883,6 +889,17 @@ impl AgentController {
 ///
 /// This is a helper that replaces the ConsoleFormatter usage from presentation.
 /// In the future, this could be moved to a domain service.
+/// Split a Vim-style bang off a command name.
+///
+/// `"/init!"` → `("/init", true)`, `"/q!"` → `("/q", true)`, `"/init"` → `("/init", false)`.
+/// A bare `"/"` or `"!"` is returned unchanged.
+fn split_bang(command: &str) -> (&str, bool) {
+    match command.strip_suffix('!') {
+        Some(base) if !base.is_empty() && base != "/" => (base, true),
+        _ => (command, false),
+    }
+}
+
 fn format_quorum_output(result: &QuorumResult, format: OutputFormat) -> String {
     match format {
         OutputFormat::Json => serde_json::to_string_pretty(result).unwrap_or_default(),
@@ -1050,6 +1067,18 @@ impl SpawnContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_split_bang() {
+        assert_eq!(split_bang("/init!"), ("/init", true));
+        assert_eq!(split_bang("/q!"), ("/q", true));
+        assert_eq!(split_bang("/init"), ("/init", false));
+        assert_eq!(split_bang("/quit"), ("/quit", false));
+        // degenerate inputs stay unchanged
+        assert_eq!(split_bang("!"), ("!", false));
+        assert_eq!(split_bang("/!"), ("/!", false));
+        assert_eq!(split_bang(""), ("", false));
+    }
     use crate::ports::agent_progress::NoAgentProgress;
     use crate::ports::context_loader::ContextLoaderPort;
     use crate::ports::human_intervention::{HumanInterventionError, HumanInterventionPort};

--- a/presentation/src/agent/presenter.rs
+++ b/presentation/src/agent/presenter.rs
@@ -137,7 +137,7 @@ impl ReplPresenter {
                     "⚠️".yellow(),
                     ".quorum/context.md".cyan()
                 );
-                println!("Use {} to regenerate.", "/init --force".cyan());
+                println!("Use {} to regenerate.", "/init! (or /init --force)".cyan());
                 println!();
             }
             UiEvent::CommandError { message } => {
@@ -247,7 +247,7 @@ impl ReplPresenter {
         println!("  /agent <task>        - Agent (autonomous task execution)");
         println!();
         println!("{}", "Other Commands:".bold());
-        println!("  /init [--force]      - Initialize project context");
+        println!("  /init[!]             - Initialize project context (! = force regenerate)");
         println!("  /config              - Show current configuration");
         println!("  /clear               - Clear conversation history");
         println!("  /verbose             - Toggle verbose mode");

--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -132,7 +132,7 @@ impl TuiPresenter {
                 )));
             }
             UiEvent::ContextAlreadyExists => {
-                state.set_flash("Context file already exists. Use /init --force to regenerate.");
+                state.set_flash("Context file already exists. Use :init! to regenerate.");
             }
             UiEvent::CommandError { message } => {
                 self.emit(TuiEvent::CommandError(message.clone()));


### PR DESCRIPTION
## Summary

TUI のコマンドモードで **`:init!`（bang）による強制再生成** をサポートします。

Vim の伝統では ex コマンドの「強制」は bang（`:w!`, `:q!`, `:e!`）で表しますが、従来の TUI は `:init --force` という CLI 文化のフラグを要求していて、Neovim ライクなモーダル UI としてパラダイムが混線していました。

### 変更内容

`handle_command()` の入口でコマンド名末尾の `!` を剥がして bang フラグとして渡す `split_bang()` を導入:

- **`:init!`**（TUI）/ **`/init!`**（REPL）→ コンテキスト強制再生成
- `--force` / `-f` はエイリアスとして維持（REPL のスラッシュコマンド文化とは相性がいいので削除しない）
- **`:q!` / `:quit!` も Vim 同様に動作**するようになった（従来は unknown command）
- 「Context file already exists」フラッシュの案内を TUI では `:init!` に更新
- REPL ヘルプは `/init[!]` 表記に更新

カスタムキーマップ・Lua コマンドとの干渉なし（bang 剥がしはビルトインコマンドの match 前のみ）。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] feat | `feature` | minor | 新機能 |
| - [ ] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

なし（会話ベースの提案から実装）

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する（957 passed / 0 failed）
- [x] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた（該当なし、既存構文は全て維持）

## Additional Notes

**E2E 検証済み**（Remote Control API `--listen` + `keys.feed` / `command.exec`）:

```
:init  → flash: "Context file already exists. Use :init! to regenerate."
:q!    → TUI 終了（従来は unknown command で無反応）
```

`split_bang()` は境界ケース（`"!"`, `"/!"`, `""`）を素通しするユニットテスト付き。

docs 側（`:init [--force]` 表記の cli.md / use-the-tui.md 等）は PR #259 のマージ後にフォローアップで `[!]` 表記に更新予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)