### PR TITLE
fix(init): context.md フッターの生成日付ズレを修正 — 手計算をやめ chrono に置き換え (#290)

### DIFF
--- a/application/src/use_cases/init_context.rs
+++ b/application/src/use_cases/init_context.rs
@@ -423,7 +423,7 @@ impl InitContextUseCase {
             input.moderator
         );
 
-        let date = chrono_lite_date();
+        let date = current_date();
         let synthesis_prompt = AgentPromptTemplate::context_synthesis(&analyses, &date);
         let system_prompt = AgentPromptTemplate::context_synthesis_system();
 
@@ -477,25 +477,22 @@ impl InitContextUseCase {
     }
 }
 
-/// Gets the current date as a string (YYYY-MM-DD format).
+/// Gets the current local date as a string (YYYY-MM-DD format).
 ///
-/// Uses a simplified calculation that's accurate enough for display purposes.
-fn chrono_lite_date() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
+/// Delegates all calendar arithmetic (leap years, month lengths) to `chrono`
+/// instead of the previous hand-rolled epoch-day calculation, which ignored
+/// leap years and assumed 30-day months and could drift the date up to ~15
+/// days into the future.
+fn current_date() -> String {
+    format_ymd(chrono::Local::now().date_naive())
+}
 
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Simple date calculation (approximate, good enough for display)
-    let days = secs / 86400;
-    let years = days / 365;
-    let remaining_days = days % 365;
-    let months = remaining_days / 30;
-    let day = remaining_days % 30 + 1;
-
-    format!("{}-{:02}-{:02}", 1970 + years, months + 1, day)
+/// Formats a [`chrono::NaiveDate`] as `YYYY-MM-DD`.
+///
+/// Extracted as a pure function so date-boundary behaviour (leap years,
+/// month lengths) can be unit-tested without depending on the system clock.
+fn format_ymd(date: chrono::NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
 }
 
 #[cfg(test)]
@@ -510,5 +507,63 @@ mod tests {
 
         assert_eq!(input.project_root, "/project");
         assert!(input.force);
+    }
+
+    use chrono::{Days, NaiveDate};
+
+    /// Builds the date that corresponds to `days` since the Unix epoch.
+    fn date_from_epoch_days(days: u64) -> NaiveDate {
+        NaiveDate::from_ymd_opt(1970, 1, 1)
+            .unwrap()
+            .checked_add_days(Days::new(days))
+            .unwrap()
+    }
+
+    #[test]
+    fn format_ymd_zero_pads_month_and_day() {
+        let date = NaiveDate::from_ymd_opt(2026, 7, 2).unwrap();
+        assert_eq!(format_ymd(date), "2026-07-02");
+    }
+
+    /// Regression test for #290: the old `chrono_lite_date()` computed
+    /// `196 % 30 + 1 = 17` for epoch day 20636 and returned `2026-07-17`,
+    /// drifting 15 days into the future. chrono must return the real date.
+    #[test]
+    fn regression_epoch_day_20636_is_july_2nd() {
+        let date = date_from_epoch_days(20636);
+        assert_eq!(format_ymd(date), "2026-07-02");
+    }
+
+    #[test]
+    fn handles_leap_day() {
+        // 2024 is a leap year, so Feb 29 exists.
+        let leap_day = NaiveDate::from_ymd_opt(2024, 2, 29).unwrap();
+        assert_eq!(format_ymd(leap_day), "2024-02-29");
+
+        // Day after the leap day rolls into March.
+        let next = leap_day.checked_add_days(Days::new(1)).unwrap();
+        assert_eq!(format_ymd(next), "2024-03-01");
+    }
+
+    #[test]
+    fn handles_end_of_month_and_year_boundaries() {
+        // 31-day month boundary (July -> August).
+        let end_of_july = NaiveDate::from_ymd_opt(2026, 7, 31).unwrap();
+        let next = end_of_july.checked_add_days(Days::new(1)).unwrap();
+        assert_eq!(format_ymd(next), "2026-08-01");
+
+        // Year boundary.
+        let new_year_eve = NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        let new_year = new_year_eve.checked_add_days(Days::new(1)).unwrap();
+        assert_eq!(format_ymd(new_year), "2026-01-01");
+    }
+
+    #[test]
+    fn current_date_matches_local_now() {
+        // current_date() must agree with chrono's own formatting of "today".
+        assert_eq!(
+            current_date(),
+            format_ymd(chrono::Local::now().date_naive())
+        );
     }
 }

--- a/application/src/use_cases/init_context.rs
+++ b/application/src/use_cases/init_context.rs
@@ -484,7 +484,17 @@ impl InitContextUseCase {
 /// leap years and assumed 30-day months and could drift the date up to ~15
 /// days into the future.
 fn current_date() -> String {
-    format_ymd(chrono::Local::now().date_naive())
+    current_date_from(chrono::Local::now())
+}
+
+/// Formats the given instant as its local calendar date (`YYYY-MM-DD`).
+///
+/// Takes the "now" instant as a parameter so tests can capture a single
+/// `Local::now()` and feed both the value under test and the expectation
+/// from it, avoiding a midnight-boundary race between two separate clock
+/// reads.
+fn current_date_from<Tz: chrono::TimeZone>(now: chrono::DateTime<Tz>) -> String {
+    format_ymd(now.date_naive())
 }
 
 /// Formats a [`chrono::NaiveDate`] as `YYYY-MM-DD`.
@@ -560,10 +570,10 @@ mod tests {
 
     #[test]
     fn current_date_matches_local_now() {
-        // current_date() must agree with chrono's own formatting of "today".
-        assert_eq!(
-            current_date(),
-            format_ymd(chrono::Local::now().date_naive())
-        );
+        // Capture "now" once so both sides use the same instant — reading the
+        // clock twice could straddle midnight and flake the assertion.
+        let now = chrono::Local::now();
+        let expected = format_ymd(now.date_naive());
+        assert_eq!(current_date_from(now), expected);
     }
 }


### PR DESCRIPTION
## 概要

`:init!` で生成される `.quorum/context.md` のフッター日付が、実行日より最大15日ほど未来にズレるバグ (#290) を修正。

## 原因

`application/src/use_cases/init_context.rs` の `chrono_lite_date()` が epoch days を手計算で日付へ変換しており、カレンダーの複雑さを2箇所で無視していた:

- `days / 365` — うるう年を無視 (1970年以降で約14日の誤差)
- `remaining_days / 30` — 全月を30日換算

epoch day 20636 (2026-07-02) で検算すると `196 % 30 + 1 = 17` → `2026-07-17` となり、issue の再現値と完全一致。

## 変更内容

- `chrono_lite_date()` を削除し、application レイヤーに既存依存の `chrono` へ委譲する `current_date()` (`chrono::Local::now().date_naive()`) に置き換え。カレンダー演算 (うるう年・月長) をすべて chrono に任せる
- 純粋関数 `format_ymd(NaiveDate)` を切り出し、システムクロックに依存せず日付境界を単体テストできるようにした (DDD + オニオン方針に沿ってテスタビリティを確保)
- 日付境界のテストを追加:
  - `regression_epoch_day_20636_is_july_2nd` — #290 再現ケース (→ 2026-07-02)
  - `handles_leap_day` — うるう日 2024-02-29 → 03-01
  - `handles_end_of_month_and_year_boundaries` — 月末・年末境界
  - `format_ymd_zero_pads_month_and_day` / `current_date_matches_local_now`

## 検証

- `cargo build` ✅
- `cargo test --workspace` 全 green ✅
- `cargo fmt --all` 適用済み ✅

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)