### PR TITLE
fix(tui): コマンドフィードバックの表記ゆれを解消 — TUI エラーは : プレフィックス + :help でオーバーレイを開く

### DIFF
--- a/application/src/ports/ui_event.rs
+++ b/application/src/ports/ui_event.rs
@@ -86,7 +86,9 @@ pub enum UiEvent {
     // === Errors & Control ===
     /// Command usage/validation error
     CommandError { message: String },
-    /// Unknown command entered
+    /// Unknown command entered.
+    /// `command` is the bare command name without any prefix — each presenter
+    /// renders its own prefix convention (`/` for REPL, `:` for TUI).
     UnknownCommand { command: String },
     /// Exit message
     Exit,

--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -446,8 +446,10 @@ impl AgentController {
                         });
                     }
                 } else {
+                    // Send the bare command name — presenters render their own
+                    // prefix convention (`/` for REPL, `:` for TUI).
                     let _ = self.tx.send(UiEvent::UnknownCommand {
-                        command: command.to_string(),
+                        command: cmd_name.to_string(),
                     });
                 }
                 CommandAction::Continue
@@ -1381,7 +1383,7 @@ mod tests {
 
         let event = rx.try_recv().unwrap();
         match event {
-            UiEvent::UnknownCommand { command } => assert_eq!(command, "/foobar"),
+            UiEvent::UnknownCommand { command } => assert_eq!(command, "foobar"),
             other => panic!("Expected UnknownCommand, got {:?}", other),
         }
     }

--- a/presentation/src/agent/presenter.rs
+++ b/presentation/src/agent/presenter.rs
@@ -144,7 +144,7 @@ impl ReplPresenter {
                 println!("{} {}", "Error:".red().bold(), message);
             }
             UiEvent::UnknownCommand { command } => {
-                println!("{} Unknown command: {}", "?".yellow(), command);
+                println!("{} Unknown command: /{}", "?".yellow(), command);
                 println!("Type {} for available commands", "/help".cyan());
             }
             UiEvent::Exit => {

--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -26,7 +26,10 @@ impl TuiPresenter {
     pub fn apply(&self, state: &mut TuiState, event: &UiEvent) {
         match event {
             UiEvent::Welcome(info) => self.handle_welcome(state, info),
-            UiEvent::Help => self.emit(TuiEvent::Flash("Type :help or ? for commands".into())),
+            UiEvent::Help => {
+                state.show_help = true;
+                state.set_flash("Press ? or Esc to close");
+            }
             UiEvent::ConfigDisplay(snapshot) => self.handle_config(state, snapshot),
             UiEvent::ModeChanged { level, description } => {
                 state.consensus_level = *level;
@@ -139,7 +142,7 @@ impl TuiPresenter {
                 state.set_flash(format!("Error: {}", message));
             }
             UiEvent::UnknownCommand { command } => {
-                state.set_flash(format!("Unknown command: {}. Type ? for help", command));
+                state.set_flash(format!("Unknown command: :{}. Type ? for help", command));
             }
             UiEvent::Exit => {
                 state.should_quit = true;
@@ -327,6 +330,29 @@ mod tests {
                 .streaming_text
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn test_unknown_command_uses_tui_prefix() {
+        let (presenter, _rx, mut state) = setup();
+        presenter.apply(
+            &mut state,
+            &UiEvent::UnknownCommand {
+                command: "nonexistent".into(),
+            },
+        );
+        let (flash, _) = state.flash_message.expect("flash should be set");
+        assert!(flash.contains(":nonexistent"), "flash was: {}", flash);
+        assert!(!flash.contains("/nonexistent"), "flash was: {}", flash);
+    }
+
+    #[test]
+    fn test_help_opens_overlay_without_circular_flash() {
+        let (presenter, _rx, mut state) = setup();
+        presenter.apply(&mut state, &UiEvent::Help);
+        assert!(state.show_help);
+        let (flash, _) = state.flash_message.expect("flash should be set");
+        assert!(!flash.contains(":help"), "flash was: {}", flash);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

TUI のコマンドフィードバックにあった2つの表記ゆれ・違和感を解消しました (#273)。

1. **Unknown command のプレフィックス不整合**: `:nonexistent` と入力すると REPL 用の `/` 表記 (`Unknown command: /nonexistent`) で flash が返っていた
2. **`:help` の循環案内**: `:help` を実行した直後に「Type :help or ? for commands」という無意味な flash が表示されていた

### 変更内容

- `UiEvent::UnknownCommand` はプレフィックスなしの素のコマンド名を運ぶように変更し、表記の決定を presentation 層に移動(REPL presenter は `/`、TUI presenter は `:` でレンダリング)
- TUI の `:help` は Help オーバーレイを開き、flash を「Press ? or Esc to close」に変更(従来は flash のみでオーバーレイは開かなかった)
- `application/src/ports/ui_event.rs` の doc コメントに表記規約を明記
- TUI presenter に回帰テスト2件追加

### 設計メモ

application 層のポートイベント(`UiEvent`)は UI 表記に依存しない中立なデータのみを持ち、サーフェスごとの表記規約(`/` vs `:`)は各 presenter の責務に寄せました。DDD + オニオンの依存方向は変わらず、domain 層は無変更です。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] fix | `fix` | patch | バグ修正 |

## Related Issues

Closes #273

## Checklist

- [x] `cargo build` succeeds
- [x] `cargo test --workspace` passes
- [x] `cargo clippy` has no warnings
- [ ] Added `breaking` label if there are breaking changes

## Additional Notes

Issue には「`:help` を実行すると Help オーバーレイは開く」とありましたが、実際のコードでは flash が出るだけでオーバーレイは開いていませんでした。本 PR で `:help` からも `?` キーと同じくオーバーレイが開くようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)