### PR TITLE
fix(tui): 起動直後の入力欄にスペースが混入する問題を修正 — 修飾キー付き文字をテキスト挿入しない

### DIFF
--- a/presentation/src/tui/mode.rs
+++ b/presentation/src/tui/mode.rs
@@ -369,6 +369,21 @@ fn handle_visual(key: KeyEvent) -> KeyAction {
     }
 }
 
+/// Whether a `Char` key event is genuine text input.
+///
+/// Control chords are never text: the legacy terminal encoding maps NUL
+/// (0x00) to Ctrl+Space, which crossterm parses as `Char(' ')` + CONTROL.
+/// Headless ptys can deliver a stray NUL at startup, which without this
+/// guard shows up as a space in the input buffer (#270). Ctrl+Space on a
+/// real terminal (e.g. IME toggle leaking through) hits the same path.
+/// SHIFT stays allowed (uppercase letters), and so does ALT (Alt+Enter is
+/// matched explicitly before the `Char` arms).
+fn is_text_input(key: &KeyEvent) -> bool {
+    !key.modifiers.intersects(
+        KeyModifiers::CONTROL | KeyModifiers::SUPER | KeyModifiers::HYPER | KeyModifiers::META,
+    )
+}
+
 fn handle_insert(key: KeyEvent) -> KeyAction {
     match key.code {
         KeyCode::Esc => KeyAction::ExitToNormal,
@@ -386,7 +401,7 @@ fn handle_insert(key: KeyEvent) -> KeyAction {
         KeyCode::Right => KeyAction::CursorRight,
         KeyCode::Home => KeyAction::CursorHome,
         KeyCode::End => KeyAction::CursorEnd,
-        KeyCode::Char(c) => KeyAction::InsertChar(c),
+        KeyCode::Char(c) if is_text_input(&key) => KeyAction::InsertChar(c),
         _ => KeyAction::None,
     }
 }
@@ -400,7 +415,7 @@ fn handle_command(key: KeyEvent) -> KeyAction {
         KeyCode::Right => KeyAction::CursorRight,
         KeyCode::Home => KeyAction::CursorHome,
         KeyCode::End => KeyAction::CursorEnd,
-        KeyCode::Char(c) => KeyAction::InsertChar(c),
+        KeyCode::Char(c) if is_text_input(&key) => KeyAction::InsertChar(c),
         _ => KeyAction::None,
     }
 }
@@ -500,6 +515,42 @@ mod tests {
         assert_eq!(
             handle_key_event(InputMode::Insert, key, None),
             KeyAction::InsertChar('[')
+        );
+    }
+
+    #[test]
+    fn test_ctrl_space_does_not_insert() {
+        // NUL (0x00) is the legacy encoding of Ctrl+Space; crossterm parses
+        // it as Char(' ') + CONTROL. Headless ptys can deliver a stray NUL
+        // at startup — it must not become a space in the input (#270).
+        let key = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::CONTROL);
+        for mode in [InputMode::Insert, InputMode::Command] {
+            assert_eq!(
+                handle_key_event(mode, key, None),
+                KeyAction::None,
+                "Ctrl+Space must not insert text in {:?}",
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn test_control_modified_char_does_not_insert() {
+        // Control chords are commands, not text (Vim behavior)
+        let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        for mode in [InputMode::Insert, InputMode::Command] {
+            assert_eq!(handle_key_event(mode, key, None), KeyAction::None);
+        }
+    }
+
+    #[test]
+    fn test_shifted_char_still_inserts() {
+        // Uppercase letters arrive with SHIFT under kitty protocol —
+        // they must still be treated as text input
+        let key = KeyEvent::new(KeyCode::Char('X'), KeyModifiers::SHIFT);
+        assert_eq!(
+            handle_key_event(InputMode::Insert, key, None),
+            KeyAction::InsertChar('X')
         );
     }
 


### PR DESCRIPTION
## [optional body]

### 概要

TUI 起動直後、入力欄に半角スペースが1文字入った状態(`input: " "`, `cursor_pos: 1`)になる問題(#270)の修正。

### 原因

- ヘッドレス pty(`script` コマンド等)では起動時に stdin へ NUL バイト(`0x00`)が届くことがある(strace で `read(0, "\0", 1024) = 1` を確認)
- crossterm は legacy 端末エンコーディングに従って NUL を **Ctrl+Space**(`KeyCode::Char(' ')` + `KeyModifiers::CONTROL`)としてパースする
- Insert モードの `KeyCode::Char(c)` アームが modifier を無視して `InsertChar(c)` を返していたため、Ctrl+Space がスペースとして挿入されていた

### 対処

`presentation/src/tui/mode.rs` に `is_text_input()` ガードを追加し、Insert / Command モードで CONTROL / SUPER / HYPER / META 付きの `Char` イベントをテキスト入力として扱わないようにした。

- SHIFT は許可維持(kitty protocol では大文字に SHIFT が付く)
- ALT も許可維持(Alt+Enter は既存の明示マッチで先に処理される)
- Ctrl+C(Quit)/ Ctrl+[(Esc)は `handle_key_event` 冒頭で先に処理されるため影響なし
- Lua カスタムキーマップ(`quorum.keymap.set`)はこのガードより前に lookup されるため、Ctrl+Space 等へのバインドは引き続き可能

副次効果として、実端末で Ctrl+Space(IME 切り替え等でよく押されるキー)がスペースとして挿入される問題も解消。

### 検証

- Issue の再現手順(`script` + `--listen` + `state.get`)で修正前 `input: " "` を再現 → 修正後 **3/3 回 `input: ""` / `cursor_pos: 0`** を確認
- `input.send` による通常の入力送信が引き続き動作することを確認
- `cargo build` 成功 / `cargo test --workspace` 全9スイートパス(テスト3本追加)

### アーキテクチャ

presentation 層のキー→アクション変換(`mode.rs`)内で完結。他層への変更なし。

## [optional footer(s)]

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)