### PR TITLE
fix(infrastructure): 利用不可モデルの静かな失敗を可視化 — InvalidModel を保持し /init で通知

### DIFF
--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -989,6 +989,14 @@ impl InitContextProgressNotifier for InitContextProgressBridge<'_> {
         self.log(format!("✓ {} analysis complete", model));
     }
 
+    fn on_model_failed(&self, model: &Model, error: &str) {
+        self.progress.on_quorum_model_complete(model, false);
+        self.log(format!(
+            "✗ {} unavailable — skipped ({}). Check models.review in init.lua.",
+            model, error
+        ));
+    }
+
     fn on_synthesis_start(&self) {
         self.progress.on_quorum_start("Context Synthesis", 1);
         self.log("Synthesizing analyses...");
@@ -1355,6 +1363,31 @@ mod tests {
             tx,
         );
         (controller, rx)
+    }
+
+    #[test]
+    fn init_bridge_surfaces_model_failure_to_ui() {
+        // Regression for #262: a failed model in `/init` must reach the UI
+        // conversation log, not only the WARN tracing log.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let progress = NoAgentProgress;
+        let bridge = InitContextProgressBridge {
+            progress: &progress,
+            tx,
+        };
+
+        bridge.on_model_failed(&Model::Gpt52Codex, "Model not available");
+
+        match rx.try_recv() {
+            Ok(UiEvent::ContextInitProgress { message }) => {
+                assert!(message.contains("gpt-5.2-codex"), "message: {message}");
+                assert!(
+                    message.contains("Model not available"),
+                    "message: {message}"
+                );
+            }
+            other => panic!("expected ContextInitProgress, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/application/src/use_cases/init_context.rs
+++ b/application/src/use_cases/init_context.rs
@@ -228,6 +228,19 @@ pub trait InitContextProgressNotifier: Send + Sync {
     /// * `model` - The model that completed
     fn on_model_complete(&self, _model: &Model) {}
 
+    /// Called when a model fails to analyze the project.
+    ///
+    /// The remaining models still contribute to synthesis, so `/init` does not
+    /// abort — but the reduced diversity (and, for unavailable models, a
+    /// misconfigured `models.review`) must be visible instead of only reaching
+    /// the WARN log. See #262.
+    ///
+    /// # Arguments
+    ///
+    /// * `model` - The model that failed
+    /// * `error` - Human-readable failure reason (e.g. "Model not available")
+    fn on_model_failed(&self, _model: &Model, _error: &str) {}
+
     /// Called when starting the synthesis phase.
     fn on_synthesis_start(&self) {}
 
@@ -404,6 +417,7 @@ impl InitContextUseCase {
                 }
                 Ok((model, Err(e))) => {
                     warn!("Model {} failed to analyze: {}", model, e);
+                    progress.on_model_failed(&model, &e.to_string());
                 }
                 Err(e) => {
                     warn!("Task join error: {}", e);

--- a/docs/explanation/design-decisions/0004-role-based-model-configuration.md
+++ b/docs/explanation/design-decisions/0004-role-based-model-configuration.md
@@ -37,9 +37,9 @@
 現在は Lua で設定する:
 
 ```lua
-quorum.config.set("models.exploration", "gpt-5.2-codex")
+quorum.config.set("models.exploration", "gpt-5.3-codex")
 quorum.config.set("models.decision", "claude-sonnet-4.5")
-quorum.config.set("models.review", { "claude-opus-4.5", "gpt-5.2-codex", "gemini-3-pro-preview" })
+quorum.config.set("models.review", { "claude-opus-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview" })
 ```
 
 ## 理由 / Rationale

--- a/docs/how-to/run-a-quorum-discussion.md
+++ b/docs/how-to/run-a-quorum-discussion.md
@@ -13,7 +13,7 @@
 copilot-quorum "What's the best way to handle errors in Rust?"
 
 # モデルを指定して Discussion
-copilot-quorum -m claude-sonnet-4.5 -m gpt-5.2-codex "Compare async/await patterns"
+copilot-quorum -m claude-sonnet-4.5 -m gpt-5.3-codex "Compare async/await patterns"
 
 # 全フェーズの出力を表示（デフォルトは統合結果のみ）
 copilot-quorum -o full "Explain the actor model"
@@ -39,7 +39,7 @@ REPL では `/council <question>` でアドホックに Quorum Discussion を実
 `~/.config/copilot-quorum/init.lua` で設定します:
 
 ```lua
-quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.2-codex", "gemini-3-pro-preview" })
+quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview" })
 quorum.config.set("models.moderator", "claude-opus-4.5")
 ```
 

--- a/docs/how-to/run-agent-tasks.md
+++ b/docs/how-to/run-agent-tasks.md
@@ -58,9 +58,9 @@ Tasks:
 
 Review History:
   Rev 1: REJECTED [○●○]
-    └─ gpt-5.2-codex: Missing error handling
+    └─ gpt-5.3-codex: Missing error handling
   Rev 2: REJECTED [●○○]
-    └─ gemini-3-pro-preview: Unclear objective
+    └─ gemini-3.1-pro-preview: Unclear objective
   Rev 3: REJECTED [○○●]
     └─ claude-sonnet-4.5: Inconsistent approach
 

--- a/docs/how-to/use-ensemble-mode.md
+++ b/docs/how-to/use-ensemble-mode.md
@@ -42,7 +42,7 @@ quorum.config.set("agent.consensus_level", "ensemble")  -- "solo" or "ensemble"
 計画を生成・相互投票するモデル群は `models.participants` で設定します:
 
 ```lua
-quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.2-codex", "gemini-3-pro-preview" })
+quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview" })
 ```
 
 全設定キーは [Configuration Reference](../reference/configuration.md) を参照してください。

--- a/docs/how-to/write-lua-plugins.md
+++ b/docs/how-to/write-lua-plugins.md
@@ -13,7 +13,7 @@
 
 -- 設定変更
 quorum.config.set("agent.hil_mode", "auto_approve")
-quorum.config["models.exploration"] = "gpt-5.2-codex"
+quorum.config["models.exploration"] = "gpt-5.3-codex"
 
 -- キーバインド
 -- 注意: builtin アクション "quit" はタブ数に関係なくアプリ全体を終了する

--- a/docs/tutorials/customizing-with-lua.md
+++ b/docs/tutorials/customizing-with-lua.md
@@ -32,10 +32,10 @@ init.lua を開いて、役割ごとにモデルを割り当てます:
 -- 情報収集は速くて安いモデル、計画とレビューは高性能モデル
 quorum.config.set("models.exploration", "claude-haiku-4.5")
 quorum.config.set("models.decision", "claude-sonnet-4.5")
-quorum.config.set("models.review", { "claude-opus-4.5", "gpt-5.2-codex" })
+quorum.config.set("models.review", { "claude-opus-4.5", "gpt-5.3-codex" })
 
 -- Discussion / Ensemble の参加モデルとモデレーター
-quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.2-codex", "gemini-3-pro-preview" })
+quorum.config.set("models.participants", { "claude-opus-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview" })
 quorum.config.set("models.moderator", "claude-opus-4.5")
 ```
 

--- a/infrastructure/src/copilot/gateway.rs
+++ b/infrastructure/src/copilot/gateway.rs
@@ -15,6 +15,7 @@
 //! which is shared with all sessions. The router handles the actual TCP
 //! communication and demultiplexing.
 
+use crate::copilot::error::CopilotError;
 use crate::copilot::router::MessageRouter;
 use crate::copilot::session::CopilotSession;
 use async_trait::async_trait;
@@ -25,6 +26,52 @@ use quorum_application::ports::llm_gateway::{
 use quorum_domain::Model;
 use std::sync::Arc;
 use tracing::info;
+
+/// Map a session-creation [`CopilotError`] to the port-level [`GatewayError`].
+///
+/// The router classifies Copilot CLI "Model X is not available" responses as
+/// [`CopilotError::InvalidModel`] (see [`MessageRouter::create_session`]). We
+/// preserve that distinction as [`GatewayError::ModelNotAvailable`] so callers
+/// (`/init`, Quorum Discussion, Plan Review) can surface a clear "利用不可モデル"
+/// hint instead of a generic session error that silently drops the model.
+fn map_session_error(err: CopilotError) -> GatewayError {
+    match err {
+        CopilotError::InvalidModel(msg) => GatewayError::ModelNotAvailable(msg),
+        other => GatewayError::SessionError(other.to_string()),
+    }
+}
+
+/// Models known to be available on GitHub Copilot CLI.
+///
+/// Copilot CLI has no model-listing endpoint, so this list is maintained by
+/// hand and verified against the CLI version we target. Verified against
+/// Copilot CLI 1.0.65 (#262/#263): `gpt-5.2-codex` and `gemini-3-pro-preview`
+/// were removed upstream (`session.create` fails with "Model not available"),
+/// and `gpt-5.4` / `gpt-5.3-codex` were added.
+///
+/// Must remain a superset of [`Model::default_models`] so the default
+/// configuration never references a dropped model (enforced by a unit test).
+fn known_available_models() -> Vec<Model> {
+    vec![
+        Model::ClaudeSonnet46,
+        Model::ClaudeOpus46,
+        Model::ClaudeSonnet45,
+        Model::ClaudeHaiku45,
+        Model::ClaudeOpus45,
+        Model::ClaudeSonnet4,
+        Model::Gpt54,
+        Model::Gpt53Codex,
+        Model::Gpt51CodexMax,
+        Model::Gpt51Codex,
+        Model::Gpt52,
+        Model::Gpt51,
+        Model::Gpt5,
+        Model::Gpt51CodexMini,
+        Model::Gpt5Mini,
+        Model::Gpt41,
+        Model::Gemini31Pro,
+    ]
+}
 
 /// LLM Gateway implementation for GitHub Copilot CLI.
 ///
@@ -96,7 +143,7 @@ impl LlmGateway for CopilotLlmGateway {
     async fn create_session(&self, model: &Model) -> Result<Box<dyn LlmSession>, GatewayError> {
         let session = CopilotSession::new(Arc::clone(&self.router), model.clone())
             .await
-            .map_err(|e| GatewayError::SessionError(e.to_string()))?;
+            .map_err(map_session_error)?;
 
         Ok(Box::new(session))
     }
@@ -112,7 +159,7 @@ impl LlmGateway for CopilotLlmGateway {
             Some(system_prompt.to_string()),
         )
         .await
-        .map_err(|e| GatewayError::SessionError(e.to_string()))?;
+        .map_err(map_session_error)?;
 
         Ok(Box::new(session))
     }
@@ -130,7 +177,7 @@ impl LlmGateway for CopilotLlmGateway {
             observer,
         )
         .await
-        .map_err(|e| GatewayError::SessionError(e.to_string()))?;
+        .map_err(map_session_error)?;
 
         Ok(Box::new(session))
     }
@@ -146,32 +193,56 @@ impl LlmGateway for CopilotLlmGateway {
             Some(system_prompt.to_string()),
         )
         .await
-        .map_err(|e| GatewayError::SessionError(e.to_string()))?;
+        .map_err(map_session_error)?;
 
         Ok(Box::new(session))
     }
 
     async fn available_models(&self) -> Result<Vec<Model>, GatewayError> {
-        // Copilot CLI doesn't have a model listing endpoint,
-        // so we return the known available models
-        Ok(vec![
-            Model::ClaudeSonnet46,
-            Model::ClaudeOpus46,
-            Model::ClaudeSonnet45,
-            Model::ClaudeHaiku45,
-            Model::ClaudeOpus45,
-            Model::ClaudeSonnet4,
-            Model::Gpt52Codex,
-            Model::Gpt51CodexMax,
-            Model::Gpt51Codex,
-            Model::Gpt52,
-            Model::Gpt51,
-            Model::Gpt5,
-            Model::Gpt51CodexMini,
-            Model::Gpt5Mini,
-            Model::Gpt41,
-            Model::Gemini3Pro,
-            Model::Gemini31Pro,
-        ])
+        Ok(known_available_models())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_invalid_model_to_model_not_available() {
+        let err = map_session_error(CopilotError::InvalidModel(
+            "Model \"gpt-5.2-codex\" is not available.".to_string(),
+        ));
+        match err {
+            GatewayError::ModelNotAvailable(msg) => assert!(msg.contains("gpt-5.2-codex")),
+            other => panic!("expected ModelNotAvailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_other_errors_to_session_error() {
+        let err = map_session_error(CopilotError::SessionNotInitialized);
+        assert!(matches!(err, GatewayError::SessionError(_)));
+    }
+
+    #[test]
+    fn available_models_superset_of_defaults() {
+        // Regression guard for #262: every default model must be in the
+        // known-available list, so the default config never silently drops a
+        // model that Copilot CLI rejects.
+        let available = known_available_models();
+        for model in Model::default_models() {
+            assert!(
+                available.contains(&model),
+                "default model {model} is missing from known_available_models()"
+            );
+        }
+    }
+
+    #[test]
+    fn available_models_exclude_dropped_models() {
+        // gpt-5.2-codex / gemini-3-pro-preview were removed in Copilot CLI 1.0.65.
+        let available = known_available_models();
+        assert!(!available.contains(&Model::Gpt52Codex));
+        assert!(!available.contains(&Model::Gemini3Pro));
     }
 }


### PR DESCRIPTION
## Summary

PR #263 でデフォルトモデルは更新済みだが、**利用不可モデルが指定された際に「静かに失敗」する経路が残っていた**（#262 の第二弾）。さらに `available_models()` に PR #263 の取りこぼしバグを発見。以下を修正:

### 「静かな失敗」の連鎖と対応

| 段階 | Before | After |
|------|--------|-------|
| ① router が CLI エラーを分類 | ✅ `CopilotError::InvalidModel` | 変更なし |
| ② gateway 境界 | ❌ `GatewayError::SessionError` に**無差別変換**（`ModelNotAvailable` variant が死んでた） | ✅ `ModelNotAvailable` にマップ |
| ③ `/init` の失敗処理 | ❌ `warn!` ログのみで握りつぶし | ✅ `on_model_failed` で通知 |
| ④ UI 通知 | ❌ 原因が UI に出ない | ✅ 会話ログに `✗ <model> unavailable — skipped` を表示 |

### 変更内容（DDD 垂直分割に沿って）

- **infra (`gateway.rs`)**: `map_session_error()` を追加し、`CopilotError::InvalidModel` → `GatewayError::ModelNotAvailable` にマップ。router が分類したモデル利用不可の区別を境界で潰さない。
- **infra (`gateway.rs`)**: `available_models()` のハードコードリストが古く、利用不可の `gpt-5.2-codex`/`gemini-3-pro-preview` を含み新デフォルト `gpt-5.4`/`gpt-5.3-codex` が欠落していたのを修正。`known_available_models()` に切り出し、**`default_models()` の superset であることをユニットテストで担保**（再発防止）。
- **application (`init_context.rs` / `agent_controller.rs`)**: `InitContextProgressNotifier::on_model_failed` を追加。モデル解析失敗を bridge 経由で会話ログに表示（TUI/CLI 両 presenter まで配線確認済み）。
- **docs**: how-to / tutorial / ADR の config 例を利用可能モデルに更新（#263 が競合回避で後回しにした分。README は利用可否を意図的に併記しているため変更せず）。

### スコープ判断

issue の調査ポイント「起動時 or セッション作成時のモデル可用性を検証し早期警告する仕組み」については、**Copilot CLI にモデル一覧 API が無く、真のプリフライト検証には実セッション試行が必要で高コスト/脆弱**なため、リアクティブな明確化（エラー発生時に確実に UI へ見せる）アプローチを採用した。

## Type of Change

| Type | Label | Version | Description |
|------|-------|---------|-------------|
| - [ ] feat | `feature` | minor | 新機能 |
| - [x] fix | `fix` | patch | バグ修正 |
| - [ ] docs | `docs` | patch | ドキュメントのみの変更 |
| - [ ] refactor | `refactor` | patch | リファクタリング |
| - [ ] perf | `perf` | patch | パフォーマンス改善 |
| - [ ] ci | `ci` | patch | CI/CD の変更 |
| - [ ] chore | `chore` | patch | その他の変更 |
| - [ ] deps | `dependencies` | patch | 依存関係の更新 |
| - [ ] breaking | `breaking` | **major** | 破壊的変更 |

## Related Issues

Closes #262

## Checklist

- [x] `cargo build` が成功する
- [x] `cargo test --workspace` が成功する（全パス・失敗ゼロ、新規テスト5本追加）
- [x] `cargo clippy` で警告がない
- [x] 破壊的変更がある場合は `breaking` ラベルを付けた（破壊的変更なし）

## Additional Notes

- 新規テスト: error mapping 2本（`InvalidModel`→`ModelNotAvailable` / その他→`SessionError`）、`available_models` の superset/除外検証 2本、`/init` 可視化 bridge 1本。
- `gpt-5.2-codex` / `gemini-3-pro-preview` の enum variant は互換性のため残置（利用可能な環境では引き続き明示指定できる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
