### PR TITLE
chore: 未使用の reedline workspace 依存を削除 + CLAUDE.md の stale な REPL 記述を更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ quorum.providers.set_default("copilot")
 ```
            cli/                 # Entrypoint, DI assembly
              |
-      presentation/             # CLI, chat REPL, output formatters
+      presentation/             # CLI, TUI, output formatters
              |
 infrastructure/ --> application/   # Adapters --> Use cases + ports
         |                |
@@ -171,7 +171,7 @@ infrastructure/ --> application/   # Adapters --> Use cases + ports
 | domain | `quorum-domain` | Entities, value objects, traits (Model, Question, Phase, QuorumResult, AgentState, Plan, Task, ToolCall, ConsensusLevel, PhaseScope, OrchestrationStrategy, LlmResponse, ContentBlock, StopReason) |
 | application | `quorum-application` | Use cases (RunQuorumUseCase, RunAgentUseCase), port traits (LlmGateway, ProgressNotifier, ToolExecutorPort, ToolResultMessage) |
 | infrastructure | `quorum-infrastructure` | Copilot CLI adapter, LocalToolExecutor (file, command, search tools) |
-| presentation | `quorum-presentation` | CLI commands, ChatRepl, ConsoleFormatter, ProgressReporter |
+| presentation | `quorum-presentation` | CLI commands, TuiApp, ConsoleFormatter, ProgressReporter |
 | cli | `copilot-quorum` | main.rs with dependency injection |
 
 ### Key Traits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ figment = { version = "0.10", features = ["toml", "env"] }
 
 # CLI
 clap = { version = "4.5", features = ["derive"] }
-reedline = "0.37"
 
 # Error handling
 thiserror = "2.0"


### PR DESCRIPTION
## 概要

Closes #292

`/init`(Ensemble)で生成される `context.md` のレビューで、上流ソース(CLAUDE.md / Cargo.toml)の stale な記述がそのまま context.md に伝染していることが判明した。汚染源となっていた 2 点を除去する。

## 変更内容

- **`Cargo.toml`**: `[workspace.dependencies]` の `reedline = "0.37"` を削除
  - どの `.rs` ファイルからも、各メンバー crate の Cargo.toml(`.workspace = true`)からも参照ゼロ = 完全に未使用(REPL は TUI に置換済み)
  - Cargo.lock は元々 reedline 未収録(宣言のみで誰も使っていなかった)のため変化なし
- **`CLAUDE.md`**: presentation 層の説明を現状に合わせて更新
  - 依存フロー図: `presentation/  # CLI, chat REPL, output formatters` → `# CLI, TUI, output formatters`
  - レイヤー表: `CLI commands, ChatRepl, ...` → `CLI commands, TuiApp, ...`
  - 実態: `presentation/src/` は `agent / cli / config / output / progress / tui` で `repl/`・`ChatRepl` は存在せず、中心は `TuiApp`

## 影響

`context.md` 生成時に実在しない `presentation/repl/` や `reedline` が Tech Stack / Key Directories に記載される汚染を除去。アーキテクチャ(DDD + オニオン + 垂直分割)自体は変更なし、ドキュメントを実態に一致させるのみ。

## 検証

- ✅ `cargo fmt --all`
- ✅ `cargo build`
- ✅ `cargo test --workspace` (全パス)

🤖 Generated with [Claude Code](https://claude.com/claude-code)