### PR TITLE
fix(review): --diff/stdin レビューで target が {} になる契約違反を修正 (#300)

### DIFF
--- a/cli/src/review.rs
+++ b/cli/src/review.rs
@@ -131,17 +131,32 @@ fn print_output(
             println!("{}", synthesis.conclusion);
         }
         ReviewOutputFormat::Json => {
-            let vote_result = VoteResult::from_votes(votes);
-            let target = QuorumTarget::pr_review(pr, title);
-            let payload =
-                QuorumResultPayload::new(QuorumTopic::PrReview, Some(target), &vote_result)
-                    .with_synthesis(synthesis);
             let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-            let record = payload.to_record(timestamp);
+            let record = build_json_record(pr, title, votes, synthesis, timestamp);
             println!("{}", serde_json::to_string_pretty(&record)?);
         }
     }
     Ok(())
+}
+
+/// Build the `quorum_result` v1 record for `--output json`.
+///
+/// `QuorumTarget::pr_review` already returns `None` when neither `pr` nor
+/// `title` is known (e.g. a bare stdin diff) — pass it straight through
+/// rather than wrapping it in `Some(..)`, so `target` is omitted from the
+/// record entirely instead of serializing as `"target": {}`.
+fn build_json_record(
+    pr: Option<u64>,
+    title: Option<String>,
+    votes: Vec<Vote>,
+    synthesis: SynthesisResult,
+    timestamp: String,
+) -> serde_json::Value {
+    let vote_result = VoteResult::from_votes(votes);
+    let target = QuorumTarget::pr_review(pr, title);
+    let payload = QuorumResultPayload::new(QuorumTopic::PrReview, target, &vote_result)
+        .with_synthesis(synthesis);
+    payload.to_record(timestamp)
 }
 
 /// Fetch a PR's diff and title via the `gh` CLI.
@@ -181,4 +196,51 @@ async fn fetch_pr_diff(pr: u64) -> Result<(String, Option<String>)> {
         .filter(|title| !title.is_empty());
 
     Ok((diff, title))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_votes() -> Vec<Vote> {
+        vec![Vote::approve("claude-opus-4.5", "Looks safe")]
+    }
+
+    fn sample_synthesis() -> SynthesisResult {
+        SynthesisResult::new("claude-opus-4.5", "Looks good, ship it.")
+    }
+
+    // Regression test: `--diff` / stdin review (no --pr, so no title either)
+    // must omit `target` entirely, per the `quorum_result` contract
+    // ("target: object? — omitted when absent", docs/reference/logging.md).
+    // This previously serialized as `"target": {}` because the caller always
+    // wrapped `QuorumTarget::pr_review(..)` in `Some(..)`.
+    #[test]
+    fn json_record_omits_target_for_diff_or_stdin_review() {
+        let record = build_json_record(
+            None,
+            None,
+            sample_votes(),
+            sample_synthesis(),
+            "2026-07-04T00:00:00.000Z".to_string(),
+        );
+        assert!(
+            record.get("target").is_none(),
+            "expected no `target` key, got: {}",
+            record
+        );
+    }
+
+    #[test]
+    fn json_record_includes_target_for_pr_review() {
+        let record = build_json_record(
+            Some(123),
+            Some("Fix the bug".to_string()),
+            sample_votes(),
+            sample_synthesis(),
+            "2026-07-04T00:00:00.000Z".to_string(),
+        );
+        assert_eq!(record["target"]["pr"], 123);
+        assert_eq!(record["target"]["title"], "Fix the bug");
+    }
 }

--- a/domain/src/quorum/result_event.rs
+++ b/domain/src/quorum/result_event.rs
@@ -78,14 +78,20 @@ impl QuorumTarget {
         }
     }
 
-    /// Target for a PR/diff review (#300). Both fields are optional since a
-    /// bare `git diff | copilot-quorum review` has neither.
-    pub fn pr_review(pr: Option<u64>, title: Option<String>) -> Self {
-        Self {
+    /// Target for a PR/diff review (#300). Returns `None` when neither `pr`
+    /// nor `title` is known (e.g. a bare `git diff | copilot-quorum review`
+    /// via stdin) — the `quorum_result` contract omits `target` entirely in
+    /// that case rather than serializing an empty object, so this returns
+    /// `Option<Self>` instead of always producing a `QuorumTarget`.
+    pub fn pr_review(pr: Option<u64>, title: Option<String>) -> Option<Self> {
+        if pr.is_none() && title.is_none() {
+            return None;
+        }
+        Some(Self {
             pr,
             title,
             ..Default::default()
-        }
+        })
     }
 }
 
@@ -215,13 +221,32 @@ mod tests {
     fn test_pr_review_topic_and_target() {
         assert_eq!(QuorumTopic::PrReview.as_str(), "pr_review");
 
-        let target = QuorumTarget::pr_review(Some(123), Some("Fix the bug".into()));
+        let target =
+            QuorumTarget::pr_review(Some(123), Some("Fix the bug".into())).expect("has pr/title");
         let json = serde_json::to_value(&target).unwrap();
         assert_eq!(json, serde_json::json!({"pr": 123, "title": "Fix the bug"}));
 
-        // A bare stdin diff has neither
-        let bare = QuorumTarget::pr_review(None, None);
-        assert_eq!(serde_json::to_value(&bare).unwrap(), serde_json::json!({}));
+        // A bare stdin diff has neither — no target at all, not an empty object
+        assert_eq!(QuorumTarget::pr_review(None, None), None);
+    }
+
+    // Regression test: a bare `git diff | copilot-quorum review` (no --pr,
+    // no title) must omit `target` from the record entirely, per the
+    // `quorum_result` contract ("target: object? — omitted when absent").
+    // An earlier version of the `review` CLI handler always wrapped
+    // `QuorumTarget::pr_review(..)` in `Some(..)`, producing `"target": {}`
+    // instead of omitting the key.
+    #[test]
+    fn test_payload_omits_target_when_pr_review_has_neither_pr_nor_title() {
+        let result = VoteResult::from_votes(vec![Vote::approve("m", "ok")]);
+        let payload = QuorumResultPayload::new(
+            QuorumTopic::PrReview,
+            QuorumTarget::pr_review(None, None),
+            &result,
+        );
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert!(json.get("target").is_none());
     }
 
     #[test]
@@ -234,7 +259,7 @@ mod tests {
             SynthesisResult::new("claude-opus-4.5", "Overall solid, but add test coverage.");
         let payload = QuorumResultPayload::new(
             QuorumTopic::PrReview,
-            Some(QuorumTarget::pr_review(Some(123), Some("Fix login".into()))),
+            QuorumTarget::pr_review(Some(123), Some("Fix login".into())),
             &result,
         )
         .with_synthesis(synthesis);


### PR DESCRIPTION
## 概要

`copilot-quorum review --output json` を `--diff` / stdin モード（`--pr` なし）で実行すると、`quorum_result` 契約（[docs/reference/logging.md](../blob/main/docs/reference/logging.md)）が定める「`target: object? — なければ省略」に反して `"target": {}` が出力されていた。PR #308 のドッグフーディングで発見。

## 原因

`cli/src/review.rs::print_output` が `QuorumTarget::pr_review(pr, title)` の戻り値を無条件に `Some(target)` で包んで `QuorumResultPayload::new(..)` に渡していた。`pr`/`title` が両方 `None`（stdin diff）でも `QuorumTarget { pr: None, title: None, .. }` という「中身が空の QuorumTarget」が `Some` に包まれるため、`QuorumResultPayload.target: Option<QuorumTarget>` の `skip_serializing_if` は素通りし、`QuorumTarget` 自身のフィールドだけが省略された結果 `{}` になっていた。

## 修正内容

- `domain/src/quorum/result_event.rs`: `QuorumTarget::pr_review(pr, title)` の戻り値を `Self` → `Option<Self>` に変更。`pr`/`title` が両方 `None` のときは `None` を返すようにし、呼び出し側が誤って `Some(..)` で包み直せないようにした（契約違反を型で防ぐ）
- `cli/src/review.rs`: `print_output` から JSON 組み立てロジックを `build_json_record` として抽出し、`QuorumTarget::pr_review(..)` の戻り値（`Option<QuorumTarget>`）をそのまま `QuorumResultPayload::new` に渡すよう修正（`Some(..)` で包まない）

### Before / After

```jsonc
// Before（--diff / stdin、--pr なし）
{
  "api_version": 1,
  "topic": "pr_review",
  "target": {},        // ← 契約違反（本来は省略されるべき）
  "approved": true,
  ...
}
```

```jsonc
// After（同じ入力）
{
  "api_version": 1,
  "topic": "pr_review",
  // target キー自体が存在しない
  "approved": true,
  ...
}
```

`--pr` 指定時（`target: {"pr": 123, "title": "..."}`）の挙動は変更なし。

## 実機検証

修正後バイナリで実際にモデル呼び出しを含めて確認:

```
$ git diff HEAD~1 HEAD -- CLAUDE.md | ./target/debug/copilot-quorum review --output json
$ echo $?
0
$ python3 -c "import json,sys; print('target' in json.load(open('/tmp/out.json')))"
False
```

## テスト

- `cli/src/review.rs`（新規 `tests` モジュール）:
  - `json_record_omits_target_for_diff_or_stdin_review` — `pr=None, title=None` で `target` キーが存在しないこと
  - `json_record_includes_target_for_pr_review` — `pr=Some(123), title=Some(..)` で従来どおり `target` が入ること
- `domain/src/quorum/result_event.rs`:
  - `test_pr_review_topic_and_target` を `pr_review` の新シグネチャ（`Option<Self>`）に合わせて更新、`pr_review(None, None) == None` を明示的にアサート
  - `test_payload_omits_target_when_pr_review_has_neither_pr_nor_title`（新規）— payload に組み込んだ際も `target` キーが省略されること
- `cargo test --workspace`: 全緑（398 → 変更なし + 新規 3 テスト）
- `cargo clippy --workspace -- -D warnings`: warning なし
- `cargo fmt --all -- --check`: 差分なし

## スコープ

このバグは `copilot-quorum review` の stdout JSON にのみ影響する。JSONL 側（`RunReviewUseCase.execute()` が publish する `quorum_result`）は元々 `target: None` を明示的に渡していたため影響なし（PR #308 の判断メモに記載済み: pr/title は CLI 層のみが知る情報のため use case 側では持たせていない）。
