### PR TITLE
feat(tui): Ask タブに質問文を echo + 親タブ通知に質問の要約を付与

### DIFF
--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -816,16 +816,17 @@ impl AgentController {
     /// Updates conversation history. For spawn tasks (interaction_id is Some),
     /// also emits InteractionCompleted event.
     pub fn finalize(&mut self, completion: TaskCompletion) {
-        if let Some(result_text) = &completion.result_text {
+        if let Some(result) = &completion.result {
             self.conversation_history.push(HistoryEntry {
                 form: completion.form,
                 request: completion.query.clone(),
-                summary: truncate_str(result_text, 200).to_string(),
+                summary: truncate_str(&result.to_context_injection(), 200).to_string(),
             });
         }
-        // Spawn path: emit InteractionCompleted
+        // Spawn path: emit InteractionCompleted with a query-aware notification
+        // so the parent tab shows what the result is answering (issue #274).
         if let Some(child_id) = completion.interaction_id
-            && let Some(result_text) = completion.result_text
+            && let Some(result) = &completion.result
         {
             let parent_id = self.interaction_tree.get(child_id).and_then(|i| i.parent);
             let _ = self
@@ -834,7 +835,7 @@ impl AgentController {
                     id: child_id,
                     form: completion.form,
                     parent_id,
-                    result_text,
+                    result_text: result.to_parent_notification(&completion.query),
                 }));
         }
     }
@@ -981,7 +982,7 @@ pub struct TaskCompletion {
     pub interaction_id: Option<InteractionId>,
     pub form: InteractionForm,
     pub query: String,
-    pub result_text: Option<String>,
+    pub result: Option<InteractionResult>,
 }
 
 impl SpawnContext {
@@ -1007,13 +1008,11 @@ impl SpawnContext {
             InteractionForm::Agent => self.execute_agent(&clean_query, progress).await,
         };
 
-        let result_text = result.as_ref().map(|r| r.to_context_injection());
-
         TaskCompletion {
             interaction_id,
             form,
             query: clean_query,
-            result_text,
+            result,
         }
     }
 
@@ -1776,7 +1775,9 @@ mod tests {
             interaction_id: Some(child_id),
             form: InteractionForm::Ask,
             query: clean_query,
-            result_text: Some("done".to_string()),
+            result: Some(InteractionResult::AskResult {
+                answer: "done".to_string(),
+            }),
         });
 
         let event = rx.try_recv().unwrap();
@@ -1784,7 +1785,8 @@ mod tests {
             UiEvent::InteractionCompleted(completed) => {
                 assert_eq!(completed.id, child_id);
                 assert_eq!(completed.form, InteractionForm::Ask);
-                assert_eq!(completed.result_text, "done");
+                // Parent notification includes the query for context (issue #274)
+                assert_eq!(completed.result_text, "[Ask] \"ship it\" → done");
                 assert!(completed.parent_id.is_some());
             }
             other => panic!("Expected InteractionCompleted, got {:?}", other),
@@ -1800,7 +1802,10 @@ mod tests {
             interaction_id: None,
             form: InteractionForm::Agent,
             query: "do something".to_string(),
-            result_text: Some("done it".to_string()),
+            result: Some(InteractionResult::AgentResult {
+                summary: "done it".to_string(),
+                success: true,
+            }),
         });
 
         // No InteractionCompleted event for inline

--- a/domain/src/interaction/mod.rs
+++ b/domain/src/interaction/mod.rs
@@ -32,8 +32,12 @@
 //! ```
 
 use crate::context::ContextMode;
+use crate::core::string::truncate;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+/// Maximum length of the query summary embedded in parent notifications.
+const PARENT_NOTIFICATION_QUERY_MAX_LEN: usize = 60;
 
 /// Maximum nesting depth for interactions.
 ///
@@ -385,6 +389,34 @@ impl InteractionResult {
             }
         }
     }
+
+    /// Convert to a notification message for the parent interaction's
+    /// conversation view.
+    ///
+    /// Unlike [`to_context_injection`](Self::to_context_injection), this
+    /// includes a summary of the original query so the parent conversation
+    /// shows what the result is answering, e.g. `[Ask] "What is 2+2?" → 4`.
+    pub fn to_parent_notification(&self, query: &str) -> String {
+        let query_summary = truncate(query.trim(), PARENT_NOTIFICATION_QUERY_MAX_LEN);
+        match self {
+            InteractionResult::AskResult { answer } => {
+                format!("[Ask] \"{}\" → {}", query_summary, answer)
+            }
+            InteractionResult::DiscussResult {
+                synthesis,
+                participant_count,
+            } => {
+                format!(
+                    "[Discuss ({} models)] \"{}\" → {}",
+                    participant_count, query_summary, synthesis
+                )
+            }
+            InteractionResult::AgentResult { summary, success } => {
+                let status = if *success { "completed" } else { "failed" };
+                format!("[Agent ({})] \"{}\" → {}", status, query_summary, summary)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -658,6 +690,54 @@ mod tests {
         };
         let injection = result.to_context_injection();
         assert_eq!(injection, "[Ask Result]: The answer is 42.");
+    }
+
+    #[test]
+    fn test_ask_result_to_parent_notification() {
+        let result = InteractionResult::AskResult {
+            answer: "4".to_string(),
+        };
+        assert_eq!(
+            result.to_parent_notification("What is 2+2?"),
+            "[Ask] \"What is 2+2?\" → 4"
+        );
+    }
+
+    #[test]
+    fn test_to_parent_notification_truncates_long_query() {
+        let result = InteractionResult::AskResult {
+            answer: "yes".to_string(),
+        };
+        let long_query = "a".repeat(100);
+        let notification = result.to_parent_notification(&long_query);
+        assert_eq!(
+            notification,
+            format!("[Ask] \"{}...\" → yes", "a".repeat(57))
+        );
+    }
+
+    #[test]
+    fn test_discuss_result_to_parent_notification() {
+        let result = InteractionResult::DiscussResult {
+            synthesis: "Approach A wins.".to_string(),
+            participant_count: 3,
+        };
+        assert_eq!(
+            result.to_parent_notification("Which approach?"),
+            "[Discuss (3 models)] \"Which approach?\" → Approach A wins."
+        );
+    }
+
+    #[test]
+    fn test_agent_result_to_parent_notification() {
+        let result = InteractionResult::AgentResult {
+            summary: "README updated.".to_string(),
+            success: true,
+        };
+        assert_eq!(
+            result.to_parent_notification("Update the README"),
+            "[Agent (completed)] \"Update the README\" → README updated."
+        );
     }
 
     #[test]

--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -92,6 +92,12 @@ impl TuiPresenter {
                     .tabs
                     .active_pane_mut()
                     .set_title_if_empty(&event.query);
+                // Echo the query as a user message so the conversation shows
+                // what the interaction is answering (issue #274). The root
+                // interaction is spawned with an empty query — skip it.
+                if !event.query.is_empty() {
+                    state.push_message_to(event.id, DisplayMessage::user(event.query.clone()));
+                }
             }
             UiEvent::InteractionCompleted(event) => {
                 // Root interaction completions (parent_id = None) are not propagated;
@@ -368,6 +374,55 @@ mod tests {
         assert!(state.show_help);
         let (flash, _) = state.flash_message.expect("flash should be set");
         assert!(!flash.contains(":help"), "flash was: {}", flash);
+    }
+
+    #[test]
+    fn test_interaction_spawned_echoes_query_as_user_message() {
+        use super::super::state::MessageRole;
+        use quorum_application::InteractionSpawnedEvent;
+        use quorum_domain::interaction::{InteractionForm, InteractionId};
+
+        let (presenter, _rx, mut state) = setup();
+        presenter.apply(
+            &mut state,
+            &UiEvent::InteractionSpawned(InteractionSpawnedEvent {
+                id: InteractionId(1),
+                form: InteractionForm::Ask,
+                parent_id: Some(InteractionId(0)),
+                query: "What is 2+2?".into(),
+            }),
+        );
+
+        let pane = state
+            .tabs
+            .pane_for_interaction_mut(InteractionId(1))
+            .expect("spawned pane missing");
+        assert_eq!(pane.conversation.messages.len(), 1);
+        assert_eq!(pane.conversation.messages[0].role, MessageRole::User);
+        assert_eq!(pane.conversation.messages[0].content, "What is 2+2?");
+    }
+
+    #[test]
+    fn test_interaction_spawned_with_empty_query_does_not_echo() {
+        use quorum_application::InteractionSpawnedEvent;
+        use quorum_domain::interaction::{InteractionForm, InteractionId};
+
+        let (presenter, _rx, mut state) = setup();
+        presenter.apply(
+            &mut state,
+            &UiEvent::InteractionSpawned(InteractionSpawnedEvent {
+                id: InteractionId(0),
+                form: InteractionForm::Agent,
+                parent_id: None,
+                query: String::new(),
+            }),
+        );
+
+        let pane = state
+            .tabs
+            .pane_for_interaction_mut(InteractionId(0))
+            .expect("root pane missing");
+        assert!(pane.conversation.messages.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`:ask` の会話表示の 2 つの UX 問題を修正:

1. **質問文が Ask タブに表示されない** — `InteractionSpawned` 受信時に query を user メッセージとして spawn 先タブへ echo するように。会話を見返したとき何への回答か分かるようになった(root interaction の空 query はスキップ)
2. **結果が親タブに `[Ask Result]: 4` と文脈なしで混入** — 親タブ通知を質問の要約付きの `[Ask] "What is 2+2?" → 4` 形式に変更(query は 60 字で切り詰め)

**修正後の見え方:**

```
Ask タブ:                        親 Agent タブ:
  You:    What is 2+2?            System: [Ask] "What is 2+2?" → 4
  System: Ask starting...
  Agent:  4
```

**レイヤー別の変更(垂直分割):**

| レイヤー | 変更 |
|---|---|
| domain | `InteractionResult::to_parent_notification(query)` を追加(`to_context_injection` と同居) |
| application | `TaskCompletion` が `result_text: Option<String>` ではなくドメインの `InteractionResult` を保持し、履歴用(`to_context_injection`)と親タブ通知用(`to_parent_notification`)を `finalize` で使い分け |
| presentation | `TuiPresenter` の `InteractionSpawned` ハンドラで query を user メッセージとして echo |

Ask 固有の対応ではなく Discuss / Agent の spawn にも同様に適用される。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] feat | `feature` | minor | 新機能 |
| - [ ] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #274

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた（該当なし）

## Additional Notes

- テスト追加: domain 4 本(`to_parent_notification` の各 variant + query truncate)、presenter 2 本(echo あり / 空 query スキップ)。既存の `finalize` テスト 2 本を新形式に更新
- `TaskCompletion` の文字列化をドメイン境界(`finalize`)へ寄せたため、application 層はドメインオブジェクトをそのまま運ぶ形になった
- #119(ask/discuss 再設計)の入力としても参照可

🤖 Generated with [Claude Code](https://claude.com/claude-code)