### PR TITLE
fix(tui): Ask の応答が2重表示される問題を修正 — AskResult の push を削除

### DIFF
--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -224,8 +224,11 @@ impl TuiPresenter {
         self.emit(TuiEvent::AgentError(msg));
     }
 
-    fn handle_ask_result(&self, state: &mut TuiState, result: &AskResultEvent) {
-        state.push_message(DisplayMessage::assistant(result.answer.clone()));
+    fn handle_ask_result(&self, _state: &mut TuiState, _result: &AskResultEvent) {
+        // The answer is displayed via streaming: StreamChunk accumulates into
+        // streaming_text and StreamEnd finalizes it as an assistant message
+        // (routed to the correct interaction pane). Pushing result.answer here
+        // would duplicate it (#267), so only emit the completion event.
         self.emit(TuiEvent::AgentResult {
             success: true,
             summary: "Ask completed".into(),
@@ -334,6 +337,60 @@ mod tests {
         let (presenter, _rx, mut state) = setup();
         presenter.apply(&mut state, &UiEvent::Exit);
         assert!(state.should_quit);
+    }
+
+    #[test]
+    fn test_ask_result_does_not_duplicate_streamed_answer() {
+        // Regression test for #267: the answer is finalized from streaming
+        // (StreamEnd → finalize_stream), so AskResult must not push it again.
+        let (presenter, mut rx, mut state) = setup();
+
+        // Simulate streaming of the answer followed by StreamEnd finalization
+        state.tabs.active_pane_mut().conversation.streaming_text = "4".into();
+        state.finalize_stream();
+
+        presenter.apply(
+            &mut state,
+            &UiEvent::AskResult(AskResultEvent { answer: "4".into() }),
+        );
+
+        let messages = &state.tabs.active_pane().conversation.messages;
+        let assistant_count = messages
+            .iter()
+            .filter(|m| m.role == super::super::state::MessageRole::Assistant)
+            .count();
+        assert_eq!(assistant_count, 1, "answer must appear exactly once");
+
+        // Completion event is still emitted for progress/remote consumers
+        assert!(matches!(
+            rx.try_recv().unwrap().event,
+            TuiEvent::AgentResult { success: true, .. }
+        ));
+    }
+
+    #[test]
+    fn test_ask_result_before_stream_end_does_not_duplicate() {
+        // ui_rx is prioritized over tui_event_rx (biased select!), so
+        // AskResult can be applied before StreamEnd. The answer must still
+        // appear exactly once after the stream is finalized.
+        let (presenter, _rx, mut state) = setup();
+
+        state.tabs.active_pane_mut().conversation.streaming_text = "4".into();
+
+        presenter.apply(
+            &mut state,
+            &UiEvent::AskResult(AskResultEvent { answer: "4".into() }),
+        );
+
+        // StreamEnd arrives afterwards
+        state.finalize_stream();
+
+        let messages = &state.tabs.active_pane().conversation.messages;
+        let assistant_count = messages
+            .iter()
+            .filter(|m| m.role == super::super::state::MessageRole::Assistant)
+            .count();
+        assert_eq!(assistant_count, 1, "answer must appear exactly once");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

TUI で `:ask` を実行すると assistant の回答が会話ペインに2回表示される問題を修正しました。

**原因**: 同じ回答が2つの経路から push されていた
1. **Streaming 経路**: `run_ask.rs` の `on_llm_chunk()` → `on_llm_stream_end()` → TUI の `StreamEnd` イベント → `finalize_stream_for()` が streaming_text を assistant メッセージとして push
2. **AskResult 経路**: `TuiPresenter::handle_ask_result()` が `result.answer` を再度 push

**修正**: streaming 側を唯一の表示経路とし、`handle_ask_result()` からメッセージ push を削除（完了イベント `TuiEvent::AgentResult` の emit は維持）。

この方針にした理由:
- TUI の Ask は必ず `TuiProgressBridge::for_interaction` 経由のため、answer は必ず stream → finalize で1回表示される
- `app.rs` の `select!` は `biased` で ui_rx を優先するため、`AskResult` が `StreamEnd` より**先に**処理される順序もありうる。「streaming があったらスキップ」のフラグ方式ではこの race で二重表示が残るが、push 削除ならどの処理順序でも exactly-once になる
- 旧実装の `push_message`（active pane 宛）はタブ切り替え中に誤った pane へ push する問題もあり、これも解消される

回帰テストを2本追加（`StreamEnd` 先行 / `AskResult` 先行の両順序をカバー）。

修正は presentation 層（TUI presenter）のみで、domain / application は無変更です。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD 変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #267

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた

## Additional Notes

`UiEvent::AskResult` イベント自体は Remote Control API などの他コンシューマー向けに維持しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)