### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "copilot-quorum"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2455,7 +2455,7 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quorum-application"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-domain"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-infrastructure"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "quorum-presentation"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["music-brain88"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## chore: bump version to 0.14.0

Workspace version を `0.13.0` → `0.14.0` にバンプ。

### 含まれる変更（0.13.0 以降の主な機能追加）

- **Remote Control API** — `--listen` で外部プロセスから TUI を操作、Phase 2 で画面キャプチャ・レイアウト調整に対応 (#255, #256)
- **ペイン単位の yank/コピー** — Visual mode + tmux 風フォーカス (#253)
- **Vim スタイルの bang コマンド** — `:init!` で強制再生成 (#265)
- **`:config` の全設定キー表示** — セクション別 + 絞り込み対応 (#281)
- **`:q` のタブ対応** — 複数タブ時は現在のタブを閉じ、`:qa` で全体終了 (#289)
- **Copilot CLI 1.0.65 対応** — permission ゲート・デフォルトモデル更新・利用不可モデルの可視化 (#254, #263, #297)
- **TUI ドッグフーディング由来のバグ修正 10 本** (#277〜#289) + タブクローズのライフサイクル修正 (#299)
- **Diátaxis 準拠のドキュメント再編** (#259)

### 変更ファイル

- `Cargo.toml`: `[workspace.package].version` を `0.14.0` に更新
- `Cargo.lock`: 全5クレートのバージョンが自動反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)