### PR TITLE
fix(agent): 最終回答への生 JSON ツールコール漏出を防止 — リーク検知 + nudge リトライ

### DIFF
--- a/application/src/use_cases/execute_task.rs
+++ b/application/src/use_cases/execute_task.rs
@@ -17,7 +17,9 @@ use quorum_domain::agent::model_config::ModelConfig;
 use quorum_domain::context::context_budget::ContextBudget;
 use quorum_domain::context::task_result_buffer::TaskResultBuffer;
 use quorum_domain::util::truncate_str;
-use quorum_domain::{AgentPromptTemplate, AgentState, Model, Task, TaskId, ToolExecution};
+use quorum_domain::{
+    AgentPromptTemplate, AgentState, Model, Task, TaskId, ToolExecution, looks_like_tool_call_json,
+};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -426,6 +428,9 @@ impl ExecuteTaskUseCase {
             .all_tools_schema(self.tool_executor.tool_spec());
         let max_turns = input.execution.max_tool_turns;
         let mut turn_count = 0;
+        // Retry budget for text-only / leaked-tool-call responses (#268)
+        const MAX_TOOL_NUDGES: usize = 2;
+        let mut nudge_count = 0;
         let mut all_outputs = Vec::new();
         let mut all_executions: Vec<ToolExecution> = Vec::new();
         let mut exec_counter: usize = 0;
@@ -463,27 +468,51 @@ impl ExecuteTaskUseCase {
                         "text": text,
                     }),
                 ));
-                all_outputs.push(text);
             }
 
             // Extract tool calls
             let tool_calls = response.tool_calls();
 
             if tool_calls.is_empty() {
-                // Tool specified but LLM responded with text only → retry once with nudge
-                if task.tool_name.is_some() && turn_count == 0 {
-                    warn!(
-                        "Task {}: expected tool '{}' but got text-only response, retrying with nudge",
-                        task.id,
-                        task.tool_name.as_deref().unwrap_or("?")
-                    );
-                    turn_count += 1;
+                // Detect a tool call the LLM wrote as raw JSON text instead of
+                // actually invoking it via the Native Tool Use API (#268).
+                let tool_call_leak = !text.is_empty()
+                    && looks_like_tool_call_json(&text, self.tool_executor.tool_spec());
 
-                    let nudge = format!(
-                        "You responded with text only, but this task REQUIRES calling `{}`. \
-                         Call the tool NOW. Do not respond with text.",
-                        task.tool_name.as_deref().unwrap_or("?")
+                // Text-only response where a tool was expected, or a leaked
+                // tool-call JSON → retry with a nudge. Leaked JSON is dropped
+                // from the output; ordinary text-only responses are kept.
+                let expected_tool = task.tool_name.is_some() && turn_count == 0;
+                if (tool_call_leak || expected_tool) && nudge_count < MAX_TOOL_NUDGES {
+                    if !tool_call_leak && !text.is_empty() {
+                        all_outputs.push(text.clone());
+                    }
+                    nudge_count += 1;
+                    turn_count += 1;
+                    warn!(
+                        "Task {}: {} (nudge {}/{})",
+                        task.id,
+                        if tool_call_leak {
+                            "LLM emitted a tool call as JSON text instead of invoking it"
+                        } else {
+                            "expected a tool call but got text-only response"
+                        },
+                        nudge_count,
+                        MAX_TOOL_NUDGES,
                     );
+
+                    let nudge = if tool_call_leak {
+                        "You wrote a tool invocation as JSON text instead of calling \
+                         the tool. Do NOT print JSON. Invoke the tool NOW using the \
+                         native tool-calling mechanism, then answer in natural language."
+                            .to_string()
+                    } else {
+                        format!(
+                            "You responded with text only, but this task REQUIRES calling `{}`. \
+                             Call the tool NOW. Do not respond with text.",
+                            task.tool_name.as_deref().unwrap_or("?")
+                        )
+                    };
                     self.conversation_logger.log(ConversationEvent::new(
                         "llm_prompt",
                         serde_json::json!({
@@ -492,6 +521,7 @@ impl ExecuteTaskUseCase {
                             "bytes": nudge.len(),
                             "text": nudge,
                             "nudge": true,
+                            "tool_call_leak": tool_call_leak,
                         }),
                     ));
                     response = match send_with_tools_cancellable(
@@ -504,16 +534,53 @@ impl ExecuteTaskUseCase {
                     .await
                     {
                         Ok(r) => r,
-                        Err(_) => break, // nudge failed — keep original text
+                        // Nudge failed — keep already-collected output
+                        // (leaked JSON was never pushed, so it cannot surface)
+                        Err(_) => break,
                     };
                     continue;
                 }
 
+                if tool_call_leak {
+                    // Nudge budget exhausted — suppress the raw JSON so it never
+                    // reaches the user as the final answer (#268).
+                    warn!(
+                        "Task {}: suppressing leaked tool-call JSON from output ({} bytes)",
+                        task.id,
+                        text.len()
+                    );
+                    self.conversation_logger.log(ConversationEvent::new(
+                        "tool_call_leak_suppressed",
+                        serde_json::json!({
+                            "task_id": task_id_str,
+                            "model": session.model().to_string(),
+                            "bytes": text.len(),
+                            "text": text,
+                        }),
+                    ));
+                    if all_outputs.is_empty() {
+                        return Err(RunAgentError::TaskExecutionFailed(
+                            "LLM returned a raw tool-call JSON instead of executing the tool \
+                             (retries exhausted)"
+                                .to_string(),
+                        ));
+                    }
+                    break;
+                }
+
+                if !text.is_empty() {
+                    all_outputs.push(text);
+                }
                 debug!(
                     "Task {}: no tool calls in response, ending execution loop",
                     task.id
                 );
                 break;
+            }
+
+            // Turn has tool calls — keep any accompanying text
+            if !text.is_empty() {
+                all_outputs.push(text);
             }
 
             // Check turn limit
@@ -952,5 +1019,348 @@ mod tests {
         let output = "\n\n  No matches found in .rs files\nSome other info";
         let brief = extract_task_brief(output, 150);
         assert_eq!(brief.unwrap(), "No matches found in .rs files");
+    }
+
+    // ==================== Tool-call leak tests (#268) ====================
+
+    use crate::config::ExecutionParams;
+    use crate::ports::conversation_logger::NoConversationLogger;
+    use crate::ports::llm_gateway::GatewayError;
+    use async_trait::async_trait;
+    use quorum_domain::session::response::{ContentBlock, LlmResponse, StopReason};
+    use quorum_domain::tool::entities::{
+        RiskLevel, ToolCall, ToolDefinition, ToolParameter, ToolSpec,
+    };
+    use quorum_domain::tool::value_objects::ToolResult;
+    use quorum_domain::{AgentPolicy, ConsensusLevel, PhaseScope, Plan, SessionMode};
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Mutex;
+
+    /// Session that pops pre-scripted responses in order.
+    struct QueueSession {
+        model: Model,
+        responses: Arc<Mutex<VecDeque<LlmResponse>>>,
+    }
+
+    impl QueueSession {
+        fn pop(&self) -> LlmResponse {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| LlmResponse::from_text("(exhausted)"))
+        }
+    }
+
+    #[async_trait]
+    impl LlmSession for QueueSession {
+        fn model(&self) -> &Model {
+            &self.model
+        }
+
+        async fn send(&self, _content: &str) -> Result<String, GatewayError> {
+            Ok(self.pop().text_content())
+        }
+
+        async fn send_with_tools(
+            &self,
+            _content: &str,
+            _tools: &[serde_json::Value],
+        ) -> Result<LlmResponse, GatewayError> {
+            Ok(self.pop())
+        }
+
+        async fn send_tool_results(
+            &self,
+            _results: &[ToolResultMessage],
+        ) -> Result<LlmResponse, GatewayError> {
+            Ok(self.pop())
+        }
+    }
+
+    struct QueueGateway {
+        responses: Arc<Mutex<VecDeque<LlmResponse>>>,
+    }
+
+    #[async_trait]
+    impl LlmGateway for QueueGateway {
+        async fn create_session(&self, model: &Model) -> Result<Box<dyn LlmSession>, GatewayError> {
+            Ok(Box::new(QueueSession {
+                model: model.clone(),
+                responses: self.responses.clone(),
+            }))
+        }
+
+        async fn create_session_with_system_prompt(
+            &self,
+            model: &Model,
+            _system_prompt: &str,
+        ) -> Result<Box<dyn LlmSession>, GatewayError> {
+            self.create_session(model).await
+        }
+
+        async fn available_models(&self) -> Result<Vec<Model>, GatewayError> {
+            Ok(vec![])
+        }
+    }
+
+    /// Executor whose spec has `run_command` (required param `command`),
+    /// matching the #268 reproduction. Records executed tool names.
+    struct RecordingToolExecutor {
+        spec: ToolSpec,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl RecordingToolExecutor {
+        fn new() -> Self {
+            Self {
+                spec: ToolSpec::new().register(
+                    ToolDefinition::new("run_command", "Run a shell command", RiskLevel::High)
+                        .with_parameter(ToolParameter::new("command", "Command to run", true)),
+                ),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ToolExecutorPort for RecordingToolExecutor {
+        fn tool_spec(&self) -> &ToolSpec {
+            &self.spec
+        }
+
+        async fn execute(&self, call: &ToolCall) -> ToolResult {
+            self.calls.lock().unwrap().push(call.tool_name.clone());
+            ToolResult::success(&call.tool_name, "ok")
+        }
+
+        fn execute_sync(&self, call: &ToolCall) -> ToolResult {
+            self.calls.lock().unwrap().push(call.tool_name.clone());
+            ToolResult::success(&call.tool_name, "ok")
+        }
+    }
+
+    struct StubToolSchema;
+
+    impl ToolSchemaPort for StubToolSchema {
+        fn tool_to_schema(&self, tool: &ToolDefinition) -> serde_json::Value {
+            serde_json::json!({ "name": tool.name })
+        }
+
+        fn all_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value> {
+            spec.all().map(|t| self.tool_to_schema(t)).collect()
+        }
+
+        fn low_risk_tools_schema(&self, spec: &ToolSpec) -> Vec<serde_json::Value> {
+            spec.low_risk_tools()
+                .map(|t| self.tool_to_schema(t))
+                .collect()
+        }
+    }
+
+    /// Reviewer that treats everything as low-risk (no review round-trips).
+    struct LowRiskReviewer;
+
+    #[async_trait]
+    impl ActionReviewer for LowRiskReviewer {
+        async fn review_action(
+            &self,
+            _tool_call_json: &str,
+            _task: &Task,
+            _state: &AgentState,
+            _models: &ModelConfig,
+            _progress: &dyn AgentProgressNotifier,
+        ) -> Result<ReviewDecision, RunAgentError> {
+            Ok(ReviewDecision::SkipReview)
+        }
+
+        fn is_high_risk_tool(
+            &self,
+            _tool_name: &str,
+            _arguments: &HashMap<String, serde_json::Value>,
+        ) -> bool {
+            false
+        }
+    }
+
+    struct NoopProgress;
+    impl AgentProgressNotifier for NoopProgress {}
+
+    fn make_use_case(
+        responses: Vec<LlmResponse>,
+        executor: Arc<RecordingToolExecutor>,
+    ) -> ExecuteTaskUseCase {
+        let gateway = Arc::new(QueueGateway {
+            responses: Arc::new(Mutex::new(responses.into())),
+        });
+        ExecuteTaskUseCase::new(
+            gateway,
+            executor,
+            Arc::new(StubToolSchema),
+            None,
+            Arc::new(LowRiskReviewer),
+            Arc::new(NoConversationLogger),
+        )
+    }
+
+    fn test_input() -> RunAgentInput {
+        RunAgentInput::new(
+            "List the crates in this workspace",
+            SessionMode {
+                consensus_level: ConsensusLevel::Solo,
+                phase_scope: PhaseScope::Fast,
+                strategy: Default::default(),
+            },
+            ModelConfig::default(),
+            AgentPolicy::default(),
+            ExecutionParams {
+                max_iterations: 10,
+                max_tool_turns: 5,
+                max_tool_retries: 2,
+                working_dir: None,
+                ensemble_session_timeout: None,
+                context_budget: ContextBudget::default(),
+            },
+        )
+    }
+
+    fn test_state(input: &RunAgentInput, task: Task) -> AgentState {
+        let mut state = input.to_agent_state("agent-test");
+        let mut plan = Plan::new("List workspace crates", "test");
+        plan.add_task(task);
+        state.set_plan(plan);
+        state
+    }
+
+    /// The exact leak shape from the #268 reproduction.
+    fn leak_response() -> LlmResponse {
+        LlmResponse::from_text(
+            "```json\n{\n  \"command\": \"cargo metadata --no-deps --format-version 1\"\n}\n```",
+        )
+    }
+
+    fn tool_use_response() -> LlmResponse {
+        let mut arguments = HashMap::new();
+        arguments.insert("command".to_string(), serde_json::json!("ls"));
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "toolu_1".to_string(),
+                name: "run_command".to_string(),
+                input: arguments,
+            }],
+            stop_reason: Some(StopReason::ToolUse),
+            model: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn leaked_tool_call_json_is_nudged_into_real_tool_call() {
+        let executor = Arc::new(RecordingToolExecutor::new());
+        let use_case = make_use_case(
+            vec![
+                leak_response(),     // turn 0: JSON as text → nudge
+                tool_use_response(), // nudge response: actual tool call
+                LlmResponse::from_text("The workspace has 5 crates."),
+            ],
+            executor.clone(),
+        );
+        let input = test_input();
+        let mut state = test_state(&input, Task::new("1", "List crates"));
+
+        let summary = use_case
+            .execute(&input, &mut state, "system", &NoopProgress)
+            .await
+            .expect("should succeed");
+
+        assert!(summary.contains("Completed 1/1"), "summary: {}", summary);
+        assert!(summary.contains("The workspace has 5 crates."));
+        assert!(
+            !summary.contains("cargo metadata"),
+            "leaked JSON must not surface: {}",
+            summary
+        );
+        assert_eq!(
+            executor.calls.lock().unwrap().as_slice(),
+            &["run_command".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn leaked_json_fails_task_when_nudges_exhausted() {
+        let executor = Arc::new(RecordingToolExecutor::new());
+        let use_case = make_use_case(
+            vec![leak_response(), leak_response(), leak_response()],
+            executor.clone(),
+        );
+        let input = test_input();
+        let mut state = test_state(&input, Task::new("1", "List crates"));
+
+        let summary = use_case
+            .execute(&input, &mut state, "system", &NoopProgress)
+            .await
+            .expect("execute() itself should not fail");
+
+        // Task fails, but the raw JSON never surfaces
+        assert!(summary.contains("FAILED"), "summary: {}", summary);
+        assert!(
+            !summary.contains("cargo metadata"),
+            "leaked JSON must not surface: {}",
+            summary
+        );
+        assert!(executor.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn leak_after_tool_turn_is_suppressed_but_earlier_output_kept() {
+        let executor = Arc::new(RecordingToolExecutor::new());
+        let use_case = make_use_case(
+            vec![
+                tool_use_response(), // turn 1: real tool call
+                leak_response(),     // after tool result: leak → nudge
+                leak_response(),     // still leaking → nudge
+                leak_response(),     // budget exhausted → suppress
+            ],
+            executor.clone(),
+        );
+        let input = test_input();
+        let mut state = test_state(&input, Task::new("1", "List crates"));
+
+        let summary = use_case
+            .execute(&input, &mut state, "system", &NoopProgress)
+            .await
+            .expect("should succeed");
+
+        // Tool output is kept; the trailing leak is dropped
+        assert!(summary.contains("OK"), "summary: {}", summary);
+        assert!(
+            !summary.contains("cargo metadata"),
+            "leaked JSON must not surface: {}",
+            summary
+        );
+        let task = &state.plan.as_ref().unwrap().tasks[0];
+        let output = task.result.as_ref().unwrap().output.clone();
+        assert!(output.contains("[run_command]: ok"), "output: {}", output);
+        assert!(!output.contains("cargo metadata"), "output: {}", output);
+    }
+
+    #[tokio::test]
+    async fn plain_text_answer_is_kept_as_before() {
+        let executor = Arc::new(RecordingToolExecutor::new());
+        let use_case = make_use_case(
+            vec![LlmResponse::from_text(
+                "The workspace contains 5 crates: domain, application, ...",
+            )],
+            executor.clone(),
+        );
+        let input = test_input();
+        let mut state = test_state(&input, Task::new("1", "List crates"));
+
+        let summary = use_case
+            .execute(&input, &mut state, "system", &NoopProgress)
+            .await
+            .expect("should succeed");
+
+        assert!(summary.contains("Completed 1/1"), "summary: {}", summary);
+        assert!(summary.contains("The workspace contains 5 crates"));
     }
 }

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -74,6 +74,7 @@ pub use session::{
     stream::StreamEvent,
 };
 pub use tool::{
+    detection::looks_like_tool_call_json,
     entities::{
         RiskLevel, ToolCall, ToolDefinition, ToolParameter, ToolSpec, classify_command_risk,
     },

--- a/domain/src/tool/detection.rs
+++ b/domain/src/tool/detection.rs
@@ -1,0 +1,231 @@
+//! Tool-call leak detection
+//!
+//! LLMs sometimes emit a tool invocation as *plain JSON text* instead of
+//! calling the tool through the Native Tool Use API (#268). When that text
+//! is treated as a normal answer, raw internal JSON leaks into the final
+//! response shown to the user.
+//!
+//! [`looks_like_tool_call_json`] is a pure domain heuristic that detects
+//! such responses so the application layer can retry (nudge) or suppress
+//! them instead of surfacing them verbatim.
+
+use super::entities::ToolSpec;
+
+/// Keys an LLM typically uses when writing a tool call as a JSON envelope,
+/// e.g. `{"tool": "run_command", "args": {...}}`.
+const TOOL_NAME_KEYS: &[&str] = &["tool", "tool_name", "name"];
+
+/// Check whether a text response is a *raw tool call written as JSON*
+/// rather than a natural-language answer.
+///
+/// The check is intentionally conservative: it only fires when the **entire**
+/// response (after stripping an optional Markdown code fence) parses as a
+/// single JSON object that matches one of two shapes:
+///
+/// 1. **Envelope shape** — the object names a registered tool via a
+///    `tool` / `tool_name` / `name` key:
+///    `{"tool": "run_command", "args": {"command": "ls"}}`
+/// 2. **Bare-arguments shape** — every top-level key matches a parameter of
+///    some registered tool, and all of that tool's required parameters are
+///    present: `{"command": "cargo metadata --no-deps"}`
+///
+/// Answers that merely *contain* JSON alongside prose are never flagged.
+///
+/// # Examples
+///
+/// ```
+/// use quorum_domain::tool::entities::{ToolSpec, ToolDefinition, ToolParameter, RiskLevel};
+/// use quorum_domain::tool::detection::looks_like_tool_call_json;
+///
+/// let spec = ToolSpec::new().register(
+///     ToolDefinition::new("run_command", "Run a shell command", RiskLevel::High)
+///         .with_parameter(ToolParameter::new("command", "Command to run", true)),
+/// );
+///
+/// assert!(looks_like_tool_call_json("{\"command\": \"ls -la\"}", &spec));
+/// assert!(looks_like_tool_call_json("```json\n{\"command\": \"ls\"}\n```", &spec));
+/// assert!(!looks_like_tool_call_json("The workspace has 5 crates.", &spec));
+/// ```
+pub fn looks_like_tool_call_json(text: &str, spec: &ToolSpec) -> bool {
+    let Some(candidate) = extract_json_candidate(text) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(candidate) else {
+        return false;
+    };
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    if obj.is_empty() {
+        return false;
+    }
+
+    // Shape 1: envelope with an explicit tool name key
+    for key in TOOL_NAME_KEYS {
+        if let Some(tool_name) = obj.get(*key).and_then(|v| v.as_str())
+            && spec.get(tool_name).is_some()
+        {
+            return true;
+        }
+    }
+
+    // Shape 2: bare arguments object matching a registered tool's parameters
+    spec.all().any(|tool| {
+        !tool.parameters.is_empty()
+            && obj
+                .keys()
+                .all(|k| tool.parameters.iter().any(|p| p.name == *k))
+            && tool
+                .parameters
+                .iter()
+                .filter(|p| p.required)
+                .all(|p| obj.contains_key(&p.name))
+    })
+}
+
+/// Extract the JSON body if the whole text is a JSON object, optionally
+/// wrapped in a Markdown code fence (```json ... ``` or ``` ... ```).
+///
+/// Returns `None` when the text has prose outside the JSON/fence.
+fn extract_json_candidate(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        // Drop the fence header line (e.g. "json") and require a closing fence
+        let after_header = rest.split_once('\n')?.1;
+        let body = after_header.strip_suffix("```")?.trim();
+        if body.starts_with('{') && body.ends_with('}') {
+            return Some(body);
+        }
+        return None;
+    }
+
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        return Some(trimmed);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::entities::{RiskLevel, ToolDefinition, ToolParameter};
+
+    fn test_spec() -> ToolSpec {
+        ToolSpec::new()
+            .register(
+                ToolDefinition::new("run_command", "Run a shell command", RiskLevel::High)
+                    .with_parameter(ToolParameter::new("command", "Command to run", true)),
+            )
+            .register(
+                ToolDefinition::new("read_file", "Read a file", RiskLevel::Low)
+                    .with_parameter(ToolParameter::new("path", "File path", true))
+                    .with_parameter(ToolParameter::new("max_bytes", "Byte limit", false)),
+            )
+    }
+
+    #[test]
+    fn detects_bare_arguments_object() {
+        let spec = test_spec();
+        assert!(looks_like_tool_call_json(
+            r#"{"command": "cargo metadata --no-deps --format-version 1"}"#,
+            &spec
+        ));
+        assert!(looks_like_tool_call_json(
+            r#"{"path": "src/main.rs"}"#,
+            &spec
+        ));
+    }
+
+    #[test]
+    fn detects_fenced_json_block() {
+        // Reproduction case from #268
+        let spec = test_spec();
+        let text = "```json\n{\n  \"command\": \"cargo metadata --no-deps --format-version 1 | jq -r '.packages'\"\n}\n```";
+        assert!(looks_like_tool_call_json(text, &spec));
+    }
+
+    #[test]
+    fn detects_plain_fence_without_language_tag() {
+        let spec = test_spec();
+        let text = "```\n{\"command\": \"ls\"}\n```";
+        assert!(looks_like_tool_call_json(text, &spec));
+    }
+
+    #[test]
+    fn detects_envelope_shape() {
+        let spec = test_spec();
+        assert!(looks_like_tool_call_json(
+            r#"{"tool": "run_command", "args": {"command": "ls"}}"#,
+            &spec
+        ));
+        assert!(looks_like_tool_call_json(
+            r#"{"tool_name": "read_file", "arguments": {"path": "a.rs"}}"#,
+            &spec
+        ));
+        assert!(looks_like_tool_call_json(
+            r#"{"name": "run_command", "input": {"command": "pwd"}}"#,
+            &spec
+        ));
+    }
+
+    #[test]
+    fn ignores_envelope_with_unknown_tool() {
+        let spec = test_spec();
+        assert!(!looks_like_tool_call_json(
+            r#"{"tool": "no_such_tool", "args": {}}"#,
+            &spec
+        ));
+        // "name" key with a non-tool value is a common data shape, not a call
+        assert!(!looks_like_tool_call_json(
+            r#"{"name": "copilot-quorum", "version": "0.1.0"}"#,
+            &spec
+        ));
+    }
+
+    #[test]
+    fn ignores_natural_language_answers() {
+        let spec = test_spec();
+        assert!(!looks_like_tool_call_json(
+            "The workspace contains 5 crates: domain, application, ...",
+            &spec
+        ));
+        assert!(!looks_like_tool_call_json("", &spec));
+    }
+
+    #[test]
+    fn ignores_json_embedded_in_prose() {
+        let spec = test_spec();
+        let text = "Here is the members list:\n```json\n{\"command\": \"ls\"}\n```\nas requested.";
+        assert!(!looks_like_tool_call_json(text, &spec));
+    }
+
+    #[test]
+    fn ignores_json_not_matching_any_tool() {
+        let spec = test_spec();
+        // Keys don't match any registered tool's parameters
+        assert!(!looks_like_tool_call_json(
+            r#"{"crates": ["quorum-domain", "quorum-application"]}"#,
+            &spec
+        ));
+        // Partial match but missing required parameter
+        assert!(!looks_like_tool_call_json(r#"{"max_bytes": 100}"#, &spec));
+    }
+
+    #[test]
+    fn ignores_empty_object_and_arrays() {
+        let spec = test_spec();
+        assert!(!looks_like_tool_call_json("{}", &spec));
+        assert!(!looks_like_tool_call_json(r#"[{"command": "ls"}]"#, &spec));
+    }
+
+    #[test]
+    fn ignores_unclosed_fence() {
+        let spec = test_spec();
+        assert!(!looks_like_tool_call_json(
+            "```json\n{\"command\": \"ls\"}",
+            &spec
+        ));
+    }
+}

--- a/domain/src/tool/mod.rs
+++ b/domain/src/tool/mod.rs
@@ -51,6 +51,7 @@
 //! - [`ToolResult`] — Execution outcome with structured [`ToolResultMetadata`](value_objects::ToolResultMetadata)
 //! - [`ToolValidator`] — Pure domain trait for parameter validation
 //! - [`ToolProvider`] — Abstraction for external tool providers (MCP, etc.)
+//! - [`looks_like_tool_call_json`] — Detect tool calls leaked as JSON text (#268)
 //!
 //! # Architecture
 //!
@@ -66,11 +67,13 @@
 //! - [`crate::agent`] — Agent system that orchestrates tool usage
 //! - [`crate::orchestration`] — Quorum consensus for high-risk tool review
 
+pub mod detection;
 pub mod entities;
 pub mod provider;
 pub mod traits;
 pub mod value_objects;
 
+pub use detection::looks_like_tool_call_json;
 pub use entities::{ToolCall, ToolDefinition, ToolSpec, classify_command_risk};
 pub use provider::{ProviderError, ToolProvider};
 pub use traits::{DefaultToolValidator, ToolValidator};


### PR DESCRIPTION
## Summary

Agent タスク実行時、LLM がツールを実行せずに**ツールコール風 JSON をテキスト出力**した場合、それが検証されずにタスク出力 → 最終回答としてユーザーに表示される問題を修正しました (#268)。

**原因**: `execute_task.rs` の Native Tool Use ループが LLM のテキスト出力を無条件に `all_outputs` へ push しており、ツールコール風 JSON もそのまま `TaskResultBuffer` → mechanical summary → 最終回答へ流れていました。既存の nudge リトライは `task.tool_name` 指定時 & turn 0 限定で、発動しても push 済みの JSON は残ったままでした。

**修正内容** (DDD + オニオン + 垂直分割に準拠):

| レイヤー | 変更 |
|---|---|
| domain | `tool/detection.rs` 新設 — `looks_like_tool_call_json()`。レスポンス全体が (コードフェンス許容で) 単一 JSON オブジェクトかつ「envelope 形 (`{"tool": "run_command", ...}`)」または「bare-args 形 (`{"command": "..."}` — #268 の再現ケース)」のときのみ検知する保守的ヒューリスティック。純粋ロジックで I/O なし |
| application | `execute_task.rs` — リーク検知時に nudge リトライ (最大 2 回) でツール実行を促す。`tool_name` 未指定タスクでも発動。リトライで解消しなければ JSON を出力から抑制し (JSONL に `tool_call_leak_suppressed` として記録)、他に出力がなければタスクを失敗扱いに |

**挙動の変化**:
- ツールコール風 JSON のテキスト出力を検知 → 実行を促すリトライ → 実ツール実行に回復
- リトライで直らない場合も、生 JSON が最終回答に漏れることはなくなる
- プローズ中に JSON が含まれるだけの通常回答は検知対象外 (誤検知防止)

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #268

関連: #130 (セッションレベルリトライ), #107 (Claude models のツール不呼び出し — 根本原因側)

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する (974 件パス、新規テスト 14 件含む)
- [x] `cargo clippy` で警告がない (既存の presentation クレートの warning のみ、本変更とは無関係)
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた (該当なし)

## Additional Notes

- 検知ヒューリスティックは意図的に保守的です: レスポンス**全体**が単一 JSON オブジェクトの場合のみ発動し、`ToolSpec` に登録済みのツール名/パラメータと照合します。回答にコード例として JSON が含まれるケースは誤検知しません (テストでカバー済み)
- Issue の期待動作のうち「タスク結果の objective 検証」は #130 のスコープと判断し、本 PR では対象外としています
- テスト: domain 層 10 件 (検知ロジック) + application 層 4 件 (nudge 回復 / リトライ枯渇で失敗 / ツール実行後リーク抑制 / 通常テキスト回答の既存挙動維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)