### PR TITLE
fix(tui): :init! の進捗を Progress ペインと会話ログに表示

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,38 @@ cargo run -p copilot-quorum -- -m claude-haiku-4.5
 cargo run -p copilot-quorum -- /init
 ```
 
+## Debugging the TUI (Remote Control API)
+
+Claude Code (や他のコーディングエージェント) から実際に TUI を起動して「見て・操作して・検証する」ためのワークフロー。
+TUI のバグ再現・修正確認はコードリーディングだけで済ませず、この方法で実機確認すること。
+
+```bash
+# 1. Build first, then launch the TUI headless with a JSON-RPC socket.
+#    - TUI は TTY 必須 → `script` で疑似端末を与えてバックグラウンド起動する
+#    - ソケットパスは短く (Unix socket の SUN_LEN ~108 文字制限。長いと "path must be shorter than SUN_LEN" で落ちる)
+cargo build
+script -qefc "./target/debug/copilot-quorum --listen /tmp/quorum-dbg.sock" /dev/null &
+
+# 2. Drive it with the reference client (method 一覧は docs/reference/tui-remote-control.md)
+scripts/tui-rpc.py /tmp/quorum-dbg.sock state.get                          # モード・モデル・flash 等
+scripts/tui-rpc.py /tmp/quorum-dbg.sock command.exec '{"command": "init!"}' # `:` コマンド実行
+scripts/tui-rpc.py /tmp/quorum-dbg.sock input.send '{"text": "Fix the bug"}'
+scripts/tui-rpc.py /tmp/quorum-dbg.sock hil.respond '{"decision": "approve"}'
+
+# 3. "See" the screen — ユーザーが見ているものと同じ画面をオフスクリーン描画で取得
+scripts/tui-rpc.py /tmp/quorum-dbg.sock screen.capture '{"width": 140, "height": 40}' \
+  | python3 -c "import json,sys; print('\n'.join(json.load(sys.stdin)['lines']))"
+scripts/tui-rpc.py /tmp/quorum-dbg.sock pane.read '{"last": 5}'            # 会話ログを構造化 JSON で
+
+# 4. Clean up
+scripts/tui-rpc.py /tmp/quorum-dbg.sock command.exec '{"command": "q!"}'
+```
+
+Tips:
+- `screen.capture` を実行前後で取れば「修正が画面にどう反映されたか」を diff で検証できる
+- LLM 呼び出しを伴う操作 (`init!` 等) は非同期。完了は `pane.read` のメッセージ (例: "Context saved to") をポーリングして検知する
+- `keys.feed` はキーボードと同一のディスパッチ経路なので、キーバインドや HiL モーダルのデバッグにも使える
+
 ## Configuration
 
 Configuration via Lua: `~/.config/copilot-quorum/init.lua` (plugins in `plugins/*.lua`)

--- a/application/src/ports/ui_event.rs
+++ b/application/src/ports/ui_event.rs
@@ -60,6 +60,8 @@ pub enum UiEvent {
     // === Context Initialization ===
     /// Context initialization starting
     ContextInitStarting { model_count: usize },
+    /// Context initialization progress log (file loading, per-model analysis, synthesis)
+    ContextInitProgress { message: String },
     /// Context initialization completed
     ContextInitResult(ContextInitResultEvent),
     /// Context initialization failed

--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -17,7 +17,9 @@ use crate::ports::ui_event::{
     AgentErrorEvent, AgentResultEvent, AskResultEvent, ConfigSnapshot, ContextInitResultEvent,
     InteractionCompletedEvent, InteractionSpawnedEvent, QuorumResultEvent, UiEvent, WelcomeInfo,
 };
-use crate::use_cases::init_context::{InitContextInput, InitContextUseCase};
+use crate::use_cases::init_context::{
+    InitContextInput, InitContextProgressNotifier, InitContextUseCase,
+};
 use crate::use_cases::run_agent::RunAgentUseCase;
 use crate::use_cases::run_ask::RunAskUseCase;
 use crate::use_cases::run_quorum::RunQuorumUseCase;
@@ -26,7 +28,7 @@ use quorum_domain::interaction::{
     InteractionForm, InteractionId, InteractionResult, InteractionTree,
 };
 use quorum_domain::util::truncate_str;
-use quorum_domain::{ConsensusLevel, Model, OutputFormat, PhaseScope, QuorumResult};
+use quorum_domain::{AgentPhase, ConsensusLevel, Model, OutputFormat, PhaseScope, QuorumResult};
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::sync::mpsc;
@@ -289,7 +291,7 @@ impl AgentController {
     pub async fn handle_command(
         &mut self,
         cmd: &str,
-        _progress: &dyn AgentProgressNotifier,
+        progress: &dyn AgentProgressNotifier,
     ) -> CommandAction {
         let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
         let command = parts.first().copied().unwrap_or("");
@@ -418,7 +420,7 @@ impl AgentController {
                 CommandAction::Continue
             }
             "/init" => {
-                self.run_init_context(args, bang).await;
+                self.run_init_context(args, bang, progress).await;
                 CommandAction::Continue
             }
             "/verbose" => {
@@ -600,7 +602,12 @@ impl AgentController {
     /// Run context initialization
     ///
     /// `bang` は Vim スタイルの強制フラグ（`:init!`）。`--force` / `-f` と等価。
-    pub async fn run_init_context(&self, args: &str, bang: bool) {
+    pub async fn run_init_context(
+        &self,
+        args: &str,
+        bang: bool,
+        progress: &dyn AgentProgressNotifier,
+    ) {
         let force = bang || args.contains("--force") || args.contains("-f");
 
         let working_dir = self
@@ -639,9 +646,14 @@ impl AgentController {
             input = input.with_force(true);
         }
 
-        // Run the initialization
+        // Run the initialization, bridging progress to both the Progress pane
+        // (via AgentProgressNotifier) and the conversation log (via UiEvent)
+        let bridge = InitContextProgressBridge {
+            progress,
+            tx: self.tx.clone(),
+        };
         let use_case = InitContextUseCase::new(self.gateway.clone(), self.context_loader.clone());
-        let result = use_case.execute(input).await;
+        let result = use_case.execute_with_progress(input, &bridge).await;
 
         match result {
             Ok(output) => {
@@ -897,6 +909,51 @@ fn split_bang(command: &str) -> (&str, bool) {
     match command.strip_suffix('!') {
         Some(base) if !base.is_empty() && base != "/" => (base, true),
         _ => (command, false),
+    }
+}
+
+/// Bridges [`InitContextProgressNotifier`] callbacks to the generic
+/// [`AgentProgressNotifier`] (Progress pane: phase + quorum vote bar) and the
+/// [`UiEvent`] channel (conversation log lines).
+struct InitContextProgressBridge<'a> {
+    progress: &'a dyn AgentProgressNotifier,
+    tx: mpsc::UnboundedSender<UiEvent>,
+}
+
+impl InitContextProgressBridge<'_> {
+    fn log(&self, message: impl Into<String>) {
+        let _ = self.tx.send(UiEvent::ContextInitProgress {
+            message: message.into(),
+        });
+    }
+}
+
+impl InitContextProgressNotifier for InitContextProgressBridge<'_> {
+    fn on_loading_files(&self) {
+        self.progress.on_phase_change(&AgentPhase::ContextGathering);
+        self.log("Loading project files...");
+    }
+
+    fn on_analysis_start(&self, model_count: usize) {
+        self.progress.on_quorum_start("Context Analysis", model_count);
+        self.log(format!(
+            "Analyzing project with {} models...",
+            model_count
+        ));
+    }
+
+    fn on_model_complete(&self, model: &Model) {
+        self.progress.on_quorum_model_complete(model, true);
+        self.log(format!("✓ {} analysis complete", model));
+    }
+
+    fn on_synthesis_start(&self) {
+        self.progress.on_quorum_start("Context Synthesis", 1);
+        self.log("Synthesizing analyses...");
+    }
+
+    fn on_complete(&self, _path: &str) {
+        self.progress.on_phase_change(&AgentPhase::Completed);
     }
 }
 

--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -935,11 +935,9 @@ impl InitContextProgressNotifier for InitContextProgressBridge<'_> {
     }
 
     fn on_analysis_start(&self, model_count: usize) {
-        self.progress.on_quorum_start("Context Analysis", model_count);
-        self.log(format!(
-            "Analyzing project with {} models...",
-            model_count
-        ));
+        self.progress
+            .on_quorum_start("Context Analysis", model_count);
+        self.log(format!("Analyzing project with {} models...", model_count));
     }
 
     fn on_model_complete(&self, model: &Model) {

--- a/presentation/src/agent/presenter.rs
+++ b/presentation/src/agent/presenter.rs
@@ -118,6 +118,9 @@ impl ReplPresenter {
                 println!("Analyzing project with {} models...", model_count);
                 println!();
             }
+            UiEvent::ContextInitProgress { message } => {
+                println!("{}", message.dimmed());
+            }
             UiEvent::ContextInitResult(result) => self.render_context_init_result(result),
             UiEvent::ContextInitError { error } => {
                 println!();

--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -122,6 +122,9 @@ impl TuiPresenter {
                     model_count
                 )));
             }
+            UiEvent::ContextInitProgress { message } => {
+                state.push_message(DisplayMessage::system(message.clone()));
+            }
             UiEvent::ContextInitResult(result) => {
                 self.handle_context_init_result(state, result);
             }
@@ -130,6 +133,7 @@ impl TuiPresenter {
                     "Context init failed: {}",
                     error
                 )));
+                Self::reset_progress(state);
             }
             UiEvent::ContextAlreadyExists => {
                 state.set_flash("Context file already exists. Use :init! to regenerate.");
@@ -246,6 +250,14 @@ impl TuiPresenter {
             result.path
         )));
         state.set_flash("Context initialized successfully");
+        Self::reset_progress(state);
+    }
+
+    /// Return the Progress pane to its idle state after context init finishes.
+    fn reset_progress(state: &mut TuiState) {
+        let progress = &mut state.tabs.active_pane_mut().progress;
+        progress.current_phase = None;
+        progress.quorum_status = None;
     }
 
     fn emit(&self, event: TuiEvent) {


### PR DESCRIPTION
## Summary

`:init!`（`/init`）実行中、TUI の Progress ペインが「Phase: Ready」のまま何も表示されず、会話ログにも経過が流れない問題を修正しました。

**原因**: TUI 経路の `AgentController::run_init_context` が progress 通知なしの `InitContextUseCase::execute()` を呼んでいた（`execute_with_progress()` と `InitContextProgressNotifier` は既存だが未配線）。`handle_command` は `TuiProgressBridge` を受け取りながら `_progress` として握りつぶしていた。

**修正**:
- `InitContextProgressBridge` を追加し、`InitContextProgressNotifier` のコールバックを2系統にブリッジ
  - `AgentProgressNotifier` → Progress ペイン（Phase 表示 + Quorum 投票バー: Context Analysis `[●·] 1/2` → Context Synthesis）
  - 新設の `UiEvent::ContextInitProgress` → 会話ログ（ファイル読込 / モデル別解析完了 / 合成開始）
- 完了・エラー時に Progress ペインを Ready にリセット
- REPL プレゼンターでも同ログを表示

あわせて、今回のデバッグで使った TUI Remote Control API（`--listen` + `scripts/tui-rpc.py`）による実機検証ワークフローを CLAUDE.md に記載しました（pty 必須・socket パス長制限の罠を含む）。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] fix | `fix` | patch | バグ修正 |
| - [x] docs | `docs` | patch | ドキュメントのみの変更 |

## Related Issues

なし

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた（破壊的変更なし）

## Additional Notes

Remote Control API で実機検証済み: `command.exec {"command": "init!"}` 実行 → `screen.capture` で Phase 遷移（🔍 Gathering Context → Quorum 投票バー進行 → Synthesis → 完了後 Ready）とログ流下（Loading project files... → ✓ model analysis complete → Synthesizing analyses... → Context saved to: ...）を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)