### PR TITLE
fix(tui): HiL モーダル表示中も会話ペインをスクロール可能に

### DIFF
--- a/presentation/src/tui/app_hil.rs
+++ b/presentation/src/tui/app_hil.rs
@@ -49,24 +49,47 @@ pub(super) fn handle_hil_request(
 }
 
 /// Handle key press while HiL modal is shown.
+///
+/// Decision keys (y/n/Esc) answer the prompt. All other keys are resolved
+/// through the Normal-mode keymap and scroll actions are delegated to the
+/// conversation pane, so the user can read the Quorum review feedback
+/// behind the modal before deciding (#269).
 pub(super) fn handle_hil_key(
     state: &mut TuiState,
     pending_hil_tx: &Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>>,
     key: crossterm::event::KeyEvent,
 ) {
+    use super::mode::{self, InputMode, KeyAction};
     use crossterm::event::KeyCode;
     match key.code {
         KeyCode::Char('y') | KeyCode::Char('Y') => {
+            state.pending_key = None;
             state.hil_prompt = None;
             state.set_flash("Plan approved");
             send_hil_response(pending_hil_tx, HumanDecision::Approve);
         }
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            state.pending_key = None;
             state.hil_prompt = None;
             state.set_flash("Plan rejected");
             send_hil_response(pending_hil_tx, HumanDecision::Reject);
         }
-        _ => {}
+        _ => {
+            // Delegate scroll keys (j/k/gg/G/arrows) to the conversation pane.
+            let action = mode::handle_key_event(InputMode::Normal, key, state.pending_key);
+            if let KeyAction::PendingKey(c) = action {
+                state.pending_key = Some(c);
+                return;
+            }
+            state.pending_key = None;
+            match action {
+                KeyAction::ScrollUp => state.scroll_up(),
+                KeyAction::ScrollDown => state.scroll_down(),
+                KeyAction::ScrollToTop => state.scroll_to_top(),
+                KeyAction::ScrollToBottom => state.scroll_to_bottom(),
+                _ => {}
+            }
+        }
     }
 }
 
@@ -77,5 +100,115 @@ fn send_hil_response(
 ) {
     if let Some(tx) = pending_hil_tx.lock().unwrap().take() {
         let _ = tx.send(decision);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn state_with_modal() -> TuiState {
+        let mut state = TuiState::new();
+        state.hil_prompt = Some(HilPrompt {
+            title: "Plan Requires Human Intervention".into(),
+            objective: "Test objective".into(),
+            tasks: vec!["task 1".into()],
+            message: "Approve or reject?".into(),
+        });
+        state
+    }
+
+    fn hil_tx() -> Arc<Mutex<Option<oneshot::Sender<HumanDecision>>>> {
+        let (tx, _rx) = oneshot::channel();
+        Arc::new(Mutex::new(Some(tx)))
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn scroll_keys_delegate_to_conversation_while_modal_shown() {
+        let mut state = state_with_modal();
+        let tx = hil_tx();
+
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('k')));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 1);
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('k')));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 2);
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('j')));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 1);
+
+        // Arrow keys work too
+        handle_hil_key(&mut state, &tx, key(KeyCode::Up));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 2);
+        handle_hil_key(&mut state, &tx, key(KeyCode::Down));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 1);
+
+        // Modal stays open, no decision consumed
+        assert!(state.hil_prompt.is_some());
+        assert!(tx.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn gg_scrolls_to_top_and_g_scrolls_to_bottom() {
+        let mut state = state_with_modal();
+        let tx = hil_tx();
+
+        // gg → scroll to top (via pending key)
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('g')));
+        assert_eq!(state.pending_key, Some('g'));
+        assert!(state.hil_prompt.is_some());
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('g')));
+        assert_eq!(state.pending_key, None);
+        assert_eq!(
+            state.tabs.active_pane().conversation.scroll_offset,
+            usize::MAX
+        );
+
+        // G → scroll to bottom
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('G')));
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 0);
+
+        assert!(state.hil_prompt.is_some());
+        assert!(tx.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn decision_keys_still_answer_the_prompt() {
+        let mut state = state_with_modal();
+        let (tx, rx) = oneshot::channel();
+        let tx = Arc::new(Mutex::new(Some(tx)));
+
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('y')));
+        assert!(state.hil_prompt.is_none());
+        assert!(tx.lock().unwrap().is_none());
+        assert!(matches!(rx.blocking_recv(), Ok(HumanDecision::Approve)));
+    }
+
+    #[test]
+    fn decision_key_clears_stale_pending_key() {
+        let mut state = state_with_modal();
+        let tx = hil_tx();
+
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('g')));
+        assert_eq!(state.pending_key, Some('g'));
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('n')));
+        assert_eq!(state.pending_key, None);
+        assert!(state.hil_prompt.is_none());
+    }
+
+    #[test]
+    fn non_scroll_keys_do_not_leak_into_other_actions() {
+        let mut state = state_with_modal();
+        let tx = hil_tx();
+
+        // `i` would enter Insert mode in Normal mode — must be ignored here
+        let mode_before = state.mode;
+        handle_hil_key(&mut state, &tx, key(KeyCode::Char('i')));
+        assert_eq!(state.mode, mode_before);
+        assert!(state.hil_prompt.is_some());
+        assert!(tx.lock().unwrap().is_some());
     }
 }

--- a/presentation/src/tui/app_render.rs
+++ b/presentation/src/tui/app_render.rs
@@ -207,7 +207,7 @@ fn render_hil_modal(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, sta
     lines.push(Line::from(&*hil.message));
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        "y: approve  n: reject  Esc: reject",
+        "y: approve  n: reject  Esc: reject  j/k: scroll conversation",
         Style::default().fg(Color::DarkGray),
     )));
 

--- a/presentation/src/tui/remote.rs
+++ b/presentation/src/tui/remote.rs
@@ -998,6 +998,46 @@ mod tests {
         assert!(state.show_help);
     }
 
+    /// Regression test for #269 — mirrors the issue's repro steps:
+    /// HiL modal shown → `keys.feed` j/k → `state.get` scroll_offset must change.
+    #[test]
+    fn keys_feed_scrolls_conversation_while_hil_modal_shown() {
+        let harness = TestHarness::new();
+        let mut state = TuiState::new();
+        state.mode = InputMode::Normal;
+        state.hil_prompt = Some(super::super::state::HilPrompt {
+            title: "Plan Requires Human Intervention".into(),
+            objective: "obj".into(),
+            tasks: vec!["task".into()],
+            message: "Approve or reject?".into(),
+        });
+        let (tx, _rx) = oneshot::channel();
+        *harness.pending_hil_tx.lock().unwrap() = Some(tx);
+
+        dispatch(
+            &mut state,
+            &harness.ctx(),
+            "keys.feed",
+            &json!({"keys": ["k", "k", "j"]}),
+        )
+        .unwrap();
+        assert_eq!(state.tabs.active_pane().conversation.scroll_offset, 1);
+        // Modal still pending — scrolling must not answer the prompt
+        assert!(state.hil_prompt.is_some());
+        assert!(harness.pending_hil_tx.lock().unwrap().is_some());
+
+        // Decision keys still work after scrolling
+        dispatch(
+            &mut state,
+            &harness.ctx(),
+            "keys.feed",
+            &json!({"keys": ["y"]}),
+        )
+        .unwrap();
+        assert!(state.hil_prompt.is_none());
+        assert!(harness.pending_hil_tx.lock().unwrap().is_none());
+    }
+
     #[test]
     fn keys_feed_invalid_descriptor_is_atomic() {
         let harness = TestHarness::new();


### PR DESCRIPTION
## Summary

HiL モーダル(Human Intervention)表示中、y/n/Esc 以外のキーが全て破棄されていたため、モーダル背後の Quorum レビューフィードバックを読めないまま承認判断を迫られる問題を修正しました。

**原因**: `dispatch_terminal_event` はモーダル表示中に全キーを `handle_hil_key` に渡しますが、`handle_hil_key` の `_ => {}` が y/n/Esc 以外を握りつぶしていました。

**修正** (Issue の期待動作オプション1「y/n/Esc 以外のキーをペインに委譲」を採用):

- y/n/Esc 以外のキーを Normal モードのキーマップ (`mode::handle_key_event`) で解決し、スクロール系アクション (`j`/`k`/矢印/`gg`/`G`) のみ会話ペインに委譲
- `gg` の pending key 処理に対応、決定キー押下時は pending をクリア
- モード遷移などの非スクロールアクションはモーダル中は引き続き無視(安全性を維持)
- モーダルフッターに `j/k: scroll conversation` ヒントを追加

**テスト**:
- `app_hil.rs`: スクロール委譲・`gg`/`G`・決定キー・非スクロールキー無視のユニットテスト 5 件
- `remote.rs`: Issue の再現手順 (`keys.feed` → `scroll_offset` 確認) をミラーした回帰テスト 1 件

変更は presentation 層のみに閉じており、domain / application への影響はありません。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #269

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない(既存の `widgets/mod.rs` の warning 1 件は本 PR と無関係)
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた(該当なし)

## Additional Notes

Issue の期待動作にはオプション2「モーダル内に Quorum レビュー要約を表示」もありますが、本 PR はスコープを絞りオプション1のみ実装しています。オプション2は #204 (ツール単位の承認 UI) と合わせて別途検討するのが良さそうです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)