### PR TITLE
fix(tui): --listen のソケットパス長を起動前にバリデーション — 不親切な SUN_LEN エラーを解消

### DIFF
--- a/presentation/src/tui/app.rs
+++ b/presentation/src/tui/app.rs
@@ -350,6 +350,15 @@ impl TuiApp {
 
     /// Run the TUI main loop
     pub async fn run(&mut self) -> io::Result<()> {
+        // Validate the remote-control socket path (--listen) up front, before
+        // touching the terminal. A too-long path otherwise fails deep in libc
+        // bind() with the opaque "SUN_LEN" message *after* raw mode is enabled,
+        // corrupting the screen; validating here surfaces a friendly error on a
+        // clean terminal. (#272)
+        if let Some(path) = &self.listen_path {
+            super::remote::validate_socket_path(path)?;
+        }
+
         // Setup terminal
         enable_raw_mode()?;
         let mut stdout = io::stdout();

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -1068,7 +1068,10 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         let msg = err.to_string();
         // Human-readable: no libc jargon, includes both byte counts.
-        assert!(!msg.contains("SUN_LEN"), "message leaked libc jargon: {msg}");
+        assert!(
+            !msg.contains("SUN_LEN"),
+            "message leaked libc jargon: {msg}"
+        );
         assert!(msg.contains(&(MAX_SOCKET_PATH_LEN + 1).to_string()));
         assert!(msg.contains(&MAX_SOCKET_PATH_LEN.to_string()));
         assert!(msg.contains("--listen"));

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -55,7 +55,8 @@ use super::tab::PaneKind;
 use quorum_domain::HumanDecision;
 use quorum_domain::interaction::InteractionForm;
 use serde_json::{Value, json};
-use std::path::PathBuf;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -102,6 +103,42 @@ impl RemoteError {
 }
 
 // ---------------------------------------------------------------------------
+// Socket path validation
+// ---------------------------------------------------------------------------
+
+/// Maximum byte length of a Unix domain socket path.
+///
+/// `sockaddr_un.sun_path` holds 108 bytes on Linux/Android (104 on
+/// macOS/BSD), including the trailing NUL — so the usable path is one byte
+/// shorter. Binding a longer path fails deep inside libc with the opaque
+/// "path must be shorter than SUN_LEN"; we check up front instead. (#272)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(super) const MAX_SOCKET_PATH_LEN: usize = 107;
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub(super) const MAX_SOCKET_PATH_LEN: usize = 103;
+
+/// Validate that `path` fits within the Unix domain socket length limit.
+///
+/// Returns a human-readable `InvalidInput` error (byte count + limit +
+/// example) rather than letting `UnixListener::bind` fail later with the
+/// opaque libc `SUN_LEN` message. Called from `TuiApp::run` before the
+/// terminal is put into raw mode, so the message reaches the user on a
+/// clean screen. (#272)
+pub(super) fn validate_socket_path(path: &Path) -> std::io::Result<()> {
+    let len = path.as_os_str().as_bytes().len();
+    if len > MAX_SOCKET_PATH_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "ソケットパスが長すぎます ({len} バイト、上限は {MAX_SOCKET_PATH_LEN} バイト)。\
+                 短いパスを指定してください: --listen /tmp/quorum.sock"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Socket listener
 // ---------------------------------------------------------------------------
 
@@ -113,6 +150,7 @@ pub fn spawn_listener(
     path: PathBuf,
     tx: mpsc::UnboundedSender<RemoteRequest>,
 ) -> std::io::Result<()> {
+    validate_socket_path(&path)?;
     if path.exists() {
         std::fs::remove_file(&path)?;
     }
@@ -1013,6 +1051,27 @@ mod tests {
         assert_eq!(err.code, -32602);
         // Nothing was fed: input buffer untouched
         assert_eq!(state.tabs.active_pane().input, "");
+    }
+
+    #[test]
+    fn validate_socket_path_accepts_short_path() {
+        assert!(validate_socket_path(Path::new("/tmp/quorum.sock")).is_ok());
+        // Exactly at the limit is allowed.
+        let at_limit = "a".repeat(MAX_SOCKET_PATH_LEN);
+        assert!(validate_socket_path(Path::new(&at_limit)).is_ok());
+    }
+
+    #[test]
+    fn validate_socket_path_rejects_long_path_with_friendly_message() {
+        let too_long = "a".repeat(MAX_SOCKET_PATH_LEN + 1);
+        let err = validate_socket_path(Path::new(&too_long)).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let msg = err.to_string();
+        // Human-readable: no libc jargon, includes both byte counts.
+        assert!(!msg.contains("SUN_LEN"), "message leaked libc jargon: {msg}");
+        assert!(msg.contains(&(MAX_SOCKET_PATH_LEN + 1).to_string()));
+        assert!(msg.contains(&MAX_SOCKET_PATH_LEN.to_string()));
+        assert!(msg.contains("--listen"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`--listen` に Unix ドメインソケットのパス長上限（Linux: 107 バイト）を超えるパスを渡すと、libc 内部マクロ名むき出しの **`Error: path must be shorter than SUN_LEN`** で即終了する問題の修正です。

### 原因

- `UnixListener::bind` はパス長超過を libc の `SUN_LEN` マクロ名を含むエラーで返すため、ユーザーには何が悪いのか・どう直せばいいのか分からない
- さらにバインドは `TuiApp::run()` 内で **raw mode + alternate screen 突入後**に行われるため（`app.rs`）、エラー表示時に画面が壊れる二重苦だった

### 修正

- `remote.rs` に `MAX_SOCKET_PATH_LEN` 定数（Linux/Android: 107、macOS/BSD: 103 — `sockaddr_un.sun_path` のサイズ差を `cfg` で吸収）と `validate_socket_path()` を追加。バイト数・上限・修正例を含む人間向けメッセージを返す
- `TuiApp::run()` の冒頭（`enable_raw_mode` **前**）で検証し、クリーンな画面でエラーを表示
- `spawn_listener()` 側でも防御的に検証（他経路からの呼び出しにも安全）

修正後の出力:

```
$ copilot-quorum --listen /tmp/aaa...(117 バイト).sock
Error: ソケットパスが長すぎます (117 バイト、上限は 107 バイト)。短いパスを指定してください: --listen /tmp/quorum.sock
```

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #272

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する（961 passed / 0 failed）
- [x] `cargo clippy` で警告がない（今回の追加分。既存の `widgets/mod.rs` の警告 1 件はスコープ外）
- [ ] 破壊的変更がある場合は `breaking` ラベルを付けた（該当なし）

## Additional Notes

**E2E 検証済み**: 117 バイトのパスで実機起動し、raw mode 突入前にクリーンな画面で上記メッセージが表示されることを確認。

境界値テスト付き（上限ちょうど 107 バイトは許可、108 バイトで拒否、メッセージに `SUN_LEN` が漏れないことも検証）。

補足: issue の再現コマンドのパスは実は 95 バイトで上限内のため、あちらは「親ディレクトリが存在しない」別エラー（`No such device or address`）になります。存在しない親ディレクトリの扱い（自動作成 or 事前チェック）は必要なら別 issue で対応するのが良さそうです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)