### PR TITLE
feat(orchestration): 敵対的パネル v2 — 反論台帳・発散チェック・裁定のVoteスキーマ統合・分解要求権 (#316)

### DIFF
--- a/application/src/config/quorum_config.rs
+++ b/application/src/config/quorum_config.rs
@@ -333,6 +333,7 @@ impl QuorumConfig {
         let question_str: String = question.into();
         RunQuorumInput::new(question_str, self.models.clone())
             .with_strategy(self.mode.strategy.clone())
+            .with_hil_mode(self.policy.hil_mode)
     }
 }
 

--- a/application/src/ports/human_intervention.rs
+++ b/application/src/ports/human_intervention.rs
@@ -140,30 +140,40 @@ pub trait HumanInterventionPort: Send + Sync {
         Ok(HumanDecision::Approve)
     }
 
-    /// Request human escalation when a Debate strategy run cannot resolve
-    /// all objections (e.g. unresolved objections remain at `max_rounds`).
+    /// Request human escalation when a Debate strategy moderator tries to
+    /// settle while critical/major [`quorum_domain::quorum::Objection`]s
+    /// remain unresolved.
     ///
-    /// Called when the `Debate` orchestration strategy reaches its round
-    /// limit with open [`quorum_domain::quorum::Objection`]s still
-    /// unresolved by the moderator.
+    /// Called at *every* settle checkpoint gated this way — not only the
+    /// final round. An early premature settle attempt and the final round
+    /// forcing a settle both route through here; `can_continue` tells the
+    /// implementation which one it's showing the user.
     ///
     /// # Arguments
     ///
     /// * `question` - The original question/topic being debated
     /// * `unresolved` - The objections that remain unresolved
     /// * `transcript_summary` - A condensed summary of the debate transcript
+    /// * `can_continue` - `true` if this is a non-final round: rejecting
+    ///   declines the premature settle and the debate continues to the next
+    ///   round. `false` if this is the final round (`max_rounds` reached):
+    ///   rejecting aborts the debate entirely, since there is no next round
+    ///   to continue to.
     ///
     /// # Default
     ///
     /// Defaults to `Reject` (fail-secure). This matches the philosophy of
     /// [`AutoRejectIntervention`]: an unresolved adversarial debate should
-    /// not silently proceed. Override in interactive implementations to
-    /// prompt the user, or in [`AutoApproveIntervention`] to bypass.
+    /// not silently settle. When `can_continue` is `true`, `Reject` simply
+    /// continues the debate rather than aborting it. Override in interactive
+    /// implementations to prompt the user, or in [`AutoApproveIntervention`]
+    /// to bypass.
     async fn request_debate_escalation(
         &self,
         _question: &str,
         _unresolved: &[quorum_domain::quorum::Objection],
         _transcript_summary: &str,
+        _can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Reject)
     }
@@ -225,6 +235,7 @@ impl HumanInterventionPort for AutoApproveIntervention {
         _question: &str,
         _unresolved: &[quorum_domain::quorum::Objection],
         _transcript_summary: &str,
+        _can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Approve)
     }
@@ -300,7 +311,7 @@ mod tests {
         let intervention = AutoRejectIntervention;
         let objection = sample_objection();
         let result = intervention
-            .request_debate_escalation("test question", &[objection], "transcript summary")
+            .request_debate_escalation("test question", &[objection], "transcript summary", true)
             .await
             .unwrap();
         assert!(matches!(result, HumanDecision::Reject));
@@ -311,7 +322,7 @@ mod tests {
         let intervention = AutoApproveIntervention;
         let objection = sample_objection();
         let result = intervention
-            .request_debate_escalation("test question", &[objection], "transcript summary")
+            .request_debate_escalation("test question", &[objection], "transcript summary", true)
             .await
             .unwrap();
         assert!(matches!(result, HumanDecision::Approve));

--- a/application/src/ports/human_intervention.rs
+++ b/application/src/ports/human_intervention.rs
@@ -139,6 +139,34 @@ pub trait HumanInterventionPort: Send + Sync {
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Approve)
     }
+
+    /// Request human escalation when a Debate strategy run cannot resolve
+    /// all objections (e.g. unresolved objections remain at `max_rounds`).
+    ///
+    /// Called when the `Debate` orchestration strategy reaches its round
+    /// limit with open [`quorum_domain::quorum::Objection`]s still
+    /// unresolved by the moderator.
+    ///
+    /// # Arguments
+    ///
+    /// * `question` - The original question/topic being debated
+    /// * `unresolved` - The objections that remain unresolved
+    /// * `transcript_summary` - A condensed summary of the debate transcript
+    ///
+    /// # Default
+    ///
+    /// Defaults to `Reject` (fail-secure). This matches the philosophy of
+    /// [`AutoRejectIntervention`]: an unresolved adversarial debate should
+    /// not silently proceed. Override in interactive implementations to
+    /// prompt the user, or in [`AutoApproveIntervention`] to bypass.
+    async fn request_debate_escalation(
+        &self,
+        _question: &str,
+        _unresolved: &[quorum_domain::quorum::Objection],
+        _transcript_summary: &str,
+    ) -> Result<HumanDecision, HumanInterventionError> {
+        Ok(HumanDecision::Reject)
+    }
 }
 
 /// Auto-reject implementation for `HilMode::AutoReject`.
@@ -182,6 +210,21 @@ impl HumanInterventionPort for AutoApproveIntervention {
         _request: &str,
         _plan: &Plan,
         _review_history: &[ReviewRound],
+    ) -> Result<HumanDecision, HumanInterventionError> {
+        Ok(HumanDecision::Approve)
+    }
+
+    /// # Warning
+    ///
+    /// **Use with caution!** This bypasses the fail-secure default and
+    /// approves proceeding even though the Debate strategy could not
+    /// resolve all objections. Only use when the consequences of
+    /// proceeding despite unresolved objections are acceptable.
+    async fn request_debate_escalation(
+        &self,
+        _question: &str,
+        _unresolved: &[quorum_domain::quorum::Objection],
+        _transcript_summary: &str,
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Approve)
     }
@@ -231,6 +274,44 @@ mod tests {
         let plan = Plan::new("test", "test");
         let result = intervention
             .request_execution_confirmation("test", &plan)
+            .await
+            .unwrap();
+        assert!(matches!(result, HumanDecision::Approve));
+    }
+
+    fn sample_objection() -> quorum_domain::quorum::Objection {
+        let mut ledger = quorum_domain::quorum::ObjectionLedger::new();
+        let id = ledger.add(
+            1,
+            "The plan ignores concurrent writes",
+            "See race in step 3",
+            quorum_domain::quorum::ObjectionSeverity::Major,
+        );
+        ledger
+            .open_objections()
+            .into_iter()
+            .find(|o| o.id == id)
+            .cloned()
+            .expect("objection should exist after add")
+    }
+
+    #[tokio::test]
+    async fn test_auto_reject_debate_escalation_defaults_to_reject() {
+        let intervention = AutoRejectIntervention;
+        let objection = sample_objection();
+        let result = intervention
+            .request_debate_escalation("test question", &[objection], "transcript summary")
+            .await
+            .unwrap();
+        assert!(matches!(result, HumanDecision::Reject));
+    }
+
+    #[tokio::test]
+    async fn test_auto_approve_debate_escalation_returns_approve() {
+        let intervention = AutoApproveIntervention;
+        let objection = sample_objection();
+        let result = intervention
+            .request_debate_escalation("test question", &[objection], "transcript summary")
             .await
             .unwrap();
         assert!(matches!(result, HumanDecision::Approve));

--- a/application/src/ports/human_intervention.rs
+++ b/application/src/ports/human_intervention.rs
@@ -153,7 +153,11 @@ pub trait HumanInterventionPort: Send + Sync {
     ///
     /// * `question` - The original question/topic being debated
     /// * `unresolved` - The objections that remain unresolved
-    /// * `transcript_summary` - A condensed summary of the debate transcript
+    /// * `transcript_summary` - A condensed (head+tail truncated to a fixed
+    ///   byte budget — see `DebateStrategyExecutor`'s
+    ///   `TRANSCRIPT_SUMMARY_MAX_BYTES`) summary of the debate transcript,
+    ///   safe to render inline (e.g. a single TUI modal line) without
+    ///   growing unbounded across rounds
     /// * `can_continue` - `true` if this is a non-final round: rejecting
     ///   declines the premature settle and the debate continues to the next
     ///   round. `false` if this is the final round (`max_rounds` reached):

--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -118,6 +118,10 @@ pub struct AgentController {
     /// The current composite event publisher, rebuilt whenever the logger,
     /// scripting engine, or extra subscribers change.
     event_publisher: Arc<dyn EventPublisher>,
+    /// Human-in-the-loop port, propagated to `RunQuorumUseCase` instances
+    /// built for `/discuss` (both inline and `SpawnContext`) so debate
+    /// escalation checkpoints can prompt the user (issue #316).
+    human_intervention: Arc<dyn HumanInterventionPort>,
 }
 
 impl AgentController {
@@ -151,7 +155,7 @@ impl AgentController {
                 tool_schema,
                 context_loader.clone(),
             )
-            .with_human_intervention(human_intervention)
+            .with_human_intervention(human_intervention.clone())
             .with_status_tracker(status_tracker.clone()),
             ask_use_case,
             review_use_case,
@@ -170,6 +174,7 @@ impl AgentController {
             status_tracker,
             extra_event_subscribers: Vec::new(),
             event_publisher: Arc::new(NoEventPublisher),
+            human_intervention,
         }
     }
 
@@ -974,6 +979,7 @@ impl AgentController {
             scripting_engine: self.scripting_engine.clone(),
             status_tracker: self.status_tracker.clone(),
             event_publisher: self.event_publisher.clone(),
+            human_intervention: self.human_intervention.clone(),
         }
     }
 
@@ -1183,6 +1189,7 @@ pub struct SpawnContext {
     pub(crate) scripting_engine: Arc<dyn ScriptingEnginePort>,
     pub(crate) status_tracker: Arc<StatusTracker>,
     pub(crate) event_publisher: Arc<dyn EventPublisher>,
+    pub(crate) human_intervention: Arc<dyn HumanInterventionPort>,
 }
 
 /// Completion result of a task (spawn or inline execution)
@@ -1281,7 +1288,9 @@ impl SpawnContext {
     ) -> Option<InteractionResult> {
         let _ = self.tx.send(UiEvent::QuorumStarting);
         let input = self.config.to_quorum_input(query.to_string());
-        let use_case = RunQuorumUseCase::new(self.gateway.clone());
+        let use_case = RunQuorumUseCase::new(self.gateway.clone())
+            .with_event_publisher(self.event_publisher.clone())
+            .with_human_intervention(self.human_intervention.clone());
         let adapter = QuorumProgressAdapter::new(progress);
         match use_case.execute_with_progress(input, &adapter).await {
             Ok(output) => {

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -27,6 +27,7 @@ use quorum_domain::quorum::parsing::{
     parse_debate_verdict, parse_decomposition_request, parse_divergence_check,
     parse_moderator_rulings, parse_opponent_rebuttals,
 };
+use quorum_domain::util::truncate_head_tail;
 use quorum_domain::{
     DebateConfig, DebateIntensity, DebatePromptTemplate, HilMode, HumanDecision, Model,
     ModelResponse, Objection, ObjectionLedger, ObjectionStatus, OrchestrationStrategy, PeerReview,
@@ -35,6 +36,14 @@ use quorum_domain::{
 };
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// Byte budget for the transcript summary handed to
+/// `HumanInterventionPort::request_debate_escalation` — the port docs call
+/// this a "condensed summary", and both the CLI and TUI render it inline
+/// (a single modal line in the TUI), so the full `render_transcript` output
+/// (unbounded, grows every round) would blow past what either surface can
+/// reasonably display.
+const TRANSCRIPT_SUMMARY_MAX_BYTES: usize = 2000;
 
 /// Adversarial discussion: fixed proponent/opponent roles attack and defend a
 /// position across rounds, with an optional third-party interjector, until a
@@ -615,7 +624,10 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     human_intervention.as_ref(),
                     question,
                     &unresolved,
-                    &Self::render_transcript(&transcript),
+                    &truncate_head_tail(
+                        &Self::render_transcript(&transcript),
+                        TRANSCRIPT_SUMMARY_MAX_BYTES,
+                    ),
                     !is_final_round,
                 )
                 .await?;
@@ -761,11 +773,13 @@ mod tests {
 
     /// Mock `HumanInterventionPort` that returns a pre-configured
     /// (`request_debate_escalation`-only) outcome and records each
-    /// invocation's `can_continue` flag (in call order) alongside the count.
+    /// invocation's `can_continue` flag and `transcript_summary` length (in
+    /// call order) alongside the count.
     struct MockEscalationHandler {
         outcome: Result<HumanDecision, HumanInterventionError>,
         calls: Mutex<usize>,
         can_continue_calls: Mutex<Vec<bool>>,
+        transcript_summary_lens: Mutex<Vec<usize>>,
     }
 
     impl MockEscalationHandler {
@@ -774,6 +788,7 @@ mod tests {
                 outcome,
                 calls: Mutex::new(0),
                 can_continue_calls: Mutex::new(Vec::new()),
+                transcript_summary_lens: Mutex::new(Vec::new()),
             }
         }
     }
@@ -793,11 +808,15 @@ mod tests {
             &self,
             _question: &str,
             _unresolved: &[Objection],
-            _transcript_summary: &str,
+            transcript_summary: &str,
             can_continue: bool,
         ) -> Result<HumanDecision, HumanInterventionError> {
             *self.calls.lock().unwrap() += 1;
             self.can_continue_calls.lock().unwrap().push(can_continue);
+            self.transcript_summary_lens
+                .lock()
+                .unwrap()
+                .push(transcript_summary.len());
             self.outcome.clone()
         }
     }
@@ -1450,6 +1469,53 @@ mod tests {
             "unexpected conclusion: {}",
             result.synthesis.conclusion
         );
+    }
+
+    #[tokio::test]
+    async fn debate_escalation_transcript_summary_is_truncated_to_budget() {
+        // Regression: debate_strategy.rs used to pass the full, unbounded
+        // render_transcript() output as `transcript_summary` — a single TUI
+        // modal line, or CLI dump, of the entire debate. It must be
+        // head+tail truncated to TRANSCRIPT_SUMMARY_MAX_BYTES instead.
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Approve)));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
+        // A very long EVIDENCE line pushes the rendered transcript well past
+        // the budget by the time escalation fires.
+        let long_evidence = "x".repeat(TRANSCRIPT_SUMMARY_MAX_BYTES * 2);
+        gateway.respond(
+            Model::Gemini31Pro,
+            format!(
+                "CLAIM: write-through never expires\nEVIDENCE: {}\nSEVERITY: CRITICAL",
+                long_evidence
+            ),
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on TTL handling.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nWrite-through wins.",
+        );
+
+        DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap();
+
+        let lens = handler.transcript_summary_lens.lock().unwrap();
+        assert_eq!(*lens, vec![TRANSCRIPT_SUMMARY_MAX_BYTES]);
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -18,13 +18,20 @@
 
 use super::strategy_executor::StrategyExecutor;
 use super::types::{RunQuorumError, RunQuorumInput};
+use crate::ports::event_publisher::{AppEvent, EventPublisher};
+use crate::ports::human_intervention::{HumanInterventionError, HumanInterventionPort};
 use crate::ports::llm_gateway::LlmGateway;
 use crate::ports::progress::ProgressNotifier;
 use async_trait::async_trait;
-use quorum_domain::quorum::parsing::parse_debate_verdict;
+use quorum_domain::quorum::parsing::{
+    parse_debate_verdict, parse_decomposition_request, parse_divergence_check,
+    parse_moderator_rulings, parse_opponent_rebuttals,
+};
 use quorum_domain::{
-    DebateConfig, DebatePromptTemplate, Model, ModelResponse, OrchestrationStrategy, PeerReview,
-    Phase, QuorumResult, SynthesisResult,
+    DebateConfig, DebateIntensity, DebatePromptTemplate, HilMode, HumanDecision, Model,
+    ModelResponse, Objection, ObjectionLedger, ObjectionStatus, OrchestrationStrategy, PeerReview,
+    Phase, QuorumResult, QuorumResultPayload, QuorumTopic, SynthesisResult, Vote, VoteResult,
+    VoteVerdict,
 };
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -69,6 +76,171 @@ impl DebateStrategyExecutor {
             .collect::<Vec<_>>()
             .join("\n\n")
     }
+
+    /// Query the opponent's attack for `round`, allowing at most one
+    /// decomposition detour (#316's `DECOMPOSE_REQUEST:` protocol).
+    ///
+    /// If the opponent's response opens with a `DECOMPOSE_REQUEST:` line
+    /// (see [`parse_decomposition_request`]), the proponent is asked to
+    /// break the targeted claim into sub-claims via
+    /// [`DebatePromptTemplate::proponent_decomposition_prompt`], that
+    /// response is appended to `transcript`, and the opponent is re-queried
+    /// against the updated transcript — all within the same round (`round`
+    /// is only used for labeling/logging here; the caller's loop counter is
+    /// never touched). If the re-query *also* opens with a
+    /// `DECOMPOSE_REQUEST:`, the second request is ignored (one detour per
+    /// round, enforced here rather than trusted to the model) — a warning
+    /// is logged and the raw response is returned as-is for the caller to
+    /// parse as a normal CLAIM/EVIDENCE/SEVERITY rebuttal (or treated as
+    /// empty if it isn't one).
+    #[allow(clippy::too_many_arguments)]
+    async fn query_opponent_attack_with_decomposition(
+        gateway: &Arc<dyn LlmGateway>,
+        opponent: &Model,
+        proponent: &Model,
+        intensity: DebateIntensity,
+        question: &str,
+        transcript: &mut Vec<(String, String)>,
+        round: usize,
+        progress: &dyn ProgressNotifier,
+    ) -> Result<String, RunQuorumError> {
+        let attack_prompt = DebatePromptTemplate::opponent_attack_prompt(
+            question,
+            &Self::render_transcript(transcript),
+        );
+        let attack_text = match Self::query(
+            gateway,
+            opponent,
+            &DebatePromptTemplate::opponent_system(intensity),
+            &attack_prompt,
+        )
+        .await
+        {
+            Ok(text) => {
+                progress.on_task_complete(&Phase::Review, opponent, true);
+                text
+            }
+            Err(e) => {
+                progress.on_task_complete(&Phase::Review, opponent, false);
+                return Err(e);
+            }
+        };
+
+        let Some(target) = parse_decomposition_request(&attack_text) else {
+            return Ok(attack_text);
+        };
+        info!(
+            "Opponent requested decomposition of \"{}\" in round {}",
+            target, round
+        );
+
+        let decomposition_prompt = DebatePromptTemplate::proponent_decomposition_prompt(
+            &target,
+            &Self::render_transcript(transcript),
+        );
+        let decomposition_text = match Self::query(
+            gateway,
+            proponent,
+            &DebatePromptTemplate::proponent_system(intensity),
+            &decomposition_prompt,
+        )
+        .await
+        {
+            Ok(text) => {
+                progress.on_task_complete(&Phase::Review, proponent, true);
+                text
+            }
+            Err(e) => {
+                progress.on_task_complete(&Phase::Review, proponent, false);
+                return Err(e);
+            }
+        };
+        transcript.push((
+            format!("Proponent (round {} decomposition)", round),
+            decomposition_text,
+        ));
+
+        let requery_prompt = DebatePromptTemplate::opponent_attack_prompt(
+            question,
+            &Self::render_transcript(transcript),
+        );
+        let requery_text = match Self::query(
+            gateway,
+            opponent,
+            &DebatePromptTemplate::opponent_system(intensity),
+            &requery_prompt,
+        )
+        .await
+        {
+            Ok(text) => {
+                progress.on_task_complete(&Phase::Review, opponent, true);
+                text
+            }
+            Err(e) => {
+                progress.on_task_complete(&Phase::Review, opponent, false);
+                return Err(e);
+            }
+        };
+
+        if parse_decomposition_request(&requery_text).is_some() {
+            warn!("decomposition request ignored — already used this round");
+        }
+
+        Ok(requery_text)
+    }
+
+    /// Decide what to do when a settle checkpoint (early verdict OR forced
+    /// final round) is reached while critical/major objections are still
+    /// unresolved.
+    ///
+    /// This mirrors `RunAgentUseCase::handle_human_intervention`
+    /// (`run_agent/hil.rs`) so the three `HilMode` branches behave
+    /// consistently across use cases:
+    /// - `AutoReject` — fail-secure default, never silently settle.
+    /// - `AutoApprove` — force the settlement through, loudly logged.
+    /// - `Interactive` — defer to `HumanInterventionPort::request_debate_escalation`
+    ///   if one is configured, otherwise fall back to `AutoReject`'s behavior.
+    async fn handle_debate_escalation(
+        hil_mode: HilMode,
+        human_intervention: Option<&Arc<dyn HumanInterventionPort>>,
+        question: &str,
+        unresolved: &[Objection],
+        transcript_summary: &str,
+    ) -> Result<HumanDecision, RunQuorumError> {
+        match hil_mode {
+            HilMode::AutoReject => {
+                warn!(
+                    "Auto-rejecting debate settlement due to HilMode::AutoReject ({} unresolved critical/major objection(s))",
+                    unresolved.len()
+                );
+                Ok(HumanDecision::Reject)
+            }
+            HilMode::AutoApprove => {
+                warn!(
+                    "Auto-approving debate settlement despite {} unresolved critical/major objection(s) (HilMode::AutoApprove) - use with caution!",
+                    unresolved.len()
+                );
+                Ok(HumanDecision::Approve)
+            }
+            HilMode::Interactive => {
+                if let Some(intervention) = human_intervention {
+                    intervention
+                        .request_debate_escalation(question, unresolved, transcript_summary)
+                        .await
+                        .map_err(|e| match e {
+                            HumanInterventionError::Cancelled => RunQuorumError::Cancelled,
+                            _ => RunQuorumError::HumanInterventionFailed(e.to_string()),
+                        })
+                } else {
+                    warn!(
+                        "No human intervention handler configured for debate escalation, auto-rejecting ({} unresolved critical/major objection(s))",
+                        unresolved.len()
+                    );
+                    Ok(HumanDecision::Reject)
+                }
+            }
+        }
+    }
 }
 
 impl Default for DebateStrategyExecutor {
@@ -92,6 +264,8 @@ impl StrategyExecutor for DebateStrategyExecutor {
         input: &RunQuorumInput,
         gateway: Arc<dyn LlmGateway>,
         progress: &dyn ProgressNotifier,
+        event_publisher: Arc<dyn EventPublisher>,
+        human_intervention: Option<Arc<dyn HumanInterventionPort>>,
     ) -> Result<QuorumResult, RunQuorumError> {
         // Dispatch to this executor only happens for the Debate variant — see
         // RunQuorumUseCase's exhaustive match. Any other variant here is a caller bug.
@@ -129,6 +303,14 @@ impl StrategyExecutor for DebateStrategyExecutor {
         let mut transcript: Vec<(String, String)> = Vec::new();
         let mut model_responses: Vec<ModelResponse> = Vec::new();
         let mut peer_reviews: Vec<PeerReview> = Vec::new();
+        // Tracks the opponent's structured (CLAIM/EVIDENCE/SEVERITY) rebuttals
+        // across rounds so the moderator can rule on each by stable ID instead
+        // of re-deriving rebuttal identity from prose each checkpoint.
+        let mut ledger = ObjectionLedger::new();
+        // Guards the anti-mode-collapse "contrarian brief" (see below) so it
+        // fires at most once per debate, even though it's only ever attempted
+        // in round 1.
+        let mut contrarian_brief_used = false;
 
         // Phase: Initial — position assignment + opening statement
         progress.on_phase_start(&Phase::Initial, 1);
@@ -161,6 +343,13 @@ impl StrategyExecutor for DebateStrategyExecutor {
         progress.on_phase_start(&Phase::Review, review_task_estimate);
 
         let mut settled_synthesis: Option<SynthesisResult> = None;
+        // Domain-computed outcome of the debate, independent of any vote
+        // tally: flips true once a settle checkpoint is actually reached
+        // (either a clean settle with no unresolved critical/major
+        // objections, or a forced settle via `HumanDecision::Approve` at
+        // escalation). The `Reject`/`Edit` escalation path returns an `Err`
+        // before this point, so it never lingers `false` past the loop.
+        let mut settled = false;
 
         for round in 1..=max_rounds {
             if round > 1 {
@@ -192,33 +381,115 @@ impl StrategyExecutor for DebateStrategyExecutor {
                 transcript.push((format!("Proponent (round {} defense)", round), defense));
             }
 
-            let attack_prompt = DebatePromptTemplate::opponent_attack_prompt(
-                question,
-                &Self::render_transcript(&transcript),
-            );
-            let attack_text = match Self::query(
+            let attack_text = Self::query_opponent_attack_with_decomposition(
                 &gateway,
                 &opponent,
-                &DebatePromptTemplate::opponent_system(config.intensity),
-                &attack_prompt,
+                &proponent,
+                config.intensity,
+                question,
+                &mut transcript,
+                round,
+                progress,
             )
-            .await
-            {
-                Ok(text) => {
-                    progress.on_task_complete(&Phase::Review, &opponent, true);
-                    text
-                }
-                Err(e) => {
-                    progress.on_task_complete(&Phase::Review, &opponent, false);
-                    return Err(e);
-                }
-            };
+            .await?;
             peer_reviews.push(PeerReview::new(
                 opponent.to_string(),
                 format!("Round {} proposal", round),
                 attack_text.clone(),
             ));
+            for (claim, evidence, severity) in parse_opponent_rebuttals(&attack_text) {
+                ledger.add(round, claim, evidence, severity);
+            }
             transcript.push((format!("Opponent (round {} attack)", round), attack_text));
+
+            // Anti-mode-collapse divergence check (#316): only once, right after
+            // round 1's opponent attack and before the round's usual moderator
+            // checkpoint. If the proponent's opening and the opponent's first
+            // attack have quietly converged on the same conclusion instead of
+            // genuinely disagreeing, attacking each other's phrasing for the
+            // rest of the debate wastes rounds on a false adversarial framing.
+            // The moderator is asked to judge this explicitly; if it finds no
+            // real divergence, a one-off "contrarian brief" is run to attack
+            // the shared premise directly, assigned to whichever voice isn't
+            // already committed to defending it (the third-party interjector
+            // if one exists, otherwise the opponent doubles up).
+            if round == 1 && !contrarian_brief_used {
+                let opening_text = transcript[0].1.clone();
+                let first_attack_text = transcript[1].1.clone();
+                let divergence_prompt = DebatePromptTemplate::divergence_check_prompt(
+                    question,
+                    &opening_text,
+                    &first_attack_text,
+                );
+                match Self::query(
+                    &gateway,
+                    &moderator,
+                    DebatePromptTemplate::moderator_divergence_system(),
+                    &divergence_prompt,
+                )
+                .await
+                {
+                    Ok(divergence_text) => {
+                        progress.on_task_complete(&Phase::Review, &moderator, true);
+                        let (divergent, note) = parse_divergence_check(&divergence_text);
+                        if !divergent {
+                            contrarian_brief_used = true;
+                            let contrarian = interjectors.first().unwrap_or(&opponent).clone();
+                            let brief_prompt = DebatePromptTemplate::contrarian_brief_prompt(
+                                question,
+                                &note,
+                                &Self::render_transcript(&transcript),
+                            );
+                            match Self::query(
+                                &gateway,
+                                &contrarian,
+                                DebatePromptTemplate::contrarian_system(),
+                                &brief_prompt,
+                            )
+                            .await
+                            {
+                                Ok(brief_text) => {
+                                    progress.on_task_complete(&Phase::Review, &contrarian, true);
+                                    for (claim, evidence, severity) in
+                                        parse_opponent_rebuttals(&brief_text)
+                                    {
+                                        ledger.add(round, claim, evidence, severity);
+                                    }
+                                    peer_reviews.push(PeerReview::new(
+                                        contrarian.to_string(),
+                                        "Contrarian brief (shared-premise attack)".to_string(),
+                                        brief_text.clone(),
+                                    ));
+                                    transcript.push((
+                                        format!("Contrarian brief ({})", contrarian),
+                                        brief_text,
+                                    ));
+                                }
+                                Err(e) => {
+                                    // The contrarian brief is a supplementary
+                                    // safeguard, not load-bearing — log and
+                                    // continue the debate rather than aborting
+                                    // over it.
+                                    warn!("Contrarian brief failed for {}: {}", contrarian, e);
+                                    progress.on_task_complete(&Phase::Review, &contrarian, false);
+                                }
+                            }
+                        } else {
+                            info!(
+                                "Debate divergence check: genuine disagreement detected, note: {}",
+                                note
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        // Likewise supplementary — a failed divergence check
+                        // shouldn't abort a debate that's otherwise proceeding
+                        // normally.
+                        warn!("Moderator divergence check failed: {}", e);
+                        progress.on_task_complete(&Phase::Review, &moderator, false);
+                    }
+                }
+            }
 
             for interjector in &interjectors {
                 let note_prompt = DebatePromptTemplate::interjector_prompt(
@@ -258,13 +529,20 @@ impl StrategyExecutor for DebateStrategyExecutor {
             }
 
             let is_final_round = round == max_rounds;
-            let checkpoint_prompt = DebatePromptTemplate::moderator_checkpoint_prompt(
-                question,
-                &Self::render_transcript(&transcript),
-                round,
-                max_rounds,
-                is_final_round,
-            );
+            let open_objections: Vec<(&str, &str)> = ledger
+                .open_objections()
+                .iter()
+                .map(|o| (o.id.as_str(), o.claim.as_str()))
+                .collect();
+            let checkpoint_prompt =
+                DebatePromptTemplate::moderator_checkpoint_prompt_with_objections(
+                    question,
+                    &Self::render_transcript(&transcript),
+                    round,
+                    max_rounds,
+                    is_final_round,
+                    &open_objections,
+                );
             let checkpoint_text = match Self::query(
                 &gateway,
                 &moderator,
@@ -283,10 +561,72 @@ impl StrategyExecutor for DebateStrategyExecutor {
                 }
             };
 
+            for (rebuttal_id, accepted, reason) in parse_moderator_rulings(&checkpoint_text) {
+                if ledger.all().iter().any(|o| o.id == rebuttal_id) {
+                    ledger.apply_ruling(&rebuttal_id, accepted, reason);
+                } else {
+                    warn!(
+                        "Moderator ruling references unknown rebuttal ID {} in round {}",
+                        rebuttal_id, round
+                    );
+                }
+            }
+
             let (verdict_settled, body) = parse_debate_verdict(&checkpoint_text);
             if verdict_settled || is_final_round {
-                settled_synthesis = Some(SynthesisResult::new(moderator.to_string(), body));
-                break;
+                // Gate every settle point — not just the final round — so a
+                // moderator can't rubber-stamp a premature "SETTLED" verdict
+                // while critical/major objections are still open.
+                let unresolved: Vec<Objection> = ledger
+                    .unresolved_critical_or_major()
+                    .into_iter()
+                    .cloned()
+                    .collect();
+
+                if unresolved.is_empty() {
+                    settled_synthesis = Some(SynthesisResult::new(moderator.to_string(), body));
+                    settled = true;
+                    break;
+                }
+
+                let decision = Self::handle_debate_escalation(
+                    input.hil_mode,
+                    human_intervention.as_ref(),
+                    question,
+                    &unresolved,
+                    &Self::render_transcript(&transcript),
+                )
+                .await?;
+
+                match decision {
+                    HumanDecision::Approve => {
+                        warn!(
+                            "Forcing debate settlement at round {} despite {} unresolved critical/major objection(s)",
+                            round,
+                            unresolved.len()
+                        );
+                        let mut synthesis = SynthesisResult::new(moderator.to_string(), body);
+                        synthesis.disagreements.push(format!(
+                            "⚠️ Settled with {} unresolved critical/major objection(s) still open: {}",
+                            unresolved.len(),
+                            unresolved
+                                .iter()
+                                .map(|o| format!("{} ({})", o.claim, o.id))
+                                .collect::<Vec<_>>()
+                                .join("; ")
+                        ));
+                        settled_synthesis = Some(synthesis);
+                        settled = true;
+                        break;
+                    }
+                    HumanDecision::Reject | HumanDecision::Edit(_) => {
+                        return Err(RunQuorumError::DebateEscalationRejected(format!(
+                            "{} unresolved critical/major objection(s) at round {}",
+                            unresolved.len(),
+                            round
+                        )));
+                    }
+                }
             }
             transcript.push((format!("Moderator (round {} note)", round), body));
         }
@@ -299,6 +639,71 @@ impl StrategyExecutor for DebateStrategyExecutor {
         progress.on_phase_start(&Phase::Synthesis, 1);
         progress.on_task_complete(&Phase::Synthesis, &moderator, true);
         progress.on_phase_complete(&Phase::Synthesis);
+
+        // Fold every objection ruling into the shared Vote schema: each
+        // ledger entry becomes one vote from the moderator, so the
+        // `quorum_result` contract (JSONL / RPC / Lua) sees the same
+        // per-claim verdicts a human reading the transcript would.
+        // Refuted (critic's objection rejected) reads as the moderator
+        // "approving" the proponent's claim; Conceded reads as a rejection
+        // of it; anything never ruled on abstains rather than silently
+        // counting either way.
+        let mut votes: Vec<Vote> = ledger
+            .all()
+            .iter()
+            .map(|objection| {
+                let id = &objection.id;
+                let claim = &objection.claim;
+                let reason = objection
+                    .ruling_reason
+                    .as_deref()
+                    .unwrap_or("no ruling recorded");
+                let verdict = match objection.status {
+                    ObjectionStatus::Refuted => VoteVerdict::Approve,
+                    ObjectionStatus::Conceded => VoteVerdict::Reject,
+                    ObjectionStatus::Unresolved => VoteVerdict::Abstain,
+                };
+                Vote::new(
+                    moderator.to_string(),
+                    verdict,
+                    format!("[{id}] {claim}: {reason}"),
+                )
+            })
+            .collect();
+
+        // Explicit closing vote for the debate as a whole — the moderator's
+        // final ruling, distinct from (and appended after) the per-objection
+        // votes above.
+        votes.push(Vote::new(
+            moderator.to_string(),
+            if settled {
+                VoteVerdict::Approve
+            } else {
+                VoteVerdict::Reject
+            },
+            synthesis.conclusion.clone(),
+        ));
+
+        // Built directly (not `VoteResult::from_votes`): `passed` must
+        // reflect the domain-computed `settled` outcome, not a majority
+        // tally of the votes above — a debate can settle with more Reject
+        // (conceded) objection-votes than Approve ones and still be a valid,
+        // decided outcome.
+        let approve_count = votes.iter().filter(|v| v.is_approve()).count();
+        let reject_count = votes.iter().filter(|v| v.is_reject()).count();
+        let total_votes = votes.len();
+        let vote_result = VoteResult {
+            passed: settled,
+            approve_count,
+            reject_count,
+            total_votes,
+            votes,
+            aggregated_feedback: None,
+        };
+
+        let payload = QuorumResultPayload::new(QuorumTopic::Debate, None, &vote_result)
+            .with_synthesis(synthesis.clone());
+        event_publisher.publish(AppEvent::QuorumResult(Box::new(payload)));
 
         Ok(QuorumResult::new(
             input.question.content(),
@@ -313,9 +718,49 @@ impl StrategyExecutor for DebateStrategyExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::event_publisher::{AppEvent, NoEventPublisher, RecordingEventPublisher};
     use crate::ports::progress::NoProgress;
     use crate::use_cases::run_quorum::test_support::ScriptedGateway;
-    use quorum_domain::{DebateIntensity, ModelConfig};
+    use quorum_domain::{DebateIntensity, ModelConfig, Plan, ReviewRound};
+    use std::sync::Mutex;
+
+    /// Mock `HumanInterventionPort` that returns a pre-configured
+    /// (`request_debate_escalation`-only) outcome and counts invocations.
+    struct MockEscalationHandler {
+        outcome: Result<HumanDecision, HumanInterventionError>,
+        calls: Mutex<usize>,
+    }
+
+    impl MockEscalationHandler {
+        fn new(outcome: Result<HumanDecision, HumanInterventionError>) -> Self {
+            Self {
+                outcome,
+                calls: Mutex::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl HumanInterventionPort for MockEscalationHandler {
+        async fn request_intervention(
+            &self,
+            _request: &str,
+            _plan: &Plan,
+            _review_history: &[ReviewRound],
+        ) -> Result<HumanDecision, HumanInterventionError> {
+            unreachable!("not exercised by debate escalation tests")
+        }
+
+        async fn request_debate_escalation(
+            &self,
+            _question: &str,
+            _unresolved: &[Objection],
+            _transcript_summary: &str,
+        ) -> Result<HumanDecision, HumanInterventionError> {
+            *self.calls.lock().unwrap() += 1;
+            self.outcome.clone()
+        }
+    }
 
     fn base_input(strategy: OrchestrationStrategy) -> RunQuorumInput {
         RunQuorumInput::new(
@@ -335,6 +780,45 @@ mod tests {
         }
     }
 
+    /// Builds a scripted moderator divergence-check response (see
+    /// `DebatePromptTemplate::moderator_divergence_system`'s `DIVERGENT:
+    /// YES|NO` format). Every round-1 attack in this file is followed by one
+    /// of these before the usual checkpoint — spelling it out as a literal
+    /// each time obscures which line is the actual signal under test.
+    fn divergence_response(divergent: bool, note: &str) -> String {
+        format!(
+            "DIVERGENT: {}\n\n{}",
+            if divergent { "YES" } else { "NO" },
+            note
+        )
+    }
+
+    /// Builds a scripted moderator checkpoint response (see
+    /// `DebatePromptTemplate::moderator_system`'s `VERDICT: SETTLED|CONTINUE`
+    /// format). `rulings` are optional `REBUTTAL_ID`/`RULING`/`REASON`
+    /// blocks (see [`ruling_block`]) prefixed before the verdict body —
+    /// pass an empty slice for scenarios with no open objections to rule on.
+    fn verdict_response(settled: bool, rulings: &[String], body: &str) -> String {
+        let verdict_line = format!("VERDICT: {}", if settled { "SETTLED" } else { "CONTINUE" });
+        if rulings.is_empty() {
+            format!("{}\n\n{}", verdict_line, body)
+        } else {
+            format!("{}\n\n{}\n\n{}", verdict_line, rulings.join("\n\n"), body)
+        }
+    }
+
+    /// Builds a single `REBUTTAL_ID`/`RULING`/`REASON` block for use inside
+    /// [`verdict_response`]'s `rulings` slice.
+    #[allow(dead_code)] // no target test in this file currently needs a ruling block
+    fn ruling_block(id: &str, accepted: bool, reason: &str) -> String {
+        format!(
+            "REBUTTAL_ID: {}\nRULING: {}\nREASON: {}",
+            id,
+            if accepted { "ACCEPTED" } else { "REJECTED" },
+            reason
+        )
+    }
+
     #[tokio::test]
     async fn debate_settles_early_when_moderator_agrees() {
         let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 5);
@@ -343,13 +827,33 @@ mod tests {
         let gateway = ScriptedGateway::new();
         gateway.respond(Model::Gpt53Codex, "Write-through keeps consistency simple.");
         gateway.respond(Model::Gemini31Pro, "Write-behind has better write latency.");
+        // Round 1's divergence check (asked before the usual checkpoint) —
+        // genuine disagreement, so no contrarian brief fires.
         gateway.respond(
             Model::ClaudeSonnet45,
-            "VERDICT: SETTLED\n\nWrite-through wins for correctness-critical systems.",
+            divergence_response(true, "They disagree on consistency vs. latency tradeoffs."),
+        );
+        // No structured opponent rebuttal was raised above, so there's
+        // nothing in the ledger to rule on — the checkpoint response omits
+        // any REBUTTAL_ID block.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            verdict_response(
+                true,
+                &[],
+                "Write-through wins for correctness-critical systems.",
+            ),
         );
 
+        let event_publisher = Arc::new(RecordingEventPublisher::new());
         let result = DebateStrategyExecutor::new()
-            .execute(&input, Arc::new(gateway), &NoProgress)
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                event_publisher.clone(),
+                None,
+            )
             .await
             .unwrap();
 
@@ -357,6 +861,27 @@ mod tests {
         assert_eq!(result.reviews.len(), 1); // opponent's round-1 attack
         assert_eq!(
             result.synthesis.conclusion,
+            "Write-through wins for correctness-critical systems."
+        );
+
+        // No structured rebuttal was raised, so the only vote is the closing
+        // one, and — since the debate settled cleanly — it approves.
+        let events = event_publisher.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        let AppEvent::QuorumResult(payload) = &events[0] else {
+            panic!("expected QuorumResult event");
+        };
+        assert_eq!(payload.topic, QuorumTopic::Debate);
+        assert!(payload.target.is_none());
+        assert!(payload.approved);
+        assert_eq!(payload.votes.len(), 1);
+        assert_eq!(payload.votes[0].verdict, VoteVerdict::Approve);
+        assert_eq!(
+            payload.votes[0].reasoning,
+            "Write-through wins for correctness-critical systems."
+        );
+        assert_eq!(
+            payload.synthesis.as_ref().unwrap().conclusion,
             "Write-through wins for correctness-critical systems."
         );
     }
@@ -369,9 +894,17 @@ mod tests {
         let gateway = ScriptedGateway::new();
         gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
         gateway.respond(Model::Gemini31Pro, "Attack round 1: latency matters more.");
+        // Round 1's divergence check — genuine disagreement, no contrarian brief.
         gateway.respond(
             Model::ClaudeSonnet45,
-            "VERDICT: CONTINUE\n\nStill contested: latency vs consistency.",
+            divergence_response(true, "They disagree on consistency vs. latency tradeoffs."),
+        );
+        // Neither round's opponent attack is a structured rebuttal, so the
+        // ledger stays empty and neither checkpoint response needs a
+        // REBUTTAL_ID ruling.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            verdict_response(false, &[], "Still contested: latency vs consistency."),
         );
         gateway.respond(
             Model::Gpt53Codex,
@@ -380,11 +913,17 @@ mod tests {
         gateway.respond(Model::Gemini31Pro, "Attack round 2: but writes pile up.");
         gateway.respond(
             Model::ClaudeSonnet45,
-            "VERDICT: CONTINUE\n\nNo real resolution, but rounds are up.",
+            verdict_response(false, &[], "No real resolution, but rounds are up."),
         );
 
         let result = DebateStrategyExecutor::new()
-            .execute(&input, Arc::new(gateway), &NoProgress)
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
             .await
             .unwrap();
 
@@ -395,6 +934,242 @@ mod tests {
             result.synthesis.conclusion,
             "No real resolution, but rounds are up."
         );
+    }
+
+    #[tokio::test]
+    async fn debate_contrarian_brief_fires_when_divergence_check_finds_no_divergence() {
+        // No interjectors — the opponent doubles up as the contrarian.
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Opening: AI will match human performance.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "Attack round 1: AI will match human performance, just later than claimed.",
+        );
+        // The moderator's divergence check finds no genuine disagreement —
+        // both sides share the premise that AI will eventually match human
+        // performance, they just quibble over timing.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: NO\n\nBoth sides agree AI will eventually match human performance.",
+        );
+        // The contrarian brief (opponent, since no interjector exists) attacks
+        // that shared premise directly.
+        gateway.respond(
+            Model::Gemini31Pro,
+            "CLAIM: AI will not match human performance\nEVIDENCE: benchmark X has plateaued for 3 years\nSEVERITY: MINOR",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nAI trajectory remains contested.",
+        );
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The contrarian brief is recorded as an extra review beyond the
+        // opponent's normal round-1 attack.
+        assert_eq!(result.reviews.len(), 2);
+        assert!(
+            result
+                .reviews
+                .iter()
+                .any(|r| r.reviewed_id.contains("Contrarian brief")),
+            "expected a contrarian-brief review, got: {:?}",
+            result
+                .reviews
+                .iter()
+                .map(|r| &r.reviewed_id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn debate_contrarian_brief_uses_interjector_when_present() {
+        let config = DebateConfig {
+            allow_interjection: true,
+            ..debate_config(
+                vec![Model::Gpt53Codex, Model::Gemini31Pro, Model::ClaudeHaiku45],
+                1,
+            )
+        };
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Opening: AI will match human performance.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "Attack round 1: AI will match human performance, just later than claimed.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: NO\n\nBoth sides agree AI will eventually match human performance.",
+        );
+        // With a third model available, the interjector — not the opponent —
+        // is assigned the contrarian brief.
+        gateway.respond(
+            Model::ClaudeHaiku45,
+            "CLAIM: AI will not match human performance\nEVIDENCE: benchmark X has plateaued for 3 years\nSEVERITY: MINOR",
+        );
+        gateway.respond(
+            Model::ClaudeHaiku45,
+            "Interjection: both ignore compute cost trends.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nAI trajectory remains contested.",
+        );
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result
+                .reviews
+                .iter()
+                .any(|r| r.reviewed_id.contains("Contrarian brief")
+                    && r.reviewer == Model::ClaudeHaiku45.to_string()),
+            "expected the interjector to deliver the contrarian brief, got: {:?}",
+            result
+                .reviews
+                .iter()
+                .map(|r| (&r.reviewer, &r.reviewed_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn debate_decomposition_request_triggers_proponent_split_then_requery() {
+        // No interjectors, single round: opponent's first attack asks for
+        // decomposition; the proponent splits the claim; the opponent then
+        // re-attacks the split claim with a normal structured rebuttal, all
+        // still counted as round 1 (max_rounds stays 1).
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Opening: caching and retry policy should share one config knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "DECOMPOSE_REQUEST: caching and retry policy should share one config knob",
+        );
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Sub-claim 1: caching should be a single knob.\nSub-claim 2: retry policy should be a single knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "CLAIM: retry policy as a single knob\nEVIDENCE: it hides per-endpoint backoff needs\nSEVERITY: MINOR",
+        );
+        // Round 1's divergence check — genuine disagreement, no contrarian brief.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on whether one knob suffices.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nSplit the knobs.",
+        );
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Only the opening is a "response"; the decomposition detour doesn't
+        // add one (it's transcript-only, not a model_responses entry).
+        assert_eq!(result.responses.len(), 1);
+        // The single opponent review slot holds the *post-decomposition*
+        // rebuttal, not the original DECOMPOSE_REQUEST text.
+        assert_eq!(result.reviews.len(), 1);
+        assert!(result.reviews[0].content.starts_with("CLAIM:"));
+        assert_eq!(result.synthesis.conclusion, "Split the knobs.");
+    }
+
+    #[tokio::test]
+    async fn debate_second_decomposition_request_in_same_round_is_ignored() {
+        // The opponent tries to request decomposition twice in the same
+        // round (after already getting one). The second request must be
+        // ignored — no second proponent detour — and the raw (still
+        // DECOMPOSE_REQUEST-prefixed) text is parsed as a normal rebuttal,
+        // which yields no CLAIM/EVIDENCE/SEVERITY (i.e. no ledger entry).
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(Model::Gpt53Codex, "Opening: one knob for everything.");
+        gateway.respond(
+            Model::Gemini31Pro,
+            "DECOMPOSE_REQUEST: one knob for everything",
+        );
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Sub-claim 1: caching knob.\nSub-claim 2: retry knob.",
+        );
+        // Second decomposition request in the same round — must be ignored.
+        gateway.respond(
+            Model::Gemini31Pro,
+            "DECOMPOSE_REQUEST: caching knob still too broad",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nGenuine disagreement over knob granularity.",
+        );
+        gateway.respond(Model::ClaudeSonnet45, "VERDICT: SETTLED\n\nUse two knobs.");
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The ignored second request is recorded as the raw review text —
+        // no third gateway call was made for it (the scripted queues above
+        // would have errored with "no scripted response left" otherwise).
+        assert_eq!(result.reviews.len(), 1);
+        assert_eq!(
+            result.reviews[0].content,
+            "DECOMPOSE_REQUEST: caching knob still too broad"
+        );
+        assert_eq!(result.synthesis.conclusion, "Use two knobs.");
     }
 
     #[tokio::test]
@@ -411,17 +1186,32 @@ mod tests {
         let gateway = ScriptedGateway::new();
         gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
         gateway.respond(Model::Gemini31Pro, "Attack: latency matters more.");
+        // Round 1's divergence check — genuine disagreement, no contrarian
+        // brief, so the interjector's queue below is used only for its
+        // normal interjection turn.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            divergence_response(true, "They disagree on latency vs consistency."),
+        );
         gateway.respond(
             Model::ClaudeHaiku45,
             "Interjection: both ignore cold-start cost.",
         );
+        // No structured opponent rebuttal, so the checkpoint response omits
+        // any REBUTTAL_ID ruling.
         gateway.respond(
             Model::ClaudeSonnet45,
-            "VERDICT: SETTLED\n\nWrite-through, with a cache warmer.",
+            verdict_response(true, &[], "Write-through, with a cache warmer."),
         );
 
         let result = DebateStrategyExecutor::new()
-            .execute(&input, Arc::new(gateway), &NoProgress)
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
             .await
             .unwrap();
 
@@ -441,10 +1231,194 @@ mod tests {
         let gateway = ScriptedGateway::new();
 
         let err = DebateStrategyExecutor::new()
-            .execute(&input, Arc::new(gateway), &NoProgress)
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
             .await
             .unwrap_err();
 
         assert!(matches!(err, RunQuorumError::NotEnoughModelsForDebate(1)));
+    }
+
+    /// Builds a common fixture: opponent raises one CRITICAL rebuttal and the
+    /// moderator declares `SETTLED` in round 1 without ruling on it — i.e. the
+    /// moderator tries to settle early while a critical objection is still open.
+    fn escalation_gateway() -> ScriptedGateway {
+        let gateway = ScriptedGateway::new();
+        gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
+        gateway.respond(
+            Model::Gemini31Pro,
+            "CLAIM: write-through never expires\nEVIDENCE: TTL config defaults to infinite\nSEVERITY: CRITICAL",
+        );
+        // Round 1's divergence check — genuine disagreement, no contrarian brief.
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on TTL handling.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nWrite-through wins.",
+        );
+        gateway
+    }
+
+    #[tokio::test]
+    async fn debate_early_settle_with_unresolved_critical_objection_is_auto_rejected() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        // RunQuorumInput::new() defaults to HilMode::AutoReject.
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let err = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_early_settle_with_unresolved_objection_forced_on_auto_approve() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::AutoApprove);
+
+        let event_publisher = Arc::new(RecordingEventPublisher::new());
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                event_publisher.clone(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.synthesis.conclusion, "Write-through wins.");
+        // Forced settlement leaves a note about the unresolved objection.
+        assert_eq!(result.synthesis.disagreements.len(), 1);
+        assert!(
+            result.synthesis.disagreements[0].contains("unresolved"),
+            "expected disagreement note about the unresolved objection, got: {:?}",
+            result.synthesis.disagreements
+        );
+
+        // The domain-computed `settled` outcome (forced via escalation
+        // Approve) drives `passed` — not a majority tally of the votes
+        // below, which include an Abstain for the still-unresolved
+        // objection alongside the closing Approve vote.
+        let events = event_publisher.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        let AppEvent::QuorumResult(payload) = &events[0] else {
+            panic!("expected QuorumResult event");
+        };
+        assert!(payload.approved);
+        assert_eq!(payload.votes.len(), 2);
+        assert_eq!(payload.votes[0].verdict, VoteVerdict::Abstain);
+        assert!(payload.votes[0].reasoning.starts_with("[R1-1]"));
+        assert!(
+            payload.votes[0]
+                .reasoning
+                .contains("write-through never expires")
+        );
+        assert_eq!(payload.votes[1].verdict, VoteVerdict::Approve);
+        assert_eq!(payload.votes[1].reasoning, "Write-through wins.");
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_escalation_approve_forces_settlement_with_note() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Approve)));
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert_eq!(result.synthesis.disagreements.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_escalation_reject_aborts_execute() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Reject)));
+
+        let err = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_without_handler_falls_back_to_reject() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+
+        let err = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_escalation_cancelled_maps_to_cancelled_error() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Err(
+            HumanInterventionError::Cancelled,
+        )));
+
+        let err = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, RunQuorumError::Cancelled));
     }
 }

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -694,7 +694,11 @@ impl StrategyExecutor for DebateStrategyExecutor {
         // Refuted (critic's objection rejected) reads as the moderator
         // "approving" the proponent's claim; Conceded reads as a rejection
         // of it; anything never ruled on abstains rather than silently
-        // counting either way.
+        // counting either way. The ruling itself (refuted/conceded/
+        // unresolved) is spelled out in `reasoning` alongside the verdict —
+        // without it, e.g. `verdict=Approve` next to `reasoning` quoting the
+        // *attacking* claim reads backwards (as if the attack were being
+        // approved, not rejected).
         let mut votes: Vec<Vote> = ledger
             .all()
             .iter()
@@ -705,15 +709,15 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     .ruling_reason
                     .as_deref()
                     .unwrap_or("no ruling recorded");
-                let verdict = match objection.status {
-                    ObjectionStatus::Refuted => VoteVerdict::Approve,
-                    ObjectionStatus::Conceded => VoteVerdict::Reject,
-                    ObjectionStatus::Unresolved => VoteVerdict::Abstain,
+                let (verdict, ruling_label) = match objection.status {
+                    ObjectionStatus::Refuted => (VoteVerdict::Approve, "refuted"),
+                    ObjectionStatus::Conceded => (VoteVerdict::Reject, "conceded"),
+                    ObjectionStatus::Unresolved => (VoteVerdict::Abstain, "unresolved"),
                 };
                 Vote::new(
                     moderator.to_string(),
                     verdict,
-                    format!("[{id}] {claim}: {reason}"),
+                    format!("[{id}][{ruling_label}] {claim}: {reason}"),
                 )
             })
             .collect();
@@ -1557,7 +1561,7 @@ mod tests {
         assert!(payload.approved);
         assert_eq!(payload.votes.len(), 2);
         assert_eq!(payload.votes[0].verdict, VoteVerdict::Abstain);
-        assert!(payload.votes[0].reasoning.starts_with("[R1-1]"));
+        assert!(payload.votes[0].reasoning.starts_with("[R1-1][unresolved]"));
         assert!(
             payload.votes[0]
                 .reasoning

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -400,6 +400,13 @@ impl StrategyExecutor for DebateStrategyExecutor {
             for (claim, evidence, severity) in parse_opponent_rebuttals(&attack_text) {
                 ledger.add(round, claim, evidence, severity);
             }
+            // Captured before `attack_text` is moved into `transcript` below —
+            // used by the divergence check further down. Reading it back out
+            // of `transcript` by index would be wrong when round 1's opponent
+            // requested a decomposition: `query_opponent_attack_with_decomposition`
+            // pushes an intermediate "Proponent (round 1 decomposition)" entry,
+            // shifting the opponent's actual attack to a later index.
+            let first_round_attack_text = (round == 1).then(|| attack_text.clone());
             transcript.push((format!("Opponent (round {} attack)", round), attack_text));
 
             // Anti-mode-collapse divergence check (#316): only once, right after
@@ -415,7 +422,8 @@ impl StrategyExecutor for DebateStrategyExecutor {
             // if one exists, otherwise the opponent doubles up).
             if round == 1 && !contrarian_brief_used {
                 let opening_text = transcript[0].1.clone();
-                let first_attack_text = transcript[1].1.clone();
+                let first_attack_text = first_round_attack_text
+                    .expect("first_round_attack_text is always Some when round == 1");
                 let divergence_prompt = DebatePromptTemplate::divergence_check_prompt(
                     question,
                     &opening_text,
@@ -1117,6 +1125,73 @@ mod tests {
         assert_eq!(result.reviews.len(), 1);
         assert!(result.reviews[0].content.starts_with("CLAIM:"));
         assert_eq!(result.synthesis.conclusion, "Split the knobs.");
+    }
+
+    #[tokio::test]
+    async fn debate_divergence_check_compares_opening_against_opponent_attack_after_decomposition()
+     {
+        // Regression: when round 1's opponent attack triggers a decomposition
+        // detour, `query_opponent_attack_with_decomposition` pushes an
+        // intermediate "Proponent (round 1 decomposition)" entry into the
+        // transcript before the opponent's actual (post-decomposition) attack
+        // is pushed. The divergence check must compare the proponent's
+        // opening against that actual attack — not against the proponent's
+        // own decomposition response that now sits at transcript[1].
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Opening: caching and retry policy should share one config knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "DECOMPOSE_REQUEST: caching and retry policy should share one config knob",
+        );
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Sub-claim 1: caching should be a single knob.\nSub-claim 2: retry policy should be a single knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "CLAIM: retry policy as a single knob\nEVIDENCE: it hides per-endpoint backoff needs\nSEVERITY: MINOR",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on whether one knob suffices.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nSplit the knobs.",
+        );
+
+        let gateway = Arc::new(gateway);
+        DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::clone(&gateway) as Arc<dyn LlmGateway>,
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let moderator_prompts = gateway.sent_prompts(Model::ClaudeSonnet45);
+        let divergence_prompt = moderator_prompts
+            .first()
+            .expect("moderator should have been queried for the divergence check first");
+        assert!(
+            divergence_prompt.contains("CLAIM: retry policy as a single knob"),
+            "divergence check must see the opponent's actual (post-decomposition) attack: {}",
+            divergence_prompt
+        );
+        assert!(
+            !divergence_prompt.contains("Sub-claim 1: caching should be a single knob"),
+            "divergence check must not see the proponent's own decomposition response: {}",
+            divergence_prompt
+        );
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[tokio::test]
     async fn debate_divergence_check_compares_opening_against_opponent_attack_after_decomposition()
-     {
+    {
         // Regression: when round 1's opponent attack triggers a decomposition
         // detour, `query_opponent_attack_with_decomposition` pushes an
         // intermediate "Proponent (round 1 decomposition)" entry into the
@@ -1612,9 +1612,10 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
-        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
-            false
-        ]);
+        assert_eq!(
+            handler.can_continue_calls.lock().unwrap().as_slice(),
+            &[false]
+        );
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
     }
 
@@ -1637,9 +1638,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
-        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
-            true
-        ]);
+        assert_eq!(
+            handler.can_continue_calls.lock().unwrap().as_slice(),
+            &[true]
+        );
         assert!(
             result
                 .synthesis
@@ -1672,7 +1674,7 @@ mod tests {
 
     #[tokio::test]
     async fn debate_interactive_without_handler_falls_back_to_reject_at_non_final_round_continues()
-     {
+    {
         let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -193,6 +193,12 @@ impl DebateStrategyExecutor {
     /// final round) is reached while critical/major objections are still
     /// unresolved.
     ///
+    /// `can_continue` is `true` for a non-final round (a `Reject` decision
+    /// declines the premature settle and the debate continues) and `false`
+    /// at the final round (a `Reject` decision aborts the debate, since
+    /// there is no next round to continue to) — see the caller's match on
+    /// the returned `HumanDecision`.
+    ///
     /// This mirrors `RunAgentUseCase::handle_human_intervention`
     /// (`run_agent/hil.rs`) so the three `HilMode` branches behave
     /// consistently across use cases:
@@ -200,12 +206,14 @@ impl DebateStrategyExecutor {
     /// - `AutoApprove` — force the settlement through, loudly logged.
     /// - `Interactive` — defer to `HumanInterventionPort::request_debate_escalation`
     ///   if one is configured, otherwise fall back to `AutoReject`'s behavior.
+    #[allow(clippy::too_many_arguments)]
     async fn handle_debate_escalation(
         hil_mode: HilMode,
         human_intervention: Option<&Arc<dyn HumanInterventionPort>>,
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, RunQuorumError> {
         match hil_mode {
             HilMode::AutoReject => {
@@ -225,7 +233,12 @@ impl DebateStrategyExecutor {
             HilMode::Interactive => {
                 if let Some(intervention) = human_intervention {
                     intervention
-                        .request_debate_escalation(question, unresolved, transcript_summary)
+                        .request_debate_escalation(
+                            question,
+                            unresolved,
+                            transcript_summary,
+                            can_continue,
+                        )
                         .await
                         .map_err(|e| match e {
                             HumanInterventionError::Cancelled => RunQuorumError::Cancelled,
@@ -603,6 +616,7 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     question,
                     &unresolved,
                     &Self::render_transcript(&transcript),
+                    !is_final_round,
                 )
                 .await?;
 
@@ -628,11 +642,24 @@ impl StrategyExecutor for DebateStrategyExecutor {
                         break;
                     }
                     HumanDecision::Reject | HumanDecision::Edit(_) => {
-                        return Err(RunQuorumError::DebateEscalationRejected(format!(
-                            "{} unresolved critical/major objection(s) at round {}",
-                            unresolved.len(),
-                            round
-                        )));
+                        if is_final_round {
+                            return Err(RunQuorumError::DebateEscalationRejected(format!(
+                                "{} unresolved critical/major objection(s) at round {}",
+                                unresolved.len(),
+                                round
+                            )));
+                        }
+                        // Non-final round: the natural response to a
+                        // premature settle attempt is to decline it and keep
+                        // debating, not to kill the whole run — fall through
+                        // to the same transcript note a normal
+                        // VERDICT: CONTINUE round would get, and proceed to
+                        // round + 1.
+                        info!(
+                            "Debate escalation declined at round {} — continuing rather than settling ({} unresolved critical/major objection(s))",
+                            round,
+                            unresolved.len()
+                        );
                     }
                 }
             }
@@ -733,10 +760,12 @@ mod tests {
     use std::sync::Mutex;
 
     /// Mock `HumanInterventionPort` that returns a pre-configured
-    /// (`request_debate_escalation`-only) outcome and counts invocations.
+    /// (`request_debate_escalation`-only) outcome and records each
+    /// invocation's `can_continue` flag (in call order) alongside the count.
     struct MockEscalationHandler {
         outcome: Result<HumanDecision, HumanInterventionError>,
         calls: Mutex<usize>,
+        can_continue_calls: Mutex<Vec<bool>>,
     }
 
     impl MockEscalationHandler {
@@ -744,6 +773,7 @@ mod tests {
             Self {
                 outcome,
                 calls: Mutex::new(0),
+                can_continue_calls: Mutex::new(Vec::new()),
             }
         }
     }
@@ -764,8 +794,10 @@ mod tests {
             _question: &str,
             _unresolved: &[Objection],
             _transcript_summary: &str,
+            can_continue: bool,
         ) -> Result<HumanDecision, HumanInterventionError> {
             *self.calls.lock().unwrap() += 1;
+            self.can_continue_calls.lock().unwrap().push(can_continue);
             self.outcome.clone()
         }
     }
@@ -817,7 +849,6 @@ mod tests {
 
     /// Builds a single `REBUTTAL_ID`/`RULING`/`REASON` block for use inside
     /// [`verdict_response`]'s `rulings` slice.
-    #[allow(dead_code)] // no target test in this file currently needs a ruling block
     fn ruling_block(id: &str, accepted: bool, reason: &str) -> String {
         format!(
             "REBUTTAL_ID: {}\nRULING: {}\nREASON: {}",
@@ -1322,6 +1353,9 @@ mod tests {
     /// Builds a common fixture: opponent raises one CRITICAL rebuttal and the
     /// moderator declares `SETTLED` in round 1 without ruling on it — i.e. the
     /// moderator tries to settle early while a critical objection is still open.
+    ///
+    /// Paired with `debate_config(_, 1)` this makes round 1 the *final*
+    /// round, so the escalation this triggers has `can_continue = false`.
     fn escalation_gateway() -> ScriptedGateway {
         let gateway = ScriptedGateway::new();
         gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
@@ -1341,9 +1375,37 @@ mod tests {
         gateway
     }
 
+    /// Same round-1 premature-settle setup as [`escalation_gateway`], but
+    /// paired with `debate_config(_, 2)` so round 1 is *not* final —
+    /// `can_continue = true`. Scripts a round 2 that resolves the R1-1
+    /// objection and settles cleanly, so tests can assert the debate
+    /// actually continues (rather than aborting) after the escalation is
+    /// declined in round 1.
+    fn escalation_continues_gateway() -> ScriptedGateway {
+        let gateway = escalation_gateway();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Defense round 2: adds a cache warmer to mitigate the TTL gap.",
+        );
+        gateway.respond(Model::Gemini31Pro, "No further rebuttal.");
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            verdict_response(
+                true,
+                &[ruling_block(
+                    "R1-1",
+                    false,
+                    "cache warmer mitigates the TTL gap",
+                )],
+                "Write-through wins with a cache warmer.",
+            ),
+        );
+        gateway
+    }
+
     #[tokio::test]
-    async fn debate_early_settle_with_unresolved_critical_objection_is_auto_rejected() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_early_settle_reject_at_final_round_aborts() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         // RunQuorumInput::new() defaults to HilMode::AutoReject.
         let input = base_input(OrchestrationStrategy::Debate(config));
 
@@ -1359,6 +1421,35 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_early_settle_reject_at_non_final_round_continues_debate() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        // RunQuorumInput::new() defaults to HilMode::AutoReject — but at a
+        // non-final round that now means "decline the early settle and keep
+        // debating", not "abort".
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
     }
 
     #[tokio::test]
@@ -1433,8 +1524,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn debate_interactive_escalation_reject_aborts_execute() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_interactive_escalation_reject_at_final_round_aborts_execute() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
         let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Reject)));
@@ -1451,12 +1542,47 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
+            false
+        ]);
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
     }
 
     #[tokio::test]
-    async fn debate_interactive_without_handler_falls_back_to_reject() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_interactive_escalation_reject_at_non_final_round_continues_debate() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Reject)));
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
+            true
+        ]);
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_without_handler_falls_back_to_reject_at_final_round() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
 
@@ -1472,6 +1598,34 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_without_handler_falls_back_to_reject_at_non_final_round_continues()
+     {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/mod.rs
+++ b/application/src/use_cases/run_quorum/mod.rs
@@ -18,6 +18,8 @@ pub use quorum_strategy::QuorumStrategyExecutor;
 pub use strategy_executor::StrategyExecutor;
 pub use types::{RunQuorumError, RunQuorumInput};
 
+use crate::ports::event_publisher::{EventPublisher, NoEventPublisher};
+use crate::ports::human_intervention::HumanInterventionPort;
 use crate::ports::llm_gateway::LlmGateway;
 use crate::ports::progress::{NoProgress, ProgressNotifier};
 use quorum_domain::{OrchestrationStrategy, QuorumResult};
@@ -27,11 +29,30 @@ use tracing::info;
 /// Use case for running a Quorum discussion
 pub struct RunQuorumUseCase {
     gateway: Arc<dyn LlmGateway>,
+    event_publisher: Arc<dyn EventPublisher>,
+    human_intervention: Option<Arc<dyn HumanInterventionPort>>,
 }
 
 impl RunQuorumUseCase {
     pub fn new(gateway: Arc<dyn LlmGateway>) -> Self {
-        Self { gateway }
+        Self {
+            gateway,
+            event_publisher: Arc::new(NoEventPublisher),
+            human_intervention: None,
+        }
+    }
+
+    /// Set the typed event publisher (the seam for `quorum_result` etc.).
+    pub fn with_event_publisher(mut self, publisher: Arc<dyn EventPublisher>) -> Self {
+        self.event_publisher = publisher;
+        self
+    }
+
+    /// Set a human intervention handler for strategies that need to escalate
+    /// to a human when automated resolution stalls (e.g. Debate deadlocks).
+    pub fn with_human_intervention(mut self, intervention: Arc<dyn HumanInterventionPort>) -> Self {
+        self.human_intervention = Some(intervention);
+        self
     }
 
     /// Execute the use case with default (no-op) progress
@@ -56,15 +77,29 @@ impl RunQuorumUseCase {
         );
 
         let gateway = Arc::clone(&self.gateway);
+        let event_publisher = Arc::clone(&self.event_publisher);
+        let human_intervention = self.human_intervention.clone();
         match &input.strategy {
             OrchestrationStrategy::Quorum(_) => {
                 QuorumStrategyExecutor::new()
-                    .execute(&input, gateway, progress)
+                    .execute(
+                        &input,
+                        gateway,
+                        progress,
+                        event_publisher,
+                        human_intervention,
+                    )
                     .await
             }
             OrchestrationStrategy::Debate(_) => {
                 DebateStrategyExecutor::new()
-                    .execute(&input, gateway, progress)
+                    .execute(
+                        &input,
+                        gateway,
+                        progress,
+                        event_publisher,
+                        human_intervention,
+                    )
                     .await
             }
         }

--- a/application/src/use_cases/run_quorum/quorum_strategy.rs
+++ b/application/src/use_cases/run_quorum/quorum_strategy.rs
@@ -6,6 +6,8 @@
 
 use super::strategy_executor::StrategyExecutor;
 use super::types::{RunQuorumError, RunQuorumInput};
+use crate::ports::event_publisher::EventPublisher;
+use crate::ports::human_intervention::HumanInterventionPort;
 use crate::ports::llm_gateway::{GatewayError, LlmGateway, StreamObserver};
 use crate::ports::progress::ProgressNotifier;
 use async_trait::async_trait;
@@ -347,6 +349,10 @@ impl StrategyExecutor for QuorumStrategyExecutor {
         input: &RunQuorumInput,
         gateway: Arc<dyn LlmGateway>,
         progress: &dyn ProgressNotifier,
+        // Not wired up yet for Quorum — vote/event publishing for this strategy
+        // is out of scope for this change (see `StrategyExecutor::execute` docs).
+        _event_publisher: Arc<dyn EventPublisher>,
+        _human_intervention: Option<Arc<dyn HumanInterventionPort>>,
     ) -> Result<QuorumResult, RunQuorumError> {
         // Phase 1: Initial Query
         let responses = self.phase_initial(&gateway, input, progress).await?;
@@ -389,6 +395,7 @@ impl StrategyExecutor for QuorumStrategyExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::event_publisher::NoEventPublisher;
     use crate::ports::progress::NoProgress;
     use crate::use_cases::run_quorum::test_support::ScriptedGateway;
     use quorum_domain::ModelConfig;
@@ -411,7 +418,13 @@ mod tests {
         gateway.respond(Model::ClaudeSonnet45, "Final synthesis: use write-through.");
 
         let result = QuorumStrategyExecutor::new()
-            .execute(&input(models), Arc::new(gateway), &NoProgress)
+            .execute(
+                &input(models),
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
             .await
             .unwrap();
 
@@ -439,6 +452,8 @@ mod tests {
                 &input(models).without_review(),
                 Arc::new(gateway),
                 &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
             )
             .await
             .unwrap();
@@ -455,7 +470,13 @@ mod tests {
         let gateway = ScriptedGateway::new();
 
         let err = QuorumStrategyExecutor::new()
-            .execute(&input(models), Arc::new(gateway), &NoProgress)
+            .execute(
+                &input(models),
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
             .await
             .unwrap_err();
 

--- a/application/src/use_cases/run_quorum/strategy_executor.rs
+++ b/application/src/use_cases/run_quorum/strategy_executor.rs
@@ -15,6 +15,8 @@
 //! [`QuorumStrategyExecutor`](super::quorum_strategy::QuorumStrategyExecutor)).
 
 use super::types::{RunQuorumError, RunQuorumInput};
+use crate::ports::event_publisher::EventPublisher;
+use crate::ports::human_intervention::HumanInterventionPort;
 use crate::ports::llm_gateway::LlmGateway;
 use crate::ports::progress::ProgressNotifier;
 use async_trait::async_trait;
@@ -31,10 +33,20 @@ pub trait StrategyExecutor: Send + Sync {
     fn phases(&self) -> Vec<Phase>;
 
     /// Execute the strategy and produce a [`QuorumResult`].
+    ///
+    /// `event_publisher` and `human_intervention` are threaded through for
+    /// strategies that need to publish typed events (e.g. Debate's objection
+    /// votes) or escalate to a human when automated resolution stalls. As of
+    /// this signature change, [`QuorumStrategyExecutor`](super::quorum_strategy::QuorumStrategyExecutor)
+    /// accepts both but doesn't wire them up yet (out of scope — see #314's
+    /// follow-ups); it's just Debate that will make use of them.
+    #[allow(clippy::too_many_arguments)]
     async fn execute(
         &self,
         input: &RunQuorumInput,
         gateway: Arc<dyn LlmGateway>,
         progress: &dyn ProgressNotifier,
+        event_publisher: Arc<dyn EventPublisher>,
+        human_intervention: Option<Arc<dyn HumanInterventionPort>>,
     ) -> Result<QuorumResult, RunQuorumError>;
 }

--- a/application/src/use_cases/run_quorum/test_support.rs
+++ b/application/src/use_cases/run_quorum/test_support.rs
@@ -15,6 +15,9 @@ use std::sync::{Arc, Mutex};
 #[derive(Default)]
 pub(super) struct ScriptedGateway {
     responses: Arc<Mutex<HashMap<Model, VecDeque<String>>>>,
+    /// Every prompt passed to `send()`, in call order, regardless of model —
+    /// lets tests assert on the exact content a caller constructed.
+    sent: Arc<Mutex<Vec<(Model, String)>>>,
 }
 
 impl ScriptedGateway {
@@ -31,11 +34,23 @@ impl ScriptedGateway {
             .or_default()
             .push_back(text.into());
     }
+
+    /// All prompts sent to `model` via `send()`, in call order.
+    pub(super) fn sent_prompts(&self, model: Model) -> Vec<String> {
+        self.sent
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(m, _)| *m == model)
+            .map(|(_, prompt)| prompt.clone())
+            .collect()
+    }
 }
 
 struct ScriptedSession {
     model: Model,
     responses: Arc<Mutex<HashMap<Model, VecDeque<String>>>>,
+    sent: Arc<Mutex<Vec<(Model, String)>>>,
 }
 
 #[async_trait]
@@ -44,7 +59,11 @@ impl LlmSession for ScriptedSession {
         &self.model
     }
 
-    async fn send(&self, _content: &str) -> Result<String, GatewayError> {
+    async fn send(&self, content: &str) -> Result<String, GatewayError> {
+        self.sent
+            .lock()
+            .unwrap()
+            .push((self.model.clone(), content.to_string()));
         self.responses
             .lock()
             .unwrap()
@@ -62,6 +81,7 @@ impl LlmGateway for ScriptedGateway {
         Ok(Box::new(ScriptedSession {
             model: model.clone(),
             responses: Arc::clone(&self.responses),
+            sent: Arc::clone(&self.sent),
         }))
     }
 

--- a/application/src/use_cases/run_quorum/types.rs
+++ b/application/src/use_cases/run_quorum/types.rs
@@ -1,7 +1,7 @@
 //! Input/error types for the RunQuorum use case.
 
 use crate::ports::llm_gateway::GatewayError;
-use quorum_domain::{ModelConfig, OrchestrationStrategy, Question};
+use quorum_domain::{HilMode, ModelConfig, OrchestrationStrategy, Question};
 use thiserror::Error;
 
 /// Errors that can occur during Quorum execution
@@ -21,6 +21,15 @@ pub enum RunQuorumError {
 
     #[error("Gateway error: {0}")]
     GatewayError(#[from] GatewayError),
+
+    #[error("Debate escalation rejected by human: {0}")]
+    DebateEscalationRejected(String),
+
+    #[error("Operation cancelled")]
+    Cancelled,
+
+    #[error("Human intervention failed: {0}")]
+    HumanInterventionFailed(String),
 }
 
 /// Input for the RunQuorum use case
@@ -34,6 +43,8 @@ pub struct RunQuorumInput {
     pub enable_review: bool,
     /// Which orchestration strategy drives this discussion
     pub strategy: OrchestrationStrategy,
+    /// Human-in-the-loop mode for debate escalation checkpoints
+    pub hil_mode: HilMode,
 }
 
 impl RunQuorumInput {
@@ -43,6 +54,9 @@ impl RunQuorumInput {
             models,
             enable_review: true,
             strategy: OrchestrationStrategy::default(),
+            // Safe-by-default: avoid surprising auto-approvals for callers that
+            // don't explicitly opt into a HiL mode.
+            hil_mode: HilMode::AutoReject,
         }
     }
 
@@ -53,6 +67,11 @@ impl RunQuorumInput {
 
     pub fn with_strategy(mut self, strategy: OrchestrationStrategy) -> Self {
         self.strategy = strategy;
+        self
+    }
+
+    pub fn with_hil_mode(mut self, mode: HilMode) -> Self {
+        self.hil_mode = mode;
         self
     }
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,6 +48,16 @@ Lua からの変更は runtime でエージェントに伝播します。
 3 軸（consensus_level / phase_scope / strategy）の意味と組み合わせ制約は
 [Orchestration Axes](../explanation/orchestration-axes.md) を参照してください。
 
+`agent.hil_mode` は Plan Review の人間介入だけでなく、`agent.strategy = "debate"`
+（Debate 戦略）のエスカレーションにも効きます。moderator が critical/major な
+反論が未解決のまま settle しようとするたびに（最終ラウンドに限らず、途中の
+settle チェックポイントでも）このモードでゲートされます: `auto_reject` は
+最終ラウンドでは討議を中止しますが、途中ラウンドでは settle を却下して
+討議を続行します（討議自体を止めるのではなく、未解決のまま決着させないための
+fail-secure）。`auto_approve` は未解決のまま強制的に settle し、`interactive`
+は `HumanInterventionPort::request_debate_escalation` 経由で都度ユーザーに
+判断を委ねます。
+
 ### `models.*` — ロール別モデル設定
 
 | キー | 型 | 用途 |

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -175,16 +175,34 @@ plan/action/final review では省略される）:
    "key_points":[],"consensus":[],"disagreements":[]}}
 ```
 
+`debate`（`agent.strategy = "debate"`、敵対的パネル v2 #316）は `target` を
+持たず、`pr_review` と同様に `synthesis` を含む。`votes` は反論台帳
+（`ObjectionLedger`）の各エントリ1件につき1票（`reasoning` は
+`[REBUTTAL_ID][refuted|conceded|unresolved] claim: reason` 形式）に加え、
+討議全体の最終裁定を表す closing vote が末尾に1件付く:
+
+```json
+{"type":"quorum_result","timestamp":"2026-07-04T10:30:00.123Z",
+ "api_version":1,"topic":"debate",
+ "approved":true,"rule":"majority",
+ "votes":[
+   {"model":"claude-opus-4.5","verdict":"approve","reasoning":"[R1-1][refuted] cache never expires: TTL config is finite","confidence":null},
+   {"model":"claude-opus-4.5","verdict":"approve","reasoning":"Write-through wins.","confidence":null}
+ ],
+ "synthesis":{"moderator":"claude-opus-4.5","conclusion":"Write-through wins.",
+   "key_points":[],"consensus":[],"disagreements":[]}}
+```
+
 | フィールド | 型 | 説明 |
 |-----------|------|------|
 | `api_version` | int | エンベロープのスキーマバージョン（現在 1） |
-| `topic` | string | `plan_review` / `action_review` / `final_review` / `pr_review` |
-| `target` | object? | topic 依存の対象識別（action_review: `task_id`, `tool`。pr_review: `pr`, `title`）。なければ省略 |
+| `topic` | string | `plan_review` / `action_review` / `final_review` / `pr_review` / `debate` |
+| `target` | object? | topic 依存の対象識別（action_review: `task_id`, `tool`。pr_review: `pr`, `title`。debate では省略）。なければ省略 |
 | `approved` | bool | 投票の集計結果 |
 | `rule` | string | 集計ルール（現在は `majority` 固定） |
 | `votes[].verdict` | string | `approve` / `reject` / `abstain` / `model_error` |
 | `feedback` | string? | 否決時の rejection feedback 集約。承認時は省略 |
-| `synthesis` | object? | moderator による統合レビュー（pr_review のみ。`moderator`, `conclusion`, `key_points`, `consensus`, `disagreements`） |
+| `synthesis` | object? | moderator による統合レビュー（pr_review / debate のみ。`moderator`, `conclusion`, `key_points`, `consensus`, `disagreements`） |
 
 **注**: `pr_review` を JSONL に発行する `RunReviewUseCase` は `target` を持たずに publish する
 （review 対象の PR 番号/タイトルは呼び出し元の CLI 層のみが知っている一時情報のため）。

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -105,6 +105,9 @@ Vim/Neovim のプラグインエコシステムに倣い、段階的に構築さ
 `QuorumResult` は `EventPublisher` 継ぎ目経由で配信される（progress bridge 経由ではない）。
 `task_id` / `tool` は action_review の相関情報（他 topic では nil）、`feedback` は否決時のみ。
 `votes_json` は `quorum_result` v1 契約の votes 配列（[Logging](logging.md) 参照）。
+`topic` は `plan_review` / `action_review` / `final_review` / `pr_review` に加え、
+Debate 戦略（`agent.strategy = "debate"`、敵対的パネル v2 #316）の最終裁定を表す
+`debate` を取り得る。
 
 ### ToolCallBefore キャンセルフロー
 

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -87,8 +87,9 @@ pub use tool::{
 
 // Re-export quorum types
 pub use quorum::{
-    ConsensusOutcome, ConsensusRound, QUORUM_RESULT_API_VERSION, QUORUM_RESULT_EVENT_TYPE,
-    QuorumResultPayload, QuorumRule, QuorumTarget, QuorumTopic, Vote, VoteResult, VoteVerdict,
+    ConsensusOutcome, ConsensusRound, Objection, ObjectionLedger, ObjectionSeverity,
+    ObjectionStatus, QUORUM_RESULT_API_VERSION, QUORUM_RESULT_EVENT_TYPE, QuorumResultPayload,
+    QuorumRule, QuorumTarget, QuorumTopic, Vote, VoteResult, VoteVerdict,
     parse_final_review_response, parse_review_response, parse_vote_score,
 };
 

--- a/domain/src/prompt/debate.rs
+++ b/domain/src/prompt/debate.rs
@@ -127,7 +127,20 @@ SEVERITY: CRITICAL (breaks the position entirely) / MAJOR (a real gap that needs
 
 A rebuttal without a concrete counterexample or evidence — e.g. "this could probably be
 made more robust" — is not falsifiable. The moderator will discard it, so don't waste a
-round on it."#,
+round on it.
+
+## Requesting decomposition
+
+Sometimes the proponent's position is compound or ambiguous — it bundles several
+independent claims together, or is phrased so vaguely that no single CLAIM/EVIDENCE/
+SEVERITY rebuttal can attack it directly. In that situation only, instead of a normal
+rebuttal you may respond with exactly one line:
+DECOMPOSE_REQUEST: <the specific claim you want broken into verifiable sub-claims>
+This asks the proponent to split that claim into sub-claims you can attack one at a
+time. Do not include CLAIM/EVIDENCE/SEVERITY when using this — it replaces them for
+that turn. You may use DECOMPOSE_REQUEST at most once per round; if the position is
+still unattackable after decomposition, fall back to your best CLAIM/EVIDENCE/SEVERITY
+rebuttal rather than requesting decomposition again."#,
             depth
         )
     }
@@ -146,6 +159,31 @@ Debate so far:
 Challenge the proponent's latest position above. Find its weakest point and attack it
 directly, using the CLAIM / EVIDENCE / SEVERITY structure from your instructions."#,
             question, transcript
+        )
+    }
+
+    /// Prompt for the proponent responding to an opponent's `DECOMPOSE_REQUEST:`.
+    ///
+    /// The opponent has judged `target` too compound or ambiguous to attack
+    /// directly and asked for it to be split into independently verifiable
+    /// sub-claims. This asks the proponent to do that decomposition rather
+    /// than to defend the claim as-is.
+    pub fn proponent_decomposition_prompt(target: &str, transcript: &str) -> String {
+        format!(
+            r#"Debate so far:
+
+{}
+
+The opponent has judged the following claim of yours too compound or ambiguous to
+attack directly, and requested that you decompose it:
+
+{}
+
+Break this claim into a small number of independently verifiable sub-claims — each
+one specific and narrow enough that the opponent could attack it with a concrete
+counterexample. Do not weaken or abandon the claim; restate it more precisely as a
+list of sub-claims that, together, are equivalent to what you originally meant."#,
+            transcript, target
         )
     }
 
@@ -204,8 +242,9 @@ Your response MUST start with exactly one of these two lines:
 VERDICT: SETTLED
 VERDICT: CONTINUE
 
-Then, for EACH rebuttal raised so far in the debate, list:
-REBUTTAL: <one-line summary of what was attacked>
+Then, for EACH open objection listed in the checkpoint prompt (each given its own
+REBUTTAL_ID), list:
+REBUTTAL_ID: <the ID exactly as given, e.g. R1-1 — do not paraphrase or renumber it>
 RULING: ACCEPTED or REJECTED
 REASON: <why — cite the concrete counterexample/evidence if accepted, or explain why it
 was unfalsifiable or wrong if rejected>
@@ -246,6 +285,160 @@ Debate so far (round {} of {}):
 
 Has the debate settled? Rule on each rebuttal raised so far, per your instructions.{}"#,
             question, round, max_rounds, transcript, final_notice
+        )
+    }
+
+    /// Per-round checkpoint prompt for the moderator, with the still-open
+    /// objections (from an [`ObjectionLedger`](crate::quorum::ObjectionLedger))
+    /// explicitly enumerated by ID and claim.
+    ///
+    /// This is the `ObjectionLedger`-aware counterpart to
+    /// [`moderator_checkpoint_prompt`](Self::moderator_checkpoint_prompt):
+    /// instead of asking the moderator to re-derive rebuttal identity from
+    /// prose, it hands over the exact `REBUTTAL_ID`s the moderator must rule
+    /// on and echo back, so [`parse_moderator_rulings`](crate::quorum::parsing::parse_moderator_rulings)
+    /// can match rulings to ledger entries by exact ID.
+    ///
+    /// `open_objections` is a list of `(id, claim)` pairs — typically built
+    /// from `ObjectionLedger::open_objections()`.
+    pub fn moderator_checkpoint_prompt_with_objections(
+        question: &str,
+        transcript: &str,
+        round: usize,
+        max_rounds: usize,
+        is_final_round: bool,
+        open_objections: &[(&str, &str)],
+    ) -> String {
+        let final_notice = if is_final_round {
+            "\nThis is the final allowed round. You MUST respond with VERDICT: SETTLED \
+             and produce your rulings and the best conclusion possible from the debate \
+             so far, even if disagreement remains."
+        } else {
+            ""
+        };
+        let objections_block = if open_objections.is_empty() {
+            "None — no unresolved objections remain in the ledger.".to_string()
+        } else {
+            open_objections
+                .iter()
+                .map(|(id, claim)| format!("REBUTTAL_ID: {}\nCLAIM: {}", id, claim))
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        };
+        format!(
+            r#"Question under debate:
+
+{}
+
+Debate so far (round {} of {}):
+
+{}
+
+Open objections requiring a ruling (rule on each by its REBUTTAL_ID, exactly as given):
+
+{}
+
+Has the debate settled? Rule on each open objection above, per your instructions.{}"#,
+            question, round, max_rounds, transcript, objections_block, final_notice
+        )
+    }
+
+    /// Additional system instructions for the moderator's divergence check.
+    ///
+    /// Before committing rounds to attacking each other's claims, the
+    /// moderator can be asked whether the proponent's opening and the
+    /// opponent's first attack are actually reaching different conclusions,
+    /// or whether they've quietly converged on the same one while disputing
+    /// unrelated framing. If they agree, the debate should attack the shared
+    /// premise itself rather than continue as if in genuine disagreement —
+    /// see [`contrarian_system`](Self::contrarian_system).
+    pub fn moderator_divergence_system() -> &'static str {
+        r#"You are being asked an additional question as the moderator of an adversarial
+debate, separate from your usual per-round ruling.
+
+Read the proponent's opening position and the opponent's first attack. Ask: are these
+substantively reaching the same conclusion, just phrased differently or arguing past
+each other on surface details? Or do they genuinely disagree on the substance?
+
+If they are substantively the same conclusion, the debate as framed is not adversarial —
+both sides share an unexamined premise, and attacking each other's phrasing wastes
+rounds. In that case the shared premise itself should be attacked instead.
+
+Your response MUST start with exactly one of these two lines:
+DIVERGENT: YES
+DIVERGENT: NO
+
+Then, on the following lines:
+- If DIVERGENT: NO — state the shared premise both sides rest on, precisely enough that
+  it could be attacked directly.
+- If DIVERGENT: YES — briefly note what genuinely differs between the two positions."#
+    }
+
+    /// Prompt for the moderator's divergence check, given the opening and
+    /// first attack.
+    pub fn divergence_check_prompt(question: &str, opening: &str, first_attack: &str) -> String {
+        format!(
+            r#"Question under debate:
+
+{}
+
+Proponent's opening position:
+
+{}
+
+Opponent's first attack:
+
+{}
+
+Are these two positions substantively the same conclusion, or do they genuinely
+diverge? Follow the DIVERGENT: YES/NO format from your instructions."#,
+            question, opening, first_attack
+        )
+    }
+
+    /// System prompt for the contrarian role.
+    ///
+    /// Used when the moderator's divergence check finds the proponent and
+    /// opponent have quietly converged on a shared premise instead of
+    /// genuinely disagreeing. The contrarian is deliberately assigned the
+    /// opposing stance to that shared premise and told to attack it directly,
+    /// rather than restate either side's existing arguments.
+    pub fn contrarian_system() -> &'static str {
+        r#"You are the contrarian in an adversarial debate between AI models.
+The proponent and opponent have converged on a shared premise instead of genuinely
+disagreeing — the debate has not been adversarial in substance, only in surface framing.
+
+Your task is to explicitly take the opposite stance to that shared premise and attack
+it directly. Do not restate or referee the existing arguments between the proponent and
+opponent — assume that premise is wrong and make the strongest case you can for why.
+
+Like the opponent's rebuttals, your case must be falsifiable: give a concrete
+counterexample, scenario, or piece of evidence for why the shared premise doesn't hold —
+not a vague impression or stylistic objection."#
+    }
+
+    /// Brief prompt for the contrarian, given the shared premise and transcript.
+    pub fn contrarian_brief_prompt(
+        question: &str,
+        shared_premise: &str,
+        transcript: &str,
+    ) -> String {
+        format!(
+            r#"Question under debate:
+
+{}
+
+Debate so far:
+
+{}
+
+The moderator has identified this as a premise both sides share instead of genuinely
+contesting:
+
+{}
+
+Take the opposite stance to this premise and attack it directly, per your instructions."#,
+            question, transcript, shared_premise
         )
     }
 }
@@ -316,10 +509,116 @@ mod tests {
     #[test]
     fn test_moderator_system_requires_structured_ruling() {
         let system = DebatePromptTemplate::moderator_system();
-        assert!(system.contains("REBUTTAL:"));
+        assert!(system.contains("REBUTTAL_ID:"));
         assert!(system.contains("RULING:"));
         assert!(system.contains("REASON:"));
         assert!(system.contains("unfalsifiable"));
         assert!(system.contains("sycophantic capitulation"));
+        // The old free-text "REBUTTAL:" summary format must be gone in favor
+        // of ID references the moderator echoes back exactly.
+        assert!(!system.contains("REBUTTAL: <one-line summary"));
+    }
+
+    #[test]
+    fn test_opponent_system_describes_decompose_request() {
+        let prompt = DebatePromptTemplate::opponent_system(DebateIntensity::Mild);
+        assert!(prompt.contains("DECOMPOSE_REQUEST:"));
+        assert!(prompt.contains("at most once per round"));
+    }
+
+    #[test]
+    fn test_proponent_decomposition_prompt_contains_target_and_transcript() {
+        let prompt = DebatePromptTemplate::proponent_decomposition_prompt(
+            "the system is secure",
+            "--- Opponent ---\nDECOMPOSE_REQUEST: the system is secure",
+        );
+        assert!(prompt.contains("the system is secure"));
+        assert!(prompt.contains("DECOMPOSE_REQUEST: the system is secure"));
+        assert!(prompt.contains("sub-claims"));
+    }
+
+    #[test]
+    fn test_moderator_checkpoint_with_objections_lists_ids_and_claims() {
+        let prompt = DebatePromptTemplate::moderator_checkpoint_prompt_with_objections(
+            "Q",
+            "transcript",
+            2,
+            3,
+            false,
+            &[
+                ("R1-1", "the cache never expires"),
+                ("R2-1", "concurrent writes are unguarded"),
+            ],
+        );
+        assert!(prompt.contains("REBUTTAL_ID: R1-1"));
+        assert!(prompt.contains("CLAIM: the cache never expires"));
+        assert!(prompt.contains("REBUTTAL_ID: R2-1"));
+        assert!(prompt.contains("CLAIM: concurrent writes are unguarded"));
+    }
+
+    #[test]
+    fn test_moderator_checkpoint_with_objections_handles_empty_ledger() {
+        let prompt = DebatePromptTemplate::moderator_checkpoint_prompt_with_objections(
+            "Q",
+            "transcript",
+            1,
+            3,
+            false,
+            &[],
+        );
+        assert!(prompt.contains("None"));
+    }
+
+    #[test]
+    fn test_moderator_checkpoint_with_objections_final_round_forces_settle() {
+        let prompt = DebatePromptTemplate::moderator_checkpoint_prompt_with_objections(
+            "Q",
+            "transcript",
+            3,
+            3,
+            true,
+            &[("R3-1", "claim")],
+        );
+        assert!(prompt.contains("MUST respond with VERDICT: SETTLED"));
+    }
+
+    #[test]
+    fn test_divergence_check_prompt_contains_opening_and_first_attack() {
+        let prompt = DebatePromptTemplate::divergence_check_prompt(
+            "Should we use REST or gRPC?",
+            "We should use REST for simplicity.",
+            "REST is fine but the real issue is versioning strategy.",
+        );
+        assert!(prompt.contains("Should we use REST or gRPC?"));
+        assert!(prompt.contains("We should use REST for simplicity."));
+        assert!(prompt.contains("REST is fine but the real issue is versioning strategy."));
+        assert!(prompt.contains("DIVERGENT: YES/NO"));
+    }
+
+    #[test]
+    fn test_moderator_divergence_system_requires_divergent_format() {
+        let system = DebatePromptTemplate::moderator_divergence_system();
+        assert!(system.contains("DIVERGENT: YES"));
+        assert!(system.contains("DIVERGENT: NO"));
+        assert!(system.contains("shared premise"));
+    }
+
+    #[test]
+    fn test_contrarian_system_requires_shared_premise_attack() {
+        let system = DebatePromptTemplate::contrarian_system();
+        assert!(system.contains("shared premise"));
+        assert!(system.contains("falsifiable"));
+        assert!(system.contains("opposite stance"));
+    }
+
+    #[test]
+    fn test_contrarian_brief_prompt_contains_shared_premise_and_transcript() {
+        let prompt = DebatePromptTemplate::contrarian_brief_prompt(
+            "Q",
+            "Both sides assume the API must be synchronous.",
+            "--- Proponent ---\nUse a synchronous API.",
+        );
+        assert!(prompt.contains("Both sides assume the API must be synchronous."));
+        assert!(prompt.contains("Use a synchronous API."));
     }
 }

--- a/domain/src/prompt/debate.rs
+++ b/domain/src/prompt/debate.rs
@@ -256,45 +256,11 @@ Finally, exactly one of:
   rebuttal — that the next round should focus on>"#
     }
 
-    /// Per-round checkpoint prompt for the moderator.
-    ///
-    /// When `is_final_round` is `true`, the moderator is instructed to settle
-    /// regardless of remaining disagreement — `max_rounds` is a hard cap.
-    pub fn moderator_checkpoint_prompt(
-        question: &str,
-        transcript: &str,
-        round: usize,
-        max_rounds: usize,
-        is_final_round: bool,
-    ) -> String {
-        let final_notice = if is_final_round {
-            "\nThis is the final allowed round. You MUST respond with VERDICT: SETTLED \
-             and produce your rulings and the best conclusion possible from the debate \
-             so far, even if disagreement remains."
-        } else {
-            ""
-        };
-        format!(
-            r#"Question under debate:
-
-{}
-
-Debate so far (round {} of {}):
-
-{}
-
-Has the debate settled? Rule on each rebuttal raised so far, per your instructions.{}"#,
-            question, round, max_rounds, transcript, final_notice
-        )
-    }
-
     /// Per-round checkpoint prompt for the moderator, with the still-open
     /// objections (from an [`ObjectionLedger`](crate::quorum::ObjectionLedger))
     /// explicitly enumerated by ID and claim.
     ///
-    /// This is the `ObjectionLedger`-aware counterpart to
-    /// [`moderator_checkpoint_prompt`](Self::moderator_checkpoint_prompt):
-    /// instead of asking the moderator to re-derive rebuttal identity from
+    /// Instead of asking the moderator to re-derive rebuttal identity from
     /// prose, it hands over the exact `REBUTTAL_ID`s the moderator must rule
     /// on and echo back, so [`parse_moderator_rulings`](crate::quorum::parsing::parse_moderator_rulings)
     /// can match rulings to ledger entries by exact ID.
@@ -460,20 +426,6 @@ mod tests {
             "--- Proponent ---\nUse REST for simplicity.",
         );
         assert!(prompt.contains("Use REST for simplicity."));
-    }
-
-    #[test]
-    fn test_moderator_checkpoint_final_round_forces_settle() {
-        let prompt =
-            DebatePromptTemplate::moderator_checkpoint_prompt("Q", "transcript", 3, 3, true);
-        assert!(prompt.contains("MUST respond with VERDICT: SETTLED"));
-    }
-
-    #[test]
-    fn test_moderator_checkpoint_non_final_round_allows_continue() {
-        let prompt =
-            DebatePromptTemplate::moderator_checkpoint_prompt("Q", "transcript", 1, 3, false);
-        assert!(!prompt.contains("MUST respond with VERDICT: SETTLED"));
     }
 
     #[test]

--- a/domain/src/quorum/mod.rs
+++ b/domain/src/quorum/mod.rs
@@ -56,6 +56,7 @@
 //! ```
 
 pub mod consensus;
+pub mod objection;
 pub mod parsing;
 pub mod result_event;
 pub mod rule;
@@ -63,6 +64,7 @@ pub mod vote;
 
 // Re-export main types
 pub use consensus::{ConsensusOutcome, ConsensusRound};
+pub use objection::{Objection, ObjectionLedger, ObjectionSeverity, ObjectionStatus};
 pub use parsing::{parse_final_review_response, parse_review_response, parse_vote_score};
 pub use result_event::{
     QUORUM_RESULT_API_VERSION, QUORUM_RESULT_EVENT_TYPE, QuorumResultPayload, QuorumTarget,

--- a/domain/src/quorum/objection.rs
+++ b/domain/src/quorum/objection.rs
@@ -1,0 +1,297 @@
+//! Objection ledger for adversarial Quorum strategies (Debate, etc.)
+//!
+//! During a `Debate` strategy run, the critic side raises structured
+//! rebuttals (`CLAIM` / `EVIDENCE` / `SEVERITY`). This module tracks those
+//! rebuttals as [`Objection`]s in an [`ObjectionLedger`] so the moderator's
+//! checkpoint rulings (conceded / refuted / unresolved) can be recorded and
+//! queried without re-parsing raw transcript text.
+//!
+//! This is pure, `async`-independent domain logic (no I/O, no LLM calls),
+//! following the precedent set by `quorum::vote` (#212).
+//!
+//! # Example
+//!
+//! ```
+//! use quorum_domain::quorum::{ObjectionLedger, ObjectionSeverity, ObjectionStatus};
+//!
+//! let mut ledger = ObjectionLedger::new();
+//! let id = ledger.add(1, "The plan ignores concurrent writes", "See race in step 3", ObjectionSeverity::Major);
+//! assert_eq!(id, "R1-1");
+//!
+//! ledger.apply_ruling(&id, true, "Critic's evidence holds; proposer failed to address it");
+//! assert_eq!(ledger.open_objections().len(), 0);
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// How serious an objection is, as classified by the critic's `SEVERITY:` line.
+///
+/// Maps directly onto the `CRITICAL` / `MAJOR` / `MINOR` vocabulary used in
+/// the Debate prompt template (`domain/src/prompt/debate.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectionSeverity {
+    /// Breaks the position entirely.
+    Critical,
+    /// A real gap that needs addressing.
+    Major,
+    /// A nitpick worth noting.
+    Minor,
+}
+
+/// Resolution state of an [`Objection`] as determined by the moderator's ruling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObjectionStatus {
+    /// The proposer conceded the point (ruling: valid objection, accepted).
+    Conceded,
+    /// The moderator ruled the objection invalid / adequately rebutted.
+    Refuted,
+    /// No ruling has been applied yet.
+    Unresolved,
+}
+
+/// A single structured rebuttal raised during a Debate round.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Objection {
+    /// Stable identifier, e.g. `"R1-1"` (round 1, objection 1).
+    pub id: String,
+    /// The claim being attacked (the `CLAIM:` line).
+    pub claim: String,
+    /// The counter-evidence offered (the `EVIDENCE:` line).
+    pub evidence: String,
+    /// Severity as classified by the critic.
+    pub severity: ObjectionSeverity,
+    /// Current resolution status.
+    pub status: ObjectionStatus,
+    /// Moderator's reasoning for the ruling, if one has been applied.
+    pub ruling_reason: Option<String>,
+}
+
+/// Ledger tracking all objections raised across a Debate run.
+///
+/// IDs are minted per round as `R{round}-{n}`, where `n` is a 1-based
+/// counter local to that round.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ObjectionLedger {
+    objections: Vec<Objection>,
+}
+
+impl ObjectionLedger {
+    /// Create an empty ledger.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a new objection raised in the given round.
+    ///
+    /// Returns the newly minted objection ID (e.g. `"R2-3"`).
+    pub fn add(
+        &mut self,
+        round: usize,
+        claim: impl Into<String>,
+        evidence: impl Into<String>,
+        severity: ObjectionSeverity,
+    ) -> String {
+        let n = self
+            .objections
+            .iter()
+            .filter(|o| o.id.starts_with(&format!("R{round}-")))
+            .count()
+            + 1;
+        let id = format!("R{round}-{n}");
+        self.objections.push(Objection {
+            id: id.clone(),
+            claim: claim.into(),
+            evidence: evidence.into(),
+            severity,
+            status: ObjectionStatus::Unresolved,
+            ruling_reason: None,
+        });
+        id
+    }
+
+    /// Apply the moderator's ruling to an objection by ID.
+    ///
+    /// `ruling: true` means the objection was conceded (upheld);
+    /// `ruling: false` means it was refuted (rejected). No-op if the ID
+    /// is not found.
+    pub fn apply_ruling(&mut self, id: &str, ruling: bool, reason: impl Into<String>) {
+        if let Some(objection) = self.objections.iter_mut().find(|o| o.id == id) {
+            objection.status = if ruling {
+                ObjectionStatus::Conceded
+            } else {
+                ObjectionStatus::Refuted
+            };
+            objection.ruling_reason = Some(reason.into());
+        }
+    }
+
+    /// All objections in the ledger, in insertion order.
+    pub fn all(&self) -> &[Objection] {
+        &self.objections
+    }
+
+    /// Unresolved objections whose severity is `Critical` or `Major`.
+    ///
+    /// Used to decide whether a Debate round can settle early: if none
+    /// remain, the moderator's checkpoint can proceed to synthesis.
+    pub fn unresolved_critical_or_major(&self) -> Vec<&Objection> {
+        self.objections
+            .iter()
+            .filter(|o| {
+                o.status == ObjectionStatus::Unresolved
+                    && matches!(
+                        o.severity,
+                        ObjectionSeverity::Critical | ObjectionSeverity::Major
+                    )
+            })
+            .collect()
+    }
+
+    /// All objections still awaiting a ruling, regardless of severity.
+    ///
+    /// Intended for building the moderator checkpoint prompt (list of
+    /// still-open points that need a verdict).
+    pub fn open_objections(&self) -> Vec<&Objection> {
+        self.objections
+            .iter()
+            .filter(|o| o.status == ObjectionStatus::Unresolved)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_mints_sequential_ids_per_round() {
+        let mut ledger = ObjectionLedger::new();
+        let id1 = ledger.add(1, "claim a", "evidence a", ObjectionSeverity::Major);
+        let id2 = ledger.add(1, "claim b", "evidence b", ObjectionSeverity::Minor);
+        let id3 = ledger.add(2, "claim c", "evidence c", ObjectionSeverity::Critical);
+
+        assert_eq!(id1, "R1-1");
+        assert_eq!(id2, "R1-2");
+        // Round 2 counter starts fresh from 1.
+        assert_eq!(id3, "R2-1");
+    }
+
+    #[test]
+    fn new_objection_starts_unresolved() {
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Critical);
+        let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
+
+        assert_eq!(objection.status, ObjectionStatus::Unresolved);
+        assert!(objection.ruling_reason.is_none());
+    }
+
+    #[test]
+    fn apply_ruling_conceded() {
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
+        ledger.apply_ruling(&id, true, "critic's evidence is solid");
+
+        let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
+        assert_eq!(objection.status, ObjectionStatus::Conceded);
+        assert_eq!(
+            objection.ruling_reason.as_deref(),
+            Some("critic's evidence is solid")
+        );
+    }
+
+    #[test]
+    fn apply_ruling_refuted() {
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Minor);
+        ledger.apply_ruling(&id, false, "already addressed in round 1");
+
+        let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
+        assert_eq!(objection.status, ObjectionStatus::Refuted);
+    }
+
+    #[test]
+    fn apply_ruling_unknown_id_is_noop() {
+        let mut ledger = ObjectionLedger::new();
+        ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
+        ledger.apply_ruling("R99-1", true, "does not exist");
+
+        // Original objection remains unresolved; nothing panics.
+        assert_eq!(ledger.open_objections().len(), 1);
+    }
+
+    #[test]
+    fn unresolved_critical_or_major_excludes_minor_and_resolved() {
+        let mut ledger = ObjectionLedger::new();
+        let critical_id = ledger.add(1, "c1", "e1", ObjectionSeverity::Critical);
+        let major_id = ledger.add(1, "c2", "e2", ObjectionSeverity::Major);
+        let minor_id = ledger.add(1, "c3", "e3", ObjectionSeverity::Minor);
+
+        // Minor is excluded regardless of status.
+        let unresolved = ledger.unresolved_critical_or_major();
+        assert_eq!(unresolved.len(), 2);
+        assert!(unresolved.iter().any(|o| o.id == critical_id));
+        assert!(unresolved.iter().any(|o| o.id == major_id));
+        assert!(!unresolved.iter().any(|o| o.id == minor_id));
+
+        // Resolving the critical one shrinks the set.
+        ledger.apply_ruling(&critical_id, false, "rebutted");
+        assert_eq!(ledger.unresolved_critical_or_major().len(), 1);
+    }
+
+    #[test]
+    fn open_objections_only_returns_unresolved() {
+        let mut ledger = ObjectionLedger::new();
+        let id1 = ledger.add(1, "c1", "e1", ObjectionSeverity::Critical);
+        let id2 = ledger.add(1, "c2", "e2", ObjectionSeverity::Minor);
+
+        assert_eq!(ledger.open_objections().len(), 2);
+
+        ledger.apply_ruling(&id1, true, "conceded");
+        let open = ledger.open_objections();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].id, id2);
+    }
+
+    #[test]
+    fn severity_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ObjectionSeverity::Critical).unwrap(),
+            "critical"
+        );
+        assert_eq!(
+            serde_json::to_value(ObjectionSeverity::Major).unwrap(),
+            "major"
+        );
+        assert_eq!(
+            serde_json::to_value(ObjectionSeverity::Minor).unwrap(),
+            "minor"
+        );
+    }
+
+    #[test]
+    fn status_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ObjectionStatus::Conceded).unwrap(),
+            "conceded"
+        );
+        assert_eq!(
+            serde_json::to_value(ObjectionStatus::Refuted).unwrap(),
+            "refuted"
+        );
+        assert_eq!(
+            serde_json::to_value(ObjectionStatus::Unresolved).unwrap(),
+            "unresolved"
+        );
+    }
+
+    #[test]
+    fn empty_ledger_has_no_open_or_unresolved_objections() {
+        let ledger = ObjectionLedger::new();
+        assert!(ledger.open_objections().is_empty());
+        assert!(ledger.unresolved_critical_or_major().is_empty());
+        assert!(ledger.all().is_empty());
+    }
+}

--- a/domain/src/quorum/objection.rs
+++ b/domain/src/quorum/objection.rs
@@ -114,17 +114,28 @@ impl ObjectionLedger {
     /// Apply the moderator's ruling to an objection by ID.
     ///
     /// `ruling: true` means the objection was conceded (upheld);
-    /// `ruling: false` means it was refuted (rejected). No-op if the ID
-    /// is not found.
-    pub fn apply_ruling(&mut self, id: &str, ruling: bool, reason: impl Into<String>) {
-        if let Some(objection) = self.objections.iter_mut().find(|o| o.id == id) {
-            objection.status = if ruling {
-                ObjectionStatus::Conceded
-            } else {
-                ObjectionStatus::Refuted
-            };
-            objection.ruling_reason = Some(reason.into());
+    /// `ruling: false` means it was refuted (rejected).
+    ///
+    /// Only applies when the objection is still `Unresolved` — a later
+    /// round's moderator re-ruling on the same `REBUTTAL_ID` does not
+    /// silently overwrite an already-`Conceded`/`Refuted` verdict from an
+    /// earlier round. Returns `true` if the ruling was applied, `false` if
+    /// the ID was not found or the objection was already resolved (the
+    /// caller may want to log a warning on `false`).
+    pub fn apply_ruling(&mut self, id: &str, ruling: bool, reason: impl Into<String>) -> bool {
+        let Some(objection) = self.objections.iter_mut().find(|o| o.id == id) else {
+            return false;
+        };
+        if objection.status != ObjectionStatus::Unresolved {
+            return false;
         }
+        objection.status = if ruling {
+            ObjectionStatus::Conceded
+        } else {
+            ObjectionStatus::Refuted
+        };
+        objection.ruling_reason = Some(reason.into());
+        true
     }
 
     /// All objections in the ledger, in insertion order.
@@ -192,7 +203,7 @@ mod tests {
     fn apply_ruling_conceded() {
         let mut ledger = ObjectionLedger::new();
         let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
-        ledger.apply_ruling(&id, true, "critic's evidence is solid");
+        assert!(ledger.apply_ruling(&id, true, "critic's evidence is solid"));
 
         let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
         assert_eq!(objection.status, ObjectionStatus::Conceded);
@@ -206,7 +217,7 @@ mod tests {
     fn apply_ruling_refuted() {
         let mut ledger = ObjectionLedger::new();
         let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Minor);
-        ledger.apply_ruling(&id, false, "already addressed in round 1");
+        assert!(ledger.apply_ruling(&id, false, "already addressed in round 1"));
 
         let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
         assert_eq!(objection.status, ObjectionStatus::Refuted);
@@ -216,10 +227,30 @@ mod tests {
     fn apply_ruling_unknown_id_is_noop() {
         let mut ledger = ObjectionLedger::new();
         ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
-        ledger.apply_ruling("R99-1", true, "does not exist");
+        assert!(!ledger.apply_ruling("R99-1", true, "does not exist"));
 
         // Original objection remains unresolved; nothing panics.
         assert_eq!(ledger.open_objections().len(), 1);
+    }
+
+    #[test]
+    fn apply_ruling_already_resolved_is_ignored() {
+        // A later round's moderator re-mentioning the same REBUTTAL_ID must
+        // not silently overwrite an already-decided ruling.
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
+        assert!(ledger.apply_ruling(&id, false, "refuted in round 1"));
+
+        // A conflicting re-ruling on the same ID is rejected...
+        assert!(!ledger.apply_ruling(&id, true, "conceded in round 2 — should not stick"));
+
+        // ...and the original ruling is untouched.
+        let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
+        assert_eq!(objection.status, ObjectionStatus::Refuted);
+        assert_eq!(
+            objection.ruling_reason.as_deref(),
+            Some("refuted in round 1")
+        );
     }
 
     #[test]

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -19,6 +19,27 @@
 
 use super::objection::ObjectionSeverity;
 
+/// Check whether `line` (after trimming leading whitespace) starts with
+/// `label`, case-insensitively, and return the trimmed rest if so.
+///
+/// Compares as byte slices (`[u8]::eq_ignore_ascii_case`) rather than
+/// slicing `&str` by byte length: `label` is always ASCII, but `line` may
+/// not be (e.g. CJK text before a label appears, or in the label's value).
+/// Slicing a `&str` at an arbitrary byte offset panics if that offset falls
+/// inside a multi-byte character; comparing raw bytes via `.get(..n)` never
+/// panics, and a successful case-insensitive match against an all-ASCII
+/// label guarantees every matched byte is itself ASCII — so the following
+/// `&trimmed[label.len()..]` slice always lands on a valid char boundary.
+fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    let trimmed = line.trim_start();
+    let prefix = trimmed.as_bytes().get(..label.len())?;
+    if prefix.eq_ignore_ascii_case(label.as_bytes()) {
+        Some(trimmed[label.len()..].trim_start())
+    } else {
+        None
+    }
+}
+
 /// Parse a review response to extract approval status and feedback.
 ///
 /// Checks for explicit APPROVE/REJECT keywords in the response text.
@@ -272,15 +293,6 @@ pub fn parse_opponent_rebuttals(text: &str) -> Vec<(String, String, ObjectionSev
         }
     }
 
-    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
-            Some(trimmed[label.len()..].trim_start())
-        } else {
-            None
-        }
-    }
-
     let mut results = Vec::new();
     let mut claim: Option<String> = None;
     let mut evidence: Option<String> = None;
@@ -396,15 +408,6 @@ pub fn parse_moderator_rulings(text: &str) -> Vec<(String, bool, String)> {
         RebuttalId,
         Ruling,
         Reason,
-    }
-
-    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
-            Some(trimmed[label.len()..].trim_start())
-        } else {
-            None
-        }
     }
 
     fn ruling_accepted(value: &str) -> bool {
@@ -563,9 +566,8 @@ pub fn parse_decomposition_request(text: &str) -> Option<String> {
     const NEAR_TOP_LINES: usize = 5;
 
     for line in text.lines().take(NEAR_TOP_LINES) {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= LABEL.len() && trimmed[..LABEL.len()].eq_ignore_ascii_case(LABEL) {
-            let target = trimmed[LABEL.len()..].trim().to_string();
+        if let Some(rest) = label_rest(line, LABEL) {
+            let target = rest.trim().to_string();
             if !target.is_empty() {
                 return Some(target);
             }
@@ -862,6 +864,31 @@ SEVERITY: CRITICAL";
         assert_eq!(rebuttals[0].2, ObjectionSeverity::Minor);
     }
 
+    #[test]
+    fn test_opponent_rebuttals_multibyte_line_before_label_does_not_panic() {
+        // Regression: a non-ASCII line preceding a label used to panic when
+        // slicing `trimmed[..label.len()]` landed mid-character (e.g. inside
+        // 'こ') instead of returning "no match" for the byte comparison.
+        let text = "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].0, "キャッシュは無効");
+        assert_eq!(rebuttals[0].1, "根拠あり");
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Major);
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_emoji_line_before_label_does_not_panic() {
+        // Same class of bug, exercised with a 4-byte emoji character instead
+        // of a 3-byte CJK one.
+        let text = "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].0, "🎉 emoji claim");
+        assert_eq!(rebuttals[0].1, "🎉 emoji evidence");
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Critical);
+    }
+
     // ==================== parse_moderator_rulings Tests ====================
 
     #[test]
@@ -936,6 +963,17 @@ REASON: second";
         assert_eq!(rulings.len(), 2);
         assert_eq!(rulings[0].0, "R1-1");
         assert_eq!(rulings[1].0, "R1-10");
+    }
+
+    #[test]
+    fn test_moderator_rulings_multibyte_line_before_label_does_not_panic() {
+        // Regression: see test_opponent_rebuttals_multibyte_line_before_label_does_not_panic.
+        let text = "→ 裁定は以下の通り\nREBUTTAL_ID: R1-1\nRULING: ACCEPTED\nREASON: 妥当";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 1);
+        assert_eq!(rulings[0].0, "R1-1");
+        assert!(rulings[0].1);
+        assert_eq!(rulings[0].2, "妥当");
     }
 
     // ==================== parse_divergence_check Tests ====================
@@ -1020,5 +1058,15 @@ REASON: second";
     #[test]
     fn test_decomposition_request_empty_target_returns_none() {
         assert_eq!(parse_decomposition_request("DECOMPOSE_REQUEST:   "), None);
+    }
+
+    #[test]
+    fn test_decomposition_request_multibyte_line_before_label_does_not_panic() {
+        // Regression: see test_opponent_rebuttals_multibyte_line_before_label_does_not_panic.
+        let text = "a主張の分解を要求します\nDECOMPOSE_REQUEST: この複合主張";
+        assert_eq!(
+            parse_decomposition_request(text),
+            Some("この複合主張".to_string())
+        );
     }
 }

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -486,10 +486,13 @@ pub fn parse_moderator_rulings(text: &str) -> Vec<(String, bool, String)> {
 /// `DIVERGENT: YES` or `DIVERGENT: NO` line, followed by either the shared
 /// premise (if not divergent) or a note on what diverges (if divergent).
 ///
-/// Conservative: if the first line doesn't clearly declare `DIVERGENT: YES`,
-/// this returns `divergent = false` — an ambiguous or malformed response is
-/// treated as "no divergence detected" rather than triggering a possibly
-/// unwarranted decomposition.
+/// Conservative: if the first line doesn't clearly declare `DIVERGENT: NO`,
+/// this returns `divergent = true` — the caller only takes action (running
+/// the extra contrarian-brief LLM call, and folding the raw response text
+/// into the prompt as a "shared premise") when it reads `divergent = false`.
+/// An ambiguous or malformed response should not silently trigger that
+/// extra work just because the moderator ignored the format; "no action"
+/// is the safe default here, not "divergence detected".
 ///
 /// # Returns
 ///
@@ -519,7 +522,7 @@ pub fn parse_divergence_check(text: &str) -> (bool, String) {
     let first_upper = first_line.to_uppercase();
 
     if !first_upper.contains("DIVERGENT") {
-        return (false, text.trim().to_string());
+        return (true, text.trim().to_string());
     }
 
     let divergent = first_upper.contains("YES") && !first_upper.contains("NO");
@@ -1002,9 +1005,11 @@ REASON: second";
     }
 
     #[test]
-    fn test_divergence_check_missing_format_defaults_to_not_divergent() {
+    fn test_divergence_check_missing_format_defaults_to_divergent() {
+        // Fail-secure: an unparseable response must not silently trigger the
+        // contrarian-brief detour (see doc comment on parse_divergence_check).
         let (divergent, note) = parse_divergence_check("The two sides seem to agree overall.");
-        assert!(!divergent);
+        assert!(divergent);
         assert_eq!(note, "The two sides seem to agree overall.");
     }
 

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -872,7 +872,8 @@ SEVERITY: CRITICAL";
         // Regression: a non-ASCII line preceding a label used to panic when
         // slicing `trimmed[..label.len()]` landed mid-character (e.g. inside
         // 'こ') instead of returning "no match" for the byte comparison.
-        let text = "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
+        let text =
+            "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
         let rebuttals = parse_opponent_rebuttals(text);
         assert_eq!(rebuttals.len(), 1);
         assert_eq!(rebuttals[0].0, "キャッシュは無効");
@@ -884,7 +885,8 @@ SEVERITY: CRITICAL";
     fn test_opponent_rebuttals_emoji_line_before_label_does_not_panic() {
         // Same class of bug, exercised with a 4-byte emoji character instead
         // of a 3-byte CJK one.
-        let text = "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
+        let text =
+            "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
         let rebuttals = parse_opponent_rebuttals(text);
         assert_eq!(rebuttals.len(), 1);
         assert_eq!(rebuttals[0].0, "🎉 emoji claim");

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -12,6 +12,12 @@
 //! | [`parse_final_review_response`] | Final outcome review | SUCCESS / FAILURE |
 //! | [`parse_vote_score`] | Ensemble plan voting | Numeric score 1-10 |
 //! | [`parse_debate_verdict`] | Debate moderator checkpoint | VERDICT: SETTLED / CONTINUE |
+//! | [`parse_opponent_rebuttals`] | Debate opponent rebuttals | CLAIM: / EVIDENCE: / SEVERITY: |
+//! | [`parse_moderator_rulings`] | Debate moderator per-rebuttal ruling | REBUTTAL_ID: / RULING: / REASON: |
+//! | [`parse_divergence_check`] | Panel divergence checkpoint | DIVERGENT: YES / NO |
+//! | [`parse_decomposition_request`] | Opponent decomposition request | DECOMPOSE_REQUEST: |
+
+use super::objection::ObjectionSeverity;
 
 /// Parse a review response to extract approval status and feedback.
 ///
@@ -202,6 +208,371 @@ pub fn parse_debate_verdict(response: &str) -> (bool, String) {
     };
 
     (settled, body)
+}
+
+/// Parse the opponent's structured rebuttals out of a Debate response.
+///
+/// The opponent is instructed (`opponent_system`) to raise each rebuttal as a
+/// `CLAIM:` / `EVIDENCE:` / `SEVERITY:` block. A single response may contain
+/// multiple such blocks back-to-back; each is returned as one tuple. Field
+/// values may span multiple lines — a value is collected until the next
+/// recognized label (`CLAIM:`, `EVIDENCE:`, or `SEVERITY:`) appears.
+///
+/// # Conservative Defaults
+///
+/// - A block missing its `SEVERITY:` line is still returned, defaulting to
+///   [`ObjectionSeverity::Minor`] — under-classifying an unclassified rebuttal
+///   is safer than dropping it entirely (it stays visible to the moderator,
+///   just without inflated urgency).
+/// - A block missing `CLAIM:` or `EVIDENCE:` entirely (i.e. no concrete
+///   attack was ever opened) is dropped — there's nothing falsifiable to act
+///   on.
+/// - Completely unstructured text (no recognized labels at all) yields an
+///   empty vec rather than guessing at intent.
+///
+/// # Examples
+///
+/// ```
+/// use quorum_domain::quorum::parsing::parse_opponent_rebuttals;
+/// use quorum_domain::quorum::ObjectionSeverity;
+///
+/// let text = "\
+/// CLAIM: the cache never expires
+/// EVIDENCE: TTL is set to None in config.rs:42
+/// SEVERITY: MAJOR
+///
+/// CLAIM: concurrent writes are unguarded
+/// EVIDENCE: no mutex around the shared counter in worker.rs
+/// SEVERITY: CRITICAL";
+///
+/// let rebuttals = parse_opponent_rebuttals(text);
+/// assert_eq!(rebuttals.len(), 2);
+/// assert_eq!(rebuttals[0].2, ObjectionSeverity::Major);
+/// assert_eq!(rebuttals[1].2, ObjectionSeverity::Critical);
+/// ```
+pub fn parse_opponent_rebuttals(text: &str) -> Vec<(String, String, ObjectionSeverity)> {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Field {
+        None,
+        Claim,
+        Evidence,
+        Severity,
+    }
+
+    fn severity_from_str(value: &str) -> Option<ObjectionSeverity> {
+        let upper = value.to_uppercase();
+        if upper.contains("CRITICAL") {
+            Some(ObjectionSeverity::Critical)
+        } else if upper.contains("MAJOR") {
+            Some(ObjectionSeverity::Major)
+        } else if upper.contains("MINOR") {
+            Some(ObjectionSeverity::Minor)
+        } else {
+            None
+        }
+    }
+
+    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+        let trimmed = line.trim_start();
+        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
+            Some(trimmed[label.len()..].trim_start())
+        } else {
+            None
+        }
+    }
+
+    let mut results = Vec::new();
+    let mut claim: Option<String> = None;
+    let mut evidence: Option<String> = None;
+    let mut severity: Option<ObjectionSeverity> = None;
+    let mut current = Field::None;
+    let mut buf = String::new();
+
+    // Flush whatever is in `buf` into the field named by `current`.
+    macro_rules! flush_current {
+        () => {
+            let value = buf.trim().to_string();
+            match current {
+                Field::Claim => claim = Some(value),
+                Field::Evidence => evidence = Some(value),
+                Field::Severity => severity = severity_from_str(&value),
+                Field::None => {}
+            }
+            buf.clear();
+        };
+    }
+
+    // Push the accumulated triple (if it has at least claim+evidence) and
+    // reset for the next block.
+    macro_rules! push_if_complete {
+        () => {
+            if let (Some(c), Some(e)) = (claim.take(), evidence.take()) {
+                results.push((c, e, severity.take().unwrap_or(ObjectionSeverity::Minor)));
+            } else {
+                severity.take();
+            }
+        };
+    }
+
+    for line in text.lines() {
+        if let Some(rest) = label_rest(line, "CLAIM:") {
+            flush_current!();
+            push_if_complete!();
+            current = Field::Claim;
+            buf.push_str(rest);
+        } else if let Some(rest) = label_rest(line, "EVIDENCE:") {
+            flush_current!();
+            current = Field::Evidence;
+            buf.push_str(rest);
+        } else if let Some(rest) = label_rest(line, "SEVERITY:") {
+            flush_current!();
+            current = Field::Severity;
+            buf.push_str(rest);
+        } else if current != Field::None {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(trimmed);
+            }
+        }
+    }
+    flush_current!();
+    push_if_complete!();
+
+    results
+}
+
+/// Parse the moderator's per-rebuttal rulings from a Debate checkpoint response.
+///
+/// The moderator is instructed (`moderator_system`) to rule on each rebuttal
+/// with a `REBUTTAL_ID:` / `RULING: ACCEPTED|REJECTED` / `REASON:` block,
+/// repeated once per rebuttal under consideration. This extracts each block
+/// as a `(rebuttal_id, accepted, reason)` tuple.
+///
+/// Matching a returned `rebuttal_id` against a known [`ObjectionLedger`]
+/// (e.g. via `ObjectionLedger::apply_ruling`) is the caller's responsibility
+/// and uses **exact string equality only** — no fuzzy matching is performed
+/// here or by the ledger. If the moderator references an ID that doesn't
+/// exist in the ledger, the caller should log a warning (`tracing::warn!`)
+/// and skip it; this parser does not have access to the ledger and cannot
+/// validate IDs itself.
+///
+/// [`ObjectionLedger`]: super::objection::ObjectionLedger
+///
+/// # Conservative Defaults
+///
+/// - A block whose `RULING:` line doesn't clearly say `ACCEPTED` (or says
+///   both/neither) defaults to `accepted = false` — an unclear ruling should
+///   not silently dismiss an objection.
+/// - A block missing `REBUTTAL_ID:` is dropped — there's no ID to apply the
+///   ruling to.
+/// - Unstructured text with no recognized blocks yields an empty vec.
+///
+/// # Examples
+///
+/// ```
+/// use quorum_domain::quorum::parsing::parse_moderator_rulings;
+///
+/// let text = "\
+/// REBUTTAL_ID: R1-1
+/// RULING: ACCEPTED
+/// REASON: the counterexample holds
+///
+/// REBUTTAL_ID: R1-2
+/// RULING: REJECTED
+/// REASON: no concrete evidence was given";
+///
+/// let rulings = parse_moderator_rulings(text);
+/// assert_eq!(rulings.len(), 2);
+/// assert_eq!(rulings[0], ("R1-1".to_string(), true, "the counterexample holds".to_string()));
+/// assert!(!rulings[1].1);
+/// ```
+pub fn parse_moderator_rulings(text: &str) -> Vec<(String, bool, String)> {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Field {
+        None,
+        RebuttalId,
+        Ruling,
+        Reason,
+    }
+
+    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+        let trimmed = line.trim_start();
+        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
+            Some(trimmed[label.len()..].trim_start())
+        } else {
+            None
+        }
+    }
+
+    fn ruling_accepted(value: &str) -> bool {
+        let upper = value.to_uppercase();
+        upper.contains("ACCEPTED") && !upper.contains("REJECTED")
+    }
+
+    let mut results = Vec::new();
+    let mut rebuttal_id: Option<String> = None;
+    let mut accepted: Option<bool> = None;
+    let mut reason: Option<String> = None;
+    let mut current = Field::None;
+    let mut buf = String::new();
+
+    macro_rules! flush_current {
+        () => {
+            let value = buf.trim().to_string();
+            match current {
+                Field::RebuttalId => rebuttal_id = Some(value),
+                Field::Ruling => accepted = Some(ruling_accepted(&value)),
+                Field::Reason => reason = Some(value),
+                Field::None => {}
+            }
+            buf.clear();
+        };
+    }
+
+    macro_rules! push_if_complete {
+        () => {
+            if let Some(id) = rebuttal_id.take() {
+                results.push((
+                    id,
+                    accepted.take().unwrap_or(false),
+                    reason.take().unwrap_or_default(),
+                ));
+            } else {
+                accepted.take();
+                reason.take();
+            }
+        };
+    }
+
+    for line in text.lines() {
+        if let Some(rest) = label_rest(line, "REBUTTAL_ID:") {
+            flush_current!();
+            push_if_complete!();
+            current = Field::RebuttalId;
+            buf.push_str(rest);
+        } else if let Some(rest) = label_rest(line, "RULING:") {
+            flush_current!();
+            current = Field::Ruling;
+            buf.push_str(rest);
+        } else if let Some(rest) = label_rest(line, "REASON:") {
+            flush_current!();
+            current = Field::Reason;
+            buf.push_str(rest);
+        } else if current != Field::None {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(trimmed);
+            }
+        }
+    }
+    flush_current!();
+    push_if_complete!();
+
+    results
+}
+
+/// Parse a panel moderator's divergence-check response.
+///
+/// Mirrors [`parse_debate_verdict`]'s structure: the moderator opens with a
+/// `DIVERGENT: YES` or `DIVERGENT: NO` line, followed by either the shared
+/// premise (if not divergent) or a note on what diverges (if divergent).
+///
+/// Conservative: if the first line doesn't clearly declare `DIVERGENT: YES`,
+/// this returns `divergent = false` — an ambiguous or malformed response is
+/// treated as "no divergence detected" rather than triggering a possibly
+/// unwarranted decomposition.
+///
+/// # Returns
+///
+/// `(divergent, shared_premise_or_note)` — the note has the leading
+/// `DIVERGENT:` line removed when present.
+///
+/// # Examples
+///
+/// ```
+/// use quorum_domain::quorum::parsing::parse_divergence_check;
+///
+/// let (divergent, note) = parse_divergence_check(
+///     "DIVERGENT: YES\n\nThe two sides are answering different questions."
+/// );
+/// assert!(divergent);
+/// assert_eq!(note, "The two sides are answering different questions.");
+///
+/// let (divergent, note) = parse_divergence_check(
+///     "DIVERGENT: NO\n\nBoth sides agree the API should be idempotent."
+/// );
+/// assert!(!divergent);
+/// assert_eq!(note, "Both sides agree the API should be idempotent.");
+/// ```
+pub fn parse_divergence_check(text: &str) -> (bool, String) {
+    let mut lines = text.lines();
+    let first_line = lines.next().unwrap_or("");
+    let first_upper = first_line.to_uppercase();
+
+    if !first_upper.contains("DIVERGENT") {
+        return (false, text.trim().to_string());
+    }
+
+    let divergent = first_upper.contains("YES") && !first_upper.contains("NO");
+    let body = lines.collect::<Vec<_>>().join("\n").trim().to_string();
+    let body = if body.is_empty() {
+        text.trim().to_string()
+    } else {
+        body
+    };
+
+    (divergent, body)
+}
+
+/// Detect an opponent's request to decompose the debate into sub-questions.
+///
+/// The opponent may open its response with a `DECOMPOSE_REQUEST: <target>`
+/// line near the top when it believes the current question conflates
+/// multiple independent claims that should be debated separately. This
+/// scans only the first few lines of the response (not the whole body) so a
+/// later, incidental mention of the phrase in the rebuttal text itself isn't
+/// mistaken for an actual request.
+///
+/// # Returns
+///
+/// `Some(target)` with the trimmed text following the label if a
+/// `DECOMPOSE_REQUEST:` line is found near the top; `None` otherwise
+/// (including when the label appears only later in the response).
+///
+/// # Examples
+///
+/// ```
+/// use quorum_domain::quorum::parsing::parse_decomposition_request;
+///
+/// let text = "DECOMPOSE_REQUEST: whether caching AND retry policy should be separate\n\nRest of the rebuttal...";
+/// assert_eq!(
+///     parse_decomposition_request(text),
+///     Some("whether caching AND retry policy should be separate".to_string())
+/// );
+///
+/// assert_eq!(parse_decomposition_request("CLAIM: the cache never expires"), None);
+/// ```
+pub fn parse_decomposition_request(text: &str) -> Option<String> {
+    const LABEL: &str = "DECOMPOSE_REQUEST:";
+    const NEAR_TOP_LINES: usize = 5;
+
+    for line in text.lines().take(NEAR_TOP_LINES) {
+        let trimmed = line.trim_start();
+        if trimmed.len() >= LABEL.len() && trimmed[..LABEL.len()].eq_ignore_ascii_case(LABEL) {
+            let target = trimmed[LABEL.len()..].trim().to_string();
+            if !target.is_empty() {
+                return Some(target);
+            }
+            return None;
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -416,5 +787,238 @@ Here is my evaluation:
         let (settled, body) = parse_debate_verdict("VERDICT: SETTLED");
         assert!(settled);
         assert_eq!(body, "VERDICT: SETTLED");
+    }
+
+    // ==================== parse_opponent_rebuttals Tests ====================
+
+    #[test]
+    fn test_opponent_rebuttals_single_block() {
+        let text = "CLAIM: the cache never expires\nEVIDENCE: TTL is None in config.rs:42\nSEVERITY: MAJOR";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].0, "the cache never expires");
+        assert_eq!(rebuttals[0].1, "TTL is None in config.rs:42");
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Major);
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_multiple_blocks() {
+        let text = "\
+CLAIM: claim one
+EVIDENCE: evidence one
+SEVERITY: CRITICAL
+
+CLAIM: claim two
+EVIDENCE: evidence two
+SEVERITY: MINOR";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 2);
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Critical);
+        assert_eq!(rebuttals[1].2, ObjectionSeverity::Minor);
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_multiline_evidence() {
+        let text = "\
+CLAIM: concurrent writes are unguarded
+EVIDENCE: no mutex around the shared counter.
+This can be reproduced by spawning two writers.
+SEVERITY: CRITICAL";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(
+            rebuttals[0].1,
+            "no mutex around the shared counter.\nThis can be reproduced by spawning two writers."
+        );
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_missing_severity_defaults_to_minor() {
+        let text = "CLAIM: claim only\nEVIDENCE: evidence only";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Minor);
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_missing_evidence_is_dropped() {
+        // No concrete evidence ever given — not falsifiable, so it's dropped.
+        let text = "CLAIM: claim without evidence\nSEVERITY: MAJOR";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert!(rebuttals.is_empty());
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_unstructured_text_is_empty() {
+        let rebuttals = parse_opponent_rebuttals("This plan has some vague issues.");
+        assert!(rebuttals.is_empty());
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_case_insensitive_labels() {
+        let text = "claim: lowercase claim\nevidence: lowercase evidence\nseverity: minor";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Minor);
+    }
+
+    // ==================== parse_moderator_rulings Tests ====================
+
+    #[test]
+    fn test_moderator_rulings_single_block_accepted() {
+        let text = "REBUTTAL_ID: R1-1\nRULING: ACCEPTED\nREASON: the counterexample holds";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 1);
+        assert_eq!(rulings[0].0, "R1-1");
+        assert!(rulings[0].1);
+        assert_eq!(rulings[0].2, "the counterexample holds");
+    }
+
+    #[test]
+    fn test_moderator_rulings_multiple_blocks() {
+        let text = "\
+REBUTTAL_ID: R1-1
+RULING: ACCEPTED
+REASON: solid evidence
+
+REBUTTAL_ID: R1-2
+RULING: REJECTED
+REASON: unfalsifiable impression";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 2);
+        assert_eq!(
+            rulings[0],
+            ("R1-1".to_string(), true, "solid evidence".to_string())
+        );
+        assert_eq!(
+            rulings[1],
+            (
+                "R1-2".to_string(),
+                false,
+                "unfalsifiable impression".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_moderator_rulings_ambiguous_ruling_defaults_to_rejected() {
+        let text = "REBUTTAL_ID: R2-1\nRULING: unclear\nREASON: model ignored the format";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 1);
+        assert!(!rulings[0].1);
+    }
+
+    #[test]
+    fn test_moderator_rulings_missing_id_is_dropped() {
+        let text = "RULING: ACCEPTED\nREASON: no id given";
+        let rulings = parse_moderator_rulings(text);
+        assert!(rulings.is_empty());
+    }
+
+    #[test]
+    fn test_moderator_rulings_unstructured_text_is_empty() {
+        let rulings = parse_moderator_rulings("No structured rulings here.");
+        assert!(rulings.is_empty());
+    }
+
+    #[test]
+    fn test_moderator_rulings_exact_id_match_no_fuzzy() {
+        // Distinct-but-similar IDs must remain distinct — no fuzzy collapsing.
+        let text = "\
+REBUTTAL_ID: R1-1
+RULING: ACCEPTED
+REASON: first
+
+REBUTTAL_ID: R1-10
+RULING: REJECTED
+REASON: second";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 2);
+        assert_eq!(rulings[0].0, "R1-1");
+        assert_eq!(rulings[1].0, "R1-10");
+    }
+
+    // ==================== parse_divergence_check Tests ====================
+
+    #[test]
+    fn test_divergence_check_yes() {
+        let (divergent, note) = parse_divergence_check(
+            "DIVERGENT: YES\n\nThe sides are answering different questions.",
+        );
+        assert!(divergent);
+        assert_eq!(note, "The sides are answering different questions.");
+    }
+
+    #[test]
+    fn test_divergence_check_no() {
+        let (divergent, note) =
+            parse_divergence_check("DIVERGENT: NO\n\nBoth sides agree on the shared premise.");
+        assert!(!divergent);
+        assert_eq!(note, "Both sides agree on the shared premise.");
+    }
+
+    #[test]
+    fn test_divergence_check_case_insensitive() {
+        let (divergent, _) = parse_divergence_check("divergent: yes\n\nSplit detected.");
+        assert!(divergent);
+    }
+
+    #[test]
+    fn test_divergence_check_missing_format_defaults_to_not_divergent() {
+        let (divergent, note) = parse_divergence_check("The two sides seem to agree overall.");
+        assert!(!divergent);
+        assert_eq!(note, "The two sides seem to agree overall.");
+    }
+
+    #[test]
+    fn test_divergence_check_yes_with_no_body_falls_back_to_full_response() {
+        let (divergent, note) = parse_divergence_check("DIVERGENT: YES");
+        assert!(divergent);
+        assert_eq!(note, "DIVERGENT: YES");
+    }
+
+    // ==================== parse_decomposition_request Tests ====================
+
+    #[test]
+    fn test_decomposition_request_found_near_top() {
+        let text = "DECOMPOSE_REQUEST: split caching from retry policy\n\nRest of rebuttal...";
+        assert_eq!(
+            parse_decomposition_request(text),
+            Some("split caching from retry policy".to_string())
+        );
+    }
+
+    #[test]
+    fn test_decomposition_request_absent_returns_none() {
+        assert_eq!(
+            parse_decomposition_request("CLAIM: the cache never expires"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_decomposition_request_case_insensitive() {
+        let text = "decompose_request: split the question";
+        assert_eq!(
+            parse_decomposition_request(text),
+            Some("split the question".to_string())
+        );
+    }
+
+    #[test]
+    fn test_decomposition_request_ignored_when_not_near_top() {
+        // The label only appears deep in the body — not a genuine request,
+        // just incidental text (e.g. quoting instructions back).
+        let mut text = String::new();
+        for i in 0..10 {
+            text.push_str(&format!("filler line {i}\n"));
+        }
+        text.push_str("DECOMPOSE_REQUEST: buried mention\n");
+        assert_eq!(parse_decomposition_request(&text), None);
+    }
+
+    #[test]
+    fn test_decomposition_request_empty_target_returns_none() {
+        assert_eq!(parse_decomposition_request("DECOMPOSE_REQUEST:   "), None);
     }
 }

--- a/domain/src/quorum/result_event.rs
+++ b/domain/src/quorum/result_event.rs
@@ -37,6 +37,8 @@ pub enum QuorumTopic {
     FinalReview,
     /// Headless review of a PR/diff (#300)
     PrReview,
+    /// Final ruling of the debate strategy (RFC #313)
+    Debate,
 }
 
 impl QuorumTopic {
@@ -47,6 +49,7 @@ impl QuorumTopic {
             Self::ActionReview => "action_review",
             Self::FinalReview => "final_review",
             Self::PrReview => "pr_review",
+            Self::Debate => "debate",
         }
     }
 }
@@ -228,6 +231,12 @@ mod tests {
 
         // A bare stdin diff has neither — no target at all, not an empty object
         assert_eq!(QuorumTarget::pr_review(None, None), None);
+    }
+
+    #[test]
+    fn test_debate_topic_as_str() {
+        // Debate has no dedicated QuorumTarget field — it's operated with target: None
+        assert_eq!(QuorumTopic::Debate.as_str(), "debate");
     }
 
     // Regression test: a bare `git diff | copilot-quorum review` (no --pr,

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -45,10 +45,14 @@
 //! | `/edit` | `edit`, `e` | Edit plan (not yet implemented) |
 //!
 //! The same handler also implements `request_debate_escalation` for the
-//! Debate strategy's round-limit escalation: it shows the question, the
-//! remaining unresolved objections (claim/evidence/severity), and a
-//! transcript summary, then accepts `/approve` (force a decision) or
-//! `/reject` (abort the debate).
+//! Debate strategy's settle-checkpoint escalation (triggered whenever the
+//! moderator tries to settle with unresolved critical/major objections —
+//! not only at the round limit): it shows the question, the remaining
+//! unresolved objections (claim/evidence/severity), and a transcript
+//! summary, then accepts `/approve` (force a decision) or `/reject`. What
+//! `/reject` does depends on whether a next round exists: it declines the
+//! early settle and continues the debate in a non-final round, or aborts
+//! the debate entirely at the final round.
 
 use async_trait::async_trait;
 use colored::Colorize;
@@ -174,6 +178,7 @@ impl InteractiveHumanIntervention {
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) {
         println!();
         println!(
@@ -191,10 +196,17 @@ impl InteractiveHumanIntervention {
         );
         println!();
 
-        println!(
-            "The debate reached its round limit with {} unresolved objection(s).",
-            unresolved.len()
-        );
+        if can_continue {
+            println!(
+                "The moderator wants to settle early with {} unresolved objection(s) still open.",
+                unresolved.len()
+            );
+        } else {
+            println!(
+                "The debate reached its round limit with {} unresolved objection(s).",
+                unresolved.len()
+            );
+        }
         println!();
 
         // Show original question
@@ -238,7 +250,14 @@ impl InteractiveHumanIntervention {
             "  {}  - Force a decision, proceeding despite unresolved objections",
             "/approve".green()
         );
-        println!("  {}   - Abort the debate", "/reject".red());
+        if can_continue {
+            println!(
+                "  {}   - Decline the early settle, continue the debate to the next round",
+                "/reject".red()
+            );
+        } else {
+            println!("  {}   - Abort the debate", "/reject".red());
+        }
         println!();
     }
 
@@ -385,8 +404,9 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
         question: &str,
         unresolved: &[quorum_domain::quorum::Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
-        self.display_debate_escalation_prompt(question, unresolved, transcript_summary);
+        self.display_debate_escalation_prompt(question, unresolved, transcript_summary, can_continue);
 
         loop {
             let input = self.read_command()?;
@@ -402,7 +422,11 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
                 }
                 "/reject" | "reject" | "r" | "q" => {
                     println!();
-                    println!("{}", "✗ Debate aborted by human".red());
+                    if can_continue {
+                        println!("{}", "✗ Early settle declined — debate continues".red());
+                    } else {
+                        println!("{}", "✗ Debate aborted by human".red());
+                    }
                     return Ok(HumanDecision::Reject);
                 }
                 "" => continue,

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -43,6 +43,12 @@
 //! | `/approve` | `approve`, `a` | Execute the current plan |
 //! | `/reject` | `reject`, `r`, `q` | Abort the agent |
 //! | `/edit` | `edit`, `e` | Edit plan (not yet implemented) |
+//!
+//! The same handler also implements `request_debate_escalation` for the
+//! Debate strategy's round-limit escalation: it shows the question, the
+//! remaining unresolved objections (claim/evidence/severity), and a
+//! transcript summary, then accepts `/approve` (force a decision) or
+//! `/reject` (abort the debate).
 
 use async_trait::async_trait;
 use colored::Colorize;
@@ -50,6 +56,7 @@ use quorum_application::ports::human_intervention::{
     HumanInterventionError, HumanInterventionPort,
 };
 use quorum_domain::core::string::truncate;
+use quorum_domain::quorum::{Objection, ObjectionSeverity};
 use quorum_domain::{HumanDecision, Plan, ReviewRound};
 use std::io::{self, Write};
 
@@ -158,6 +165,80 @@ impl InteractiveHumanIntervention {
             "  {}     - Edit plan (feature coming soon)",
             "/edit".yellow()
         );
+        println!();
+    }
+
+    /// Display the debate escalation prompt UI
+    fn display_debate_escalation_prompt(
+        &self,
+        question: &str,
+        unresolved: &[Objection],
+        transcript_summary: &str,
+    ) {
+        println!();
+        println!(
+            "{}",
+            "═══════════════════════════════════════════════════════════════"
+                .yellow()
+                .bold()
+        );
+        println!("{}", "  ⚖️  Debate Requires Human Ruling".yellow().bold());
+        println!(
+            "{}",
+            "═══════════════════════════════════════════════════════════════"
+                .yellow()
+                .bold()
+        );
+        println!();
+
+        println!(
+            "The debate reached its round limit with {} unresolved objection(s).",
+            unresolved.len()
+        );
+        println!();
+
+        // Show original question
+        println!("{}", "Question:".cyan().bold());
+        println!("  {}", question.dimmed());
+        println!();
+
+        // Show unresolved objections
+        if !unresolved.is_empty() {
+            println!("{}", "Unresolved Objections:".cyan().bold());
+            for objection in unresolved {
+                let severity = match objection.severity {
+                    ObjectionSeverity::Critical => "CRITICAL".red(),
+                    ObjectionSeverity::Major => "MAJOR".yellow(),
+                    ObjectionSeverity::Minor => "minor".dimmed(),
+                };
+                println!(
+                    "  [{}] {} {}",
+                    objection.id,
+                    severity,
+                    truncate(&objection.claim, 80)
+                );
+                println!(
+                    "    └─ evidence: {}",
+                    truncate(&objection.evidence, 80).dimmed()
+                );
+            }
+            println!();
+        }
+
+        // Show transcript summary
+        if !transcript_summary.is_empty() {
+            println!("{}", "Transcript Summary:".cyan().bold());
+            println!("  {}", transcript_summary.dimmed());
+            println!();
+        }
+
+        // Show commands
+        println!("{}", "Commands:".cyan().bold());
+        println!(
+            "  {}  - Force a decision, proceeding despite unresolved objections",
+            "/approve".green()
+        );
+        println!("  {}   - Abort the debate", "/reject".red());
         println!();
     }
 
@@ -286,6 +367,42 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
                 "/reject" | "reject" | "r" | "n" | "no" | "q" => {
                     println!();
                     println!("{}", "✗ Execution cancelled".yellow());
+                    return Ok(HumanDecision::Reject);
+                }
+                "" => continue,
+                _ => {
+                    println!();
+                    println!("{} Unknown command: {}", "⚠️".yellow(), input.red());
+                    println!("Available commands: /approve, /reject");
+                    println!();
+                }
+            }
+        }
+    }
+
+    async fn request_debate_escalation(
+        &self,
+        question: &str,
+        unresolved: &[quorum_domain::quorum::Objection],
+        transcript_summary: &str,
+    ) -> Result<HumanDecision, HumanInterventionError> {
+        self.display_debate_escalation_prompt(question, unresolved, transcript_summary);
+
+        loop {
+            let input = self.read_command()?;
+
+            match input.to_lowercase().as_str() {
+                "/approve" | "approve" | "a" => {
+                    println!();
+                    println!(
+                        "{}",
+                        "✓ Debate forced to a decision by human ruling".green()
+                    );
+                    return Ok(HumanDecision::Approve);
+                }
+                "/reject" | "reject" | "r" | "q" => {
+                    println!();
+                    println!("{}", "✗ Debate aborted by human".red());
                     return Ok(HumanDecision::Reject);
                 }
                 "" => continue,

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -406,7 +406,12 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
         transcript_summary: &str,
         can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
-        self.display_debate_escalation_prompt(question, unresolved, transcript_summary, can_continue);
+        self.display_debate_escalation_prompt(
+            question,
+            unresolved,
+            transcript_summary,
+            can_continue,
+        );
 
         loop {
             let input = self.read_command()?;

--- a/presentation/src/tui/app_hil.rs
+++ b/presentation/src/tui/app_hil.rs
@@ -40,6 +40,7 @@ pub(super) fn handle_hil_request(
             question,
             unresolved,
             transcript_summary,
+            can_continue,
         } => (
             "Debate Requires Human Ruling".to_string(),
             question.clone(),
@@ -54,11 +55,19 @@ pub(super) fn handle_hil_request(
                     format!("[{}] ({}) {}", o.id, severity, o.claim)
                 })
                 .collect(),
-            format!(
-                "{} unresolved objection(s). {} Approve to force a decision, reject to abort.",
-                unresolved.len(),
-                transcript_summary
-            ),
+            if *can_continue {
+                format!(
+                    "{} unresolved objection(s). Moderator wants to settle early. {} Approve to force a decision, reject to continue the debate.",
+                    unresolved.len(),
+                    transcript_summary
+                )
+            } else {
+                format!(
+                    "{} unresolved objection(s) at the round limit. {} Approve to force a decision, reject to abort.",
+                    unresolved.len(),
+                    transcript_summary
+                )
+            },
         ),
     };
 
@@ -151,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_hil_request_builds_prompt_for_debate_escalation() {
+    fn handle_hil_request_builds_prompt_for_debate_escalation_at_final_round() {
         let mut state = TuiState::new();
         let (response_tx, _response_rx) = oneshot::channel();
         let pending_hil_tx = Arc::new(Mutex::new(None));
@@ -161,6 +170,7 @@ mod tests {
                 question: "Should we ship the migration?".to_string(),
                 unresolved: vec![sample_objection()],
                 transcript_summary: "3 rounds, 1 objection remains".to_string(),
+                can_continue: false,
             },
             response_tx,
         };
@@ -174,7 +184,33 @@ mod tests {
         assert!(prompt.tasks[0].contains("MAJOR"));
         assert!(prompt.tasks[0].contains("The plan ignores concurrent writes"));
         assert!(prompt.message.contains("1 unresolved objection"));
+        assert!(prompt.message.contains("round limit"));
+        assert!(prompt.message.contains("reject to abort"));
         assert!(prompt.message.contains("3 rounds, 1 objection remains"));
+        assert!(pending_hil_tx.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn handle_hil_request_builds_prompt_for_debate_escalation_at_early_settle() {
+        let mut state = TuiState::new();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let pending_hil_tx = Arc::new(Mutex::new(None));
+
+        let request = HilRequest {
+            kind: HilKind::DebateEscalation {
+                question: "Should we ship the migration?".to_string(),
+                unresolved: vec![sample_objection()],
+                transcript_summary: "1 round, 1 objection remains".to_string(),
+                can_continue: true,
+            },
+            response_tx,
+        };
+
+        handle_hil_request(&mut state, &pending_hil_tx, request);
+
+        let prompt = state.hil_prompt.expect("hil_prompt should be set");
+        assert!(prompt.message.contains("settle early"));
+        assert!(prompt.message.contains("reject to continue the debate"));
         assert!(pending_hil_tx.lock().unwrap().is_some());
     }
 

--- a/presentation/src/tui/app_hil.rs
+++ b/presentation/src/tui/app_hil.rs
@@ -3,6 +3,7 @@
 use super::event::{HilKind, HilRequest};
 use super::state::{HilPrompt, TuiState};
 use quorum_domain::HumanDecision;
+use quorum_domain::quorum::ObjectionSeverity;
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 
@@ -34,6 +35,30 @@ pub(super) fn handle_hil_request(
             plan.objective.clone(),
             plan.tasks.iter().map(|t| t.description.clone()).collect(),
             "Approve execution?".to_string(),
+        ),
+        HilKind::DebateEscalation {
+            question,
+            unresolved,
+            transcript_summary,
+        } => (
+            "Debate Requires Human Ruling".to_string(),
+            question.clone(),
+            unresolved
+                .iter()
+                .map(|o| {
+                    let severity = match o.severity {
+                        ObjectionSeverity::Critical => "CRITICAL",
+                        ObjectionSeverity::Major => "MAJOR",
+                        ObjectionSeverity::Minor => "minor",
+                    };
+                    format!("[{}] ({}) {}", o.id, severity, o.claim)
+                })
+                .collect(),
+            format!(
+                "{} unresolved objection(s). {} Approve to force a decision, reject to abort.",
+                unresolved.len(),
+                transcript_summary
+            ),
         ),
     };
 
@@ -107,6 +132,51 @@ fn send_hil_response(
 mod tests {
     use super::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use quorum_domain::quorum::{Objection, ObjectionLedger};
+
+    fn sample_objection() -> Objection {
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(
+            1,
+            "The plan ignores concurrent writes",
+            "See race in step 3",
+            ObjectionSeverity::Major,
+        );
+        ledger
+            .open_objections()
+            .into_iter()
+            .find(|o| o.id == id)
+            .cloned()
+            .expect("objection should exist after add")
+    }
+
+    #[test]
+    fn handle_hil_request_builds_prompt_for_debate_escalation() {
+        let mut state = TuiState::new();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let pending_hil_tx = Arc::new(Mutex::new(None));
+
+        let request = HilRequest {
+            kind: HilKind::DebateEscalation {
+                question: "Should we ship the migration?".to_string(),
+                unresolved: vec![sample_objection()],
+                transcript_summary: "3 rounds, 1 objection remains".to_string(),
+            },
+            response_tx,
+        };
+
+        handle_hil_request(&mut state, &pending_hil_tx, request);
+
+        let prompt = state.hil_prompt.expect("hil_prompt should be set");
+        assert_eq!(prompt.title, "Debate Requires Human Ruling");
+        assert_eq!(prompt.objective, "Should we ship the migration?");
+        assert_eq!(prompt.tasks.len(), 1);
+        assert!(prompt.tasks[0].contains("MAJOR"));
+        assert!(prompt.tasks[0].contains("The plan ignores concurrent writes"));
+        assert!(prompt.message.contains("1 unresolved objection"));
+        assert!(prompt.message.contains("3 rounds, 1 objection remains"));
+        assert!(pending_hil_tx.lock().unwrap().is_some());
+    }
 
     fn state_with_modal() -> TuiState {
         let mut state = TuiState::new();

--- a/presentation/src/tui/event.rs
+++ b/presentation/src/tui/event.rs
@@ -225,13 +225,18 @@ pub enum HilKind {
         request: String,
         plan: Plan,
     },
-    /// Debate strategy round-limit escalation — unresolved objections remain
-    /// after the moderator ran out of checkpoint rounds (see
-    /// `HumanInterventionPort::request_debate_escalation`).
+    /// Debate strategy settle-checkpoint escalation — the moderator tried to
+    /// settle while critical/major objections remain unresolved (see
+    /// `HumanInterventionPort::request_debate_escalation`). Fires at every
+    /// such checkpoint, not only the final round.
     DebateEscalation {
         question: String,
         unresolved: Vec<Objection>,
         transcript_summary: String,
+        /// `true` when this is a non-final round: rejecting declines the
+        /// early settle and continues the debate. `false` at the final
+        /// round: rejecting aborts the debate entirely.
+        can_continue: bool,
     },
 }
 

--- a/presentation/src/tui/event.rs
+++ b/presentation/src/tui/event.rs
@@ -3,6 +3,7 @@
 //! Defines the commands sent TO the controller task and the events
 //! coming FROM it (via UiEvent channel and progress bridge).
 
+use quorum_domain::quorum::Objection;
 use quorum_domain::{
     AgentPhase, ConsensusLevel, ContextMode, HumanDecision, InteractionForm, InteractionId, Plan,
     ReviewRound, StreamContext,
@@ -223,6 +224,14 @@ pub enum HilKind {
     ExecutionConfirmation {
         request: String,
         plan: Plan,
+    },
+    /// Debate strategy round-limit escalation — unresolved objections remain
+    /// after the moderator ran out of checkpoint rounds (see
+    /// `HumanInterventionPort::request_debate_escalation`).
+    DebateEscalation {
+        question: String,
+        unresolved: Vec<Objection>,
+        transcript_summary: String,
     },
 }
 

--- a/presentation/src/tui/human_intervention.rs
+++ b/presentation/src/tui/human_intervention.rs
@@ -83,6 +83,7 @@ impl HumanInterventionPort for TuiHumanIntervention {
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -91,6 +92,7 @@ impl HumanInterventionPort for TuiHumanIntervention {
                 question: question.to_string(),
                 unresolved: unresolved.to_vec(),
                 transcript_summary: transcript_summary.to_string(),
+                can_continue,
             },
             response_tx,
         };

--- a/presentation/src/tui/human_intervention.rs
+++ b/presentation/src/tui/human_intervention.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use quorum_application::ports::human_intervention::{
     HumanInterventionError, HumanInterventionPort,
 };
+use quorum_domain::quorum::Objection;
 use quorum_domain::{HumanDecision, Plan, ReviewRound};
 use tokio::sync::{mpsc, oneshot};
 
@@ -64,6 +65,32 @@ impl HumanInterventionPort for TuiHumanIntervention {
             kind: HilKind::ExecutionConfirmation {
                 request: request.to_string(),
                 plan: plan.clone(),
+            },
+            response_tx,
+        };
+
+        self.hil_tx
+            .send(hil_request)
+            .map_err(|_| HumanInterventionError::IoError("TUI channel closed".to_string()))?;
+
+        response_rx.await.map_err(|_| {
+            HumanInterventionError::IoError("TUI response channel dropped".to_string())
+        })
+    }
+
+    async fn request_debate_escalation(
+        &self,
+        question: &str,
+        unresolved: &[Objection],
+        transcript_summary: &str,
+    ) -> Result<HumanDecision, HumanInterventionError> {
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let hil_request = HilRequest {
+            kind: HilKind::DebateEscalation {
+                question: question.to_string(),
+                unresolved: unresolved.to_vec(),
+                transcript_summary: transcript_summary.to_string(),
             },
             response_tx,
         };


### PR DESCRIPTION
## Summary

Closes #316

RFC #313 の GAN 対応表レビューで導出された構造系機能。#314(PR #315) のプロンプトレベル3原則（反証可能性ゲート・理由付き譲歩・構造化裁定）に続き、型・フローレベルの残りを実装する。

- **反論台帳（Objection Ledger）**: `domain/src/quorum/objection.rs` を新規追加。`{claim, evidence, severity, status}` を追跡する純粋ロジック（async 非依存、#212 の `InteractionScheduler` が前例）。opponent の `CLAIM/EVIDENCE/SEVERITY` と moderator の `REBUTTAL_ID/RULING/REASON` をパースする関数を `parsing.rs` に追加。未解決の CRITICAL/MAJOR 反論が残ったまま決着しそうになったら、既存の `HumanInterventionPort`/`HilMode`（AutoReject/AutoApprove/Interactive）を再利用して HiL にエスカレーションする（新規 HiL 機構は作らず fail-secure デフォルト = Reject）。
- **発散チェック（反 mode collapse）**: Round 1 の opening/attack が実質同一かをモデレーターへの追加の問いで検知し、検知時は天邪鬼ブリーフ（反対立場を割り当てた追加ラウンド）を1討議につき1回発動。`max_rounds` を消費しない。
- **裁定の Vote スキーマ統合**: `QuorumTopic::Debate` を新設し、反論ごとの ruling を Vote（Refuted→Approve / Conceded→Reject / Unresolved→Abstain）に、討議全体の最終裁定を末尾の closing vote にマッピング。`VoteResult` は `from_votes()` の多数決再計算ではなく構造体リテラルで直接構築し、`passed` にはドメインで計算した実際の settled/escalated 真偽値をセット（Vote 集計との意味のすり替えを防止）。`AppEvent::QuorumResult` として publish され、JSONL/Lua 購読者は無変更で観測できる。
- **分解要求権（反・難読化論法）**: opponent が `DECOMPOSE_REQUEST` で相手の主張を検証可能なサブ主張への分解を要求できる。1ラウンドにつき最大1回、ラウンドは消費しない。

`DebateStrategyExecutor` / `HumanInterventionPort` / `RunQuorumUseCase` / `AgentController` / TUI・CLI の HiL アダプタまで一貫して配線。

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`（1211 passed, 0 failed）
- [x] `cargo fmt --all --check`
- [x] `ObjectionLedger` のユニットテスト（9本）
- [x] パーサー（`parse_opponent_rebuttals`/`parse_moderator_rulings`/`parse_divergence_check`/`parse_decomposition_request`）のユニット・doctest
- [x] `debate_strategy.rs` の統合テスト（エスカレーション approve/reject/cancelled 各分岐、天邪鬼ブリーフ発動、分解要求の1ラウンド1回制限、Vote publish）
- [x] 既存4テスト（`debate_settles_early_when_moderator_agrees` 等）は無傷

実装は copilot-quorum（exploration=gpt-5.6-terra, decision=claude-sonnet-5）が生成し、レビュー・実機検証のうえコミット。

🤖 Generated with [Claude Code](https://claude.com/claude-code)