### PR TITLE
fix(init): :init のモデル失敗を UI に出す + 実行中はヘッダー Phase を表示 (#261)

### DIFF
--- a/application/src/use_cases/init_context.rs
+++ b/application/src/use_cases/init_context.rs
@@ -522,6 +522,9 @@ fn format_ymd(date: chrono::NaiveDate) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::llm_gateway::LlmSession;
+    use quorum_domain::context::{KnownContextFile, LoadedContextFile};
+    use std::sync::Mutex;
 
     #[test]
     fn test_init_context_input() {
@@ -589,5 +592,81 @@ mod tests {
         let now = chrono::Local::now();
         let expected = format_ymd(now.date_naive());
         assert_eq!(current_date_from(now), expected);
+    }
+
+    /// Gateway whose sessions never open, so every model analysis fails.
+    struct FailingGateway;
+
+    #[async_trait::async_trait]
+    impl LlmGateway for FailingGateway {
+        async fn create_session(
+            &self,
+            _model: &Model,
+        ) -> Result<Box<dyn LlmSession>, GatewayError> {
+            Err(GatewayError::Other("session unavailable".into()))
+        }
+
+        async fn create_session_with_system_prompt(
+            &self,
+            model: &Model,
+            _system_prompt: &str,
+        ) -> Result<Box<dyn LlmSession>, GatewayError> {
+            self.create_session(model).await
+        }
+
+        async fn available_models(&self) -> Result<Vec<Model>, GatewayError> {
+            Ok(vec![])
+        }
+    }
+
+    /// Context loader stub that reports one loadable file and no existing output.
+    struct StubLoader;
+
+    impl ContextLoaderPort for StubLoader {
+        fn load_known_files(&self, _project_root: &Path) -> Vec<LoadedContextFile> {
+            vec![LoadedContextFile::new(
+                KnownContextFile::CargoToml,
+                "/project/Cargo.toml",
+                "[package]\nname = \"demo\"",
+            )]
+        }
+
+        fn context_file_exists(&self, _project_root: &Path) -> bool {
+            false
+        }
+
+        fn write_context_file(&self, _project_root: &Path, _content: &str) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingProgress {
+        failed: Mutex<Vec<String>>,
+    }
+
+    impl InitContextProgressNotifier for RecordingProgress {
+        fn on_model_failed(&self, model: &Model, _error: &str) {
+            self.failed.lock().unwrap().push(model.to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_model_failure_is_reported_to_progress() {
+        // Regression test for #261: a model that fails during analysis must be
+        // surfaced via on_model_failed, not silently swallowed.
+        let use_case = InitContextUseCase::new(Arc::new(FailingGateway), Arc::new(StubLoader));
+        let input = InitContextInput::new("/project", vec![Model::default()])
+            .with_moderator(Model::default());
+        let progress = RecordingProgress::default();
+
+        let result = use_case.execute_with_progress(input, &progress).await;
+
+        assert!(matches!(result, Err(InitContextError::AllModelsFailed)));
+        assert_eq!(
+            progress.failed.lock().unwrap().len(),
+            1,
+            "the failed model must be reported exactly once"
+        );
     }
 }

--- a/presentation/src/tui/presenter.rs
+++ b/presentation/src/tui/presenter.rs
@@ -126,6 +126,13 @@ impl TuiPresenter {
                 self.emit(TuiEvent::AgentError(error.clone()));
             }
             UiEvent::ContextInitStarting { model_count } => {
+                // Mark the pane as running so the header shows the live phase
+                // instead of "Ready" while context generation is in flight.
+                {
+                    let progress = &mut state.tabs.active_pane_mut().progress;
+                    progress.is_running = true;
+                    progress.phase_name = "Gathering Context".to_string();
+                }
                 state.push_message(DisplayMessage::system(format!(
                     "Initializing context with {} models...",
                     model_count
@@ -255,6 +262,7 @@ impl TuiPresenter {
         let progress = &mut state.tabs.active_pane_mut().progress;
         progress.current_phase = None;
         progress.quorum_status = None;
+        progress.is_running = false;
     }
 
     fn emit(&self, event: TuiEvent) {
@@ -578,5 +586,52 @@ mod tests {
         assert!(!state.tabs.active_pane().progress.is_running);
         // streaming text finalized + error message
         assert!(state.tabs.active_pane().conversation.messages.len() >= 2);
+    }
+
+    #[test]
+    fn test_context_init_marks_header_running_then_idle() {
+        // Regression test for #261: while /init runs, the header must show the
+        // live phase (is_running = true) instead of "Ready"; once the context
+        // is saved it returns to idle.
+        let (presenter, _rx, mut state) = setup();
+
+        presenter.apply(&mut state, &UiEvent::ContextInitStarting { model_count: 2 });
+        assert!(
+            state.tabs.active_pane().progress.is_running,
+            "header must report a running phase during init"
+        );
+        assert_eq!(
+            state.tabs.active_pane().progress.phase_name,
+            "Gathering Context"
+        );
+
+        presenter.apply(
+            &mut state,
+            &UiEvent::ContextInitResult(ContextInitResultEvent {
+                path: ".quorum/context.md".into(),
+                content: "ctx".into(),
+                contributing_models: vec!["m".into()],
+            }),
+        );
+        assert!(
+            !state.tabs.active_pane().progress.is_running,
+            "header must return to idle after init completes"
+        );
+    }
+
+    #[test]
+    fn test_context_init_error_resets_running() {
+        // A failed /init must also clear the running flag so the header does
+        // not stay stuck on a phase.
+        let (presenter, _rx, mut state) = setup();
+
+        presenter.apply(&mut state, &UiEvent::ContextInitStarting { model_count: 2 });
+        presenter.apply(
+            &mut state,
+            &UiEvent::ContextInitError {
+                error: "boom".into(),
+            },
+        );
+        assert!(!state.tabs.active_pane().progress.is_running);
     }
 }


### PR DESCRIPTION
## 概要

Fixes #261

`:init` 実行中のフィードバックが乏しく、ハングと誤認されやすかった問題への対応です。
issue は2本立て（進捗の未配線 / モデル失敗が UI に出ない）でしたが、経緯として:

- **進捗配線（Gap の前提）**: #266 で対応済み
- **Gap A（モデル失敗を UI に出す）**: 本 PR 作成後に **#297 が同等の実装をマージ**（`on_model_failed` の trait 追加＋ブリッジ配線）
- **Gap B（実行中ヘッダーの Phase が `Ready` 固定）**: 本 PR で対応 ← **未対応で残っていた分**

そのため rebase 後の本 PR の実質的な差分は **Gap B の修正**と、**失敗報告（Gap A）の挙動を固定する回帰テスト**です。

## Gap B — 実行中にヘッダーの Phase が `Ready` のまま

`header.rs` は `progress.is_running == true` のときだけ live phase を表示しますが、このフラグは `AgentStarting` でしか立たず、`:init`（`ContextInitStarting`）では立たないため init 中ずっと `Ready` 表示でした（issue の症状そのもの）。

- `ContextInitStarting` 受信時に `pane.progress.is_running = true` + 初期 phase 名をセット（`presentation/src/tui/presenter.rs`）
- `reset_progress`（成功・失敗どちらの経路も通る）で `is_running = false` に戻す

## Gap A（#297 でマージ済み）の回帰テスト

`on_model_failed` の配線自体は #297 に含まれるため本 PR ではコード変更しませんが、その挙動（分析失敗時に notifier へ届くこと）を固定するため application 層のテストを追加しています。#297 の意図（`models.review` 誤設定・利用不可モデルの可視化）を壊さないよう、ブリッジの文言は #297 版を維持しています。

## テスト

- `presentation`: init ライフサイクルで `is_running` が true→idle に遷移すること / 失敗時も idle に戻ること
- `application`: モデル失敗時に `on_model_failed` が呼ばれること（`AllModelsFailed` パス）

## 検証

- `cargo build` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all --check` ✅

## アーキテクチャ

DDD + オニオン + 垂直分割を維持（Gap B は presentation 層に閉じた変更、テストは各層内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)