### PR TITLE
fix(init): synthesis テンプレートに Build & Test セクションを追加

### DIFF
--- a/domain/src/prompt/agent.rs
+++ b/domain/src/prompt/agent.rs
@@ -570,6 +570,9 @@ Output format:
 ## Key Directories
 [Important directories and their purposes]
 
+## Build & Test
+[How to build, test, and run the project — include concrete commands]
+
 ## Key Concepts
 [Important domain concepts or abstractions]
 
@@ -1040,5 +1043,25 @@ mod tests {
 
         assert!(prompt.contains("[✓] Run unit tests"));
         assert!(prompt.contains("[✗] Run integration tests"));
+    }
+
+    #[test]
+    fn test_context_synthesis_system_includes_build_section() {
+        let prompt = AgentPromptTemplate::context_synthesis_system();
+
+        // The analysis prompt collects Build System info, so the synthesis
+        // output template must retain a Build section — otherwise the
+        // build/test commands are dropped from context.md (issue #291).
+        assert!(prompt.contains("## Build & Test"));
+        assert!(prompt.contains("## Overview"));
+        assert!(prompt.contains("## Key Concepts"));
+    }
+
+    #[test]
+    fn test_context_analysis_asks_about_build_system() {
+        let prompt = AgentPromptTemplate::context_analysis("Cargo.toml\nsrc/main.rs");
+
+        assert!(prompt.contains("Build System"));
+        assert!(prompt.contains("Cargo.toml"));
     }
 }


### PR DESCRIPTION
## Summary

`/init` の分析プロンプト `context_analysis()` は各モデルに **Build System**（ビルド/テスト方法）を質問するが、統合テンプレート `context_synthesis_system()` の出力フォーマットに Build セクションが存在しないため、収集したビルド/テストコマンドが最終的な `.quorum/context.md` から毎回脱落していた。

出力テンプレートの Key Directories と Key Concepts の間に `## Build & Test` セクションを追加し、`cargo build` / `cargo test` などのコマンドが context.md に保存されるようにした。分析プロンプトの質問順（4. Key Directories → 5. Build System → 6. Key Concepts）に合わせて配置。

退行防止テストを 2 件追加:
- `test_context_synthesis_system_includes_build_section` — 統合テンプレートに Build セクションが含まれること
- `test_context_analysis_asks_about_build_system` — 分析プロンプトが Build System を質問し続けること（片側だけ消えても検知できる）

変更は `quorum-domain` 層のプロンプトテンプレートのみで完結しており、オニオン/垂直分割の依存方向（domain は外部依存なし）を維持している。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [x] fix | `fix` | patch | バグ修正 |

## Related Issues

Closes #291

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた（該当なし）

## Additional Notes

`.quorum/context.md` を再生成（`:init!`）すると、これまで欠落していたビルド/テストコマンドが `## Build & Test` セクションに含まれるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
