### PR TITLE
fix(orchestration): 敵対的パネル v2 のレビュー指摘対応 (PR #319)

### DIFF
--- a/application/src/ports/human_intervention.rs
+++ b/application/src/ports/human_intervention.rs
@@ -140,30 +140,40 @@ pub trait HumanInterventionPort: Send + Sync {
         Ok(HumanDecision::Approve)
     }
 
-    /// Request human escalation when a Debate strategy run cannot resolve
-    /// all objections (e.g. unresolved objections remain at `max_rounds`).
+    /// Request human escalation when a Debate strategy moderator tries to
+    /// settle while critical/major [`quorum_domain::quorum::Objection`]s
+    /// remain unresolved.
     ///
-    /// Called when the `Debate` orchestration strategy reaches its round
-    /// limit with open [`quorum_domain::quorum::Objection`]s still
-    /// unresolved by the moderator.
+    /// Called at *every* settle checkpoint gated this way — not only the
+    /// final round. An early premature settle attempt and the final round
+    /// forcing a settle both route through here; `can_continue` tells the
+    /// implementation which one it's showing the user.
     ///
     /// # Arguments
     ///
     /// * `question` - The original question/topic being debated
     /// * `unresolved` - The objections that remain unresolved
     /// * `transcript_summary` - A condensed summary of the debate transcript
+    /// * `can_continue` - `true` if this is a non-final round: rejecting
+    ///   declines the premature settle and the debate continues to the next
+    ///   round. `false` if this is the final round (`max_rounds` reached):
+    ///   rejecting aborts the debate entirely, since there is no next round
+    ///   to continue to.
     ///
     /// # Default
     ///
     /// Defaults to `Reject` (fail-secure). This matches the philosophy of
     /// [`AutoRejectIntervention`]: an unresolved adversarial debate should
-    /// not silently proceed. Override in interactive implementations to
-    /// prompt the user, or in [`AutoApproveIntervention`] to bypass.
+    /// not silently settle. When `can_continue` is `true`, `Reject` simply
+    /// continues the debate rather than aborting it. Override in interactive
+    /// implementations to prompt the user, or in [`AutoApproveIntervention`]
+    /// to bypass.
     async fn request_debate_escalation(
         &self,
         _question: &str,
         _unresolved: &[quorum_domain::quorum::Objection],
         _transcript_summary: &str,
+        _can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Reject)
     }
@@ -225,6 +235,7 @@ impl HumanInterventionPort for AutoApproveIntervention {
         _question: &str,
         _unresolved: &[quorum_domain::quorum::Objection],
         _transcript_summary: &str,
+        _can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         Ok(HumanDecision::Approve)
     }
@@ -300,7 +311,7 @@ mod tests {
         let intervention = AutoRejectIntervention;
         let objection = sample_objection();
         let result = intervention
-            .request_debate_escalation("test question", &[objection], "transcript summary")
+            .request_debate_escalation("test question", &[objection], "transcript summary", true)
             .await
             .unwrap();
         assert!(matches!(result, HumanDecision::Reject));
@@ -311,7 +322,7 @@ mod tests {
         let intervention = AutoApproveIntervention;
         let objection = sample_objection();
         let result = intervention
-            .request_debate_escalation("test question", &[objection], "transcript summary")
+            .request_debate_escalation("test question", &[objection], "transcript summary", true)
             .await
             .unwrap();
         assert!(matches!(result, HumanDecision::Approve));

--- a/application/src/ports/human_intervention.rs
+++ b/application/src/ports/human_intervention.rs
@@ -153,7 +153,11 @@ pub trait HumanInterventionPort: Send + Sync {
     ///
     /// * `question` - The original question/topic being debated
     /// * `unresolved` - The objections that remain unresolved
-    /// * `transcript_summary` - A condensed summary of the debate transcript
+    /// * `transcript_summary` - A condensed (head+tail truncated to a fixed
+    ///   byte budget — see `DebateStrategyExecutor`'s
+    ///   `TRANSCRIPT_SUMMARY_MAX_BYTES`) summary of the debate transcript,
+    ///   safe to render inline (e.g. a single TUI modal line) without
+    ///   growing unbounded across rounds
     /// * `can_continue` - `true` if this is a non-final round: rejecting
     ///   declines the premature settle and the debate continues to the next
     ///   round. `false` if this is the final round (`max_rounds` reached):

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -27,6 +27,7 @@ use quorum_domain::quorum::parsing::{
     parse_debate_verdict, parse_decomposition_request, parse_divergence_check,
     parse_moderator_rulings, parse_opponent_rebuttals,
 };
+use quorum_domain::util::truncate_head_tail;
 use quorum_domain::{
     DebateConfig, DebateIntensity, DebatePromptTemplate, HilMode, HumanDecision, Model,
     ModelResponse, Objection, ObjectionLedger, ObjectionStatus, OrchestrationStrategy, PeerReview,
@@ -35,6 +36,14 @@ use quorum_domain::{
 };
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// Byte budget for the transcript summary handed to
+/// `HumanInterventionPort::request_debate_escalation` — the port docs call
+/// this a "condensed summary", and both the CLI and TUI render it inline
+/// (a single modal line in the TUI), so the full `render_transcript` output
+/// (unbounded, grows every round) would blow past what either surface can
+/// reasonably display.
+const TRANSCRIPT_SUMMARY_MAX_BYTES: usize = 2000;
 
 /// Adversarial discussion: fixed proponent/opponent roles attack and defend a
 /// position across rounds, with an optional third-party interjector, until a
@@ -615,7 +624,10 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     human_intervention.as_ref(),
                     question,
                     &unresolved,
-                    &Self::render_transcript(&transcript),
+                    &truncate_head_tail(
+                        &Self::render_transcript(&transcript),
+                        TRANSCRIPT_SUMMARY_MAX_BYTES,
+                    ),
                     !is_final_round,
                 )
                 .await?;
@@ -761,11 +773,13 @@ mod tests {
 
     /// Mock `HumanInterventionPort` that returns a pre-configured
     /// (`request_debate_escalation`-only) outcome and records each
-    /// invocation's `can_continue` flag (in call order) alongside the count.
+    /// invocation's `can_continue` flag and `transcript_summary` length (in
+    /// call order) alongside the count.
     struct MockEscalationHandler {
         outcome: Result<HumanDecision, HumanInterventionError>,
         calls: Mutex<usize>,
         can_continue_calls: Mutex<Vec<bool>>,
+        transcript_summary_lens: Mutex<Vec<usize>>,
     }
 
     impl MockEscalationHandler {
@@ -774,6 +788,7 @@ mod tests {
                 outcome,
                 calls: Mutex::new(0),
                 can_continue_calls: Mutex::new(Vec::new()),
+                transcript_summary_lens: Mutex::new(Vec::new()),
             }
         }
     }
@@ -793,11 +808,15 @@ mod tests {
             &self,
             _question: &str,
             _unresolved: &[Objection],
-            _transcript_summary: &str,
+            transcript_summary: &str,
             can_continue: bool,
         ) -> Result<HumanDecision, HumanInterventionError> {
             *self.calls.lock().unwrap() += 1;
             self.can_continue_calls.lock().unwrap().push(can_continue);
+            self.transcript_summary_lens
+                .lock()
+                .unwrap()
+                .push(transcript_summary.len());
             self.outcome.clone()
         }
     }
@@ -1450,6 +1469,53 @@ mod tests {
             "unexpected conclusion: {}",
             result.synthesis.conclusion
         );
+    }
+
+    #[tokio::test]
+    async fn debate_escalation_transcript_summary_is_truncated_to_budget() {
+        // Regression: debate_strategy.rs used to pass the full, unbounded
+        // render_transcript() output as `transcript_summary` — a single TUI
+        // modal line, or CLI dump, of the entire debate. It must be
+        // head+tail truncated to TRANSCRIPT_SUMMARY_MAX_BYTES instead.
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Approve)));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
+        // A very long EVIDENCE line pushes the rendered transcript well past
+        // the budget by the time escalation fires.
+        let long_evidence = "x".repeat(TRANSCRIPT_SUMMARY_MAX_BYTES * 2);
+        gateway.respond(
+            Model::Gemini31Pro,
+            format!(
+                "CLAIM: write-through never expires\nEVIDENCE: {}\nSEVERITY: CRITICAL",
+                long_evidence
+            ),
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on TTL handling.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nWrite-through wins.",
+        );
+
+        DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap();
+
+        let lens = handler.transcript_summary_lens.lock().unwrap();
+        assert_eq!(*lens, vec![TRANSCRIPT_SUMMARY_MAX_BYTES]);
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -694,7 +694,11 @@ impl StrategyExecutor for DebateStrategyExecutor {
         // Refuted (critic's objection rejected) reads as the moderator
         // "approving" the proponent's claim; Conceded reads as a rejection
         // of it; anything never ruled on abstains rather than silently
-        // counting either way.
+        // counting either way. The ruling itself (refuted/conceded/
+        // unresolved) is spelled out in `reasoning` alongside the verdict —
+        // without it, e.g. `verdict=Approve` next to `reasoning` quoting the
+        // *attacking* claim reads backwards (as if the attack were being
+        // approved, not rejected).
         let mut votes: Vec<Vote> = ledger
             .all()
             .iter()
@@ -705,15 +709,15 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     .ruling_reason
                     .as_deref()
                     .unwrap_or("no ruling recorded");
-                let verdict = match objection.status {
-                    ObjectionStatus::Refuted => VoteVerdict::Approve,
-                    ObjectionStatus::Conceded => VoteVerdict::Reject,
-                    ObjectionStatus::Unresolved => VoteVerdict::Abstain,
+                let (verdict, ruling_label) = match objection.status {
+                    ObjectionStatus::Refuted => (VoteVerdict::Approve, "refuted"),
+                    ObjectionStatus::Conceded => (VoteVerdict::Reject, "conceded"),
+                    ObjectionStatus::Unresolved => (VoteVerdict::Abstain, "unresolved"),
                 };
                 Vote::new(
                     moderator.to_string(),
                     verdict,
-                    format!("[{id}] {claim}: {reason}"),
+                    format!("[{id}][{ruling_label}] {claim}: {reason}"),
                 )
             })
             .collect();
@@ -1557,7 +1561,7 @@ mod tests {
         assert!(payload.approved);
         assert_eq!(payload.votes.len(), 2);
         assert_eq!(payload.votes[0].verdict, VoteVerdict::Abstain);
-        assert!(payload.votes[0].reasoning.starts_with("[R1-1]"));
+        assert!(payload.votes[0].reasoning.starts_with("[R1-1][unresolved]"));
         assert!(
             payload.votes[0]
                 .reasoning

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -400,6 +400,13 @@ impl StrategyExecutor for DebateStrategyExecutor {
             for (claim, evidence, severity) in parse_opponent_rebuttals(&attack_text) {
                 ledger.add(round, claim, evidence, severity);
             }
+            // Captured before `attack_text` is moved into `transcript` below —
+            // used by the divergence check further down. Reading it back out
+            // of `transcript` by index would be wrong when round 1's opponent
+            // requested a decomposition: `query_opponent_attack_with_decomposition`
+            // pushes an intermediate "Proponent (round 1 decomposition)" entry,
+            // shifting the opponent's actual attack to a later index.
+            let first_round_attack_text = (round == 1).then(|| attack_text.clone());
             transcript.push((format!("Opponent (round {} attack)", round), attack_text));
 
             // Anti-mode-collapse divergence check (#316): only once, right after
@@ -415,7 +422,8 @@ impl StrategyExecutor for DebateStrategyExecutor {
             // if one exists, otherwise the opponent doubles up).
             if round == 1 && !contrarian_brief_used {
                 let opening_text = transcript[0].1.clone();
-                let first_attack_text = transcript[1].1.clone();
+                let first_attack_text = first_round_attack_text
+                    .expect("first_round_attack_text is always Some when round == 1");
                 let divergence_prompt = DebatePromptTemplate::divergence_check_prompt(
                     question,
                     &opening_text,
@@ -1117,6 +1125,73 @@ mod tests {
         assert_eq!(result.reviews.len(), 1);
         assert!(result.reviews[0].content.starts_with("CLAIM:"));
         assert_eq!(result.synthesis.conclusion, "Split the knobs.");
+    }
+
+    #[tokio::test]
+    async fn debate_divergence_check_compares_opening_against_opponent_attack_after_decomposition()
+     {
+        // Regression: when round 1's opponent attack triggers a decomposition
+        // detour, `query_opponent_attack_with_decomposition` pushes an
+        // intermediate "Proponent (round 1 decomposition)" entry into the
+        // transcript before the opponent's actual (post-decomposition) attack
+        // is pushed. The divergence check must compare the proponent's
+        // opening against that actual attack — not against the proponent's
+        // own decomposition response that now sits at transcript[1].
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Opening: caching and retry policy should share one config knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "DECOMPOSE_REQUEST: caching and retry policy should share one config knob",
+        );
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Sub-claim 1: caching should be a single knob.\nSub-claim 2: retry policy should be a single knob.",
+        );
+        gateway.respond(
+            Model::Gemini31Pro,
+            "CLAIM: retry policy as a single knob\nEVIDENCE: it hides per-endpoint backoff needs\nSEVERITY: MINOR",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "DIVERGENT: YES\n\nThey disagree on whether one knob suffices.",
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            "VERDICT: SETTLED\n\nSplit the knobs.",
+        );
+
+        let gateway = Arc::new(gateway);
+        DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::clone(&gateway) as Arc<dyn LlmGateway>,
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let moderator_prompts = gateway.sent_prompts(Model::ClaudeSonnet45);
+        let divergence_prompt = moderator_prompts
+            .first()
+            .expect("moderator should have been queried for the divergence check first");
+        assert!(
+            divergence_prompt.contains("CLAIM: retry policy as a single knob"),
+            "divergence check must see the opponent's actual (post-decomposition) attack: {}",
+            divergence_prompt
+        );
+        assert!(
+            !divergence_prompt.contains("Sub-claim 1: caching should be a single knob"),
+            "divergence check must not see the proponent's own decomposition response: {}",
+            divergence_prompt
+        );
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[tokio::test]
     async fn debate_divergence_check_compares_opening_against_opponent_attack_after_decomposition()
-     {
+    {
         // Regression: when round 1's opponent attack triggers a decomposition
         // detour, `query_opponent_attack_with_decomposition` pushes an
         // intermediate "Proponent (round 1 decomposition)" entry into the
@@ -1612,9 +1612,10 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
-        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
-            false
-        ]);
+        assert_eq!(
+            handler.can_continue_calls.lock().unwrap().as_slice(),
+            &[false]
+        );
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
     }
 
@@ -1637,9 +1638,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
-        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
-            true
-        ]);
+        assert_eq!(
+            handler.can_continue_calls.lock().unwrap().as_slice(),
+            &[true]
+        );
         assert!(
             result
                 .synthesis
@@ -1672,7 +1674,7 @@ mod tests {
 
     #[tokio::test]
     async fn debate_interactive_without_handler_falls_back_to_reject_at_non_final_round_continues()
-     {
+    {
         let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -193,6 +193,12 @@ impl DebateStrategyExecutor {
     /// final round) is reached while critical/major objections are still
     /// unresolved.
     ///
+    /// `can_continue` is `true` for a non-final round (a `Reject` decision
+    /// declines the premature settle and the debate continues) and `false`
+    /// at the final round (a `Reject` decision aborts the debate, since
+    /// there is no next round to continue to) — see the caller's match on
+    /// the returned `HumanDecision`.
+    ///
     /// This mirrors `RunAgentUseCase::handle_human_intervention`
     /// (`run_agent/hil.rs`) so the three `HilMode` branches behave
     /// consistently across use cases:
@@ -200,12 +206,14 @@ impl DebateStrategyExecutor {
     /// - `AutoApprove` — force the settlement through, loudly logged.
     /// - `Interactive` — defer to `HumanInterventionPort::request_debate_escalation`
     ///   if one is configured, otherwise fall back to `AutoReject`'s behavior.
+    #[allow(clippy::too_many_arguments)]
     async fn handle_debate_escalation(
         hil_mode: HilMode,
         human_intervention: Option<&Arc<dyn HumanInterventionPort>>,
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, RunQuorumError> {
         match hil_mode {
             HilMode::AutoReject => {
@@ -225,7 +233,12 @@ impl DebateStrategyExecutor {
             HilMode::Interactive => {
                 if let Some(intervention) = human_intervention {
                     intervention
-                        .request_debate_escalation(question, unresolved, transcript_summary)
+                        .request_debate_escalation(
+                            question,
+                            unresolved,
+                            transcript_summary,
+                            can_continue,
+                        )
                         .await
                         .map_err(|e| match e {
                             HumanInterventionError::Cancelled => RunQuorumError::Cancelled,
@@ -603,6 +616,7 @@ impl StrategyExecutor for DebateStrategyExecutor {
                     question,
                     &unresolved,
                     &Self::render_transcript(&transcript),
+                    !is_final_round,
                 )
                 .await?;
 
@@ -628,11 +642,24 @@ impl StrategyExecutor for DebateStrategyExecutor {
                         break;
                     }
                     HumanDecision::Reject | HumanDecision::Edit(_) => {
-                        return Err(RunQuorumError::DebateEscalationRejected(format!(
-                            "{} unresolved critical/major objection(s) at round {}",
-                            unresolved.len(),
-                            round
-                        )));
+                        if is_final_round {
+                            return Err(RunQuorumError::DebateEscalationRejected(format!(
+                                "{} unresolved critical/major objection(s) at round {}",
+                                unresolved.len(),
+                                round
+                            )));
+                        }
+                        // Non-final round: the natural response to a
+                        // premature settle attempt is to decline it and keep
+                        // debating, not to kill the whole run — fall through
+                        // to the same transcript note a normal
+                        // VERDICT: CONTINUE round would get, and proceed to
+                        // round + 1.
+                        info!(
+                            "Debate escalation declined at round {} — continuing rather than settling ({} unresolved critical/major objection(s))",
+                            round,
+                            unresolved.len()
+                        );
                     }
                 }
             }
@@ -733,10 +760,12 @@ mod tests {
     use std::sync::Mutex;
 
     /// Mock `HumanInterventionPort` that returns a pre-configured
-    /// (`request_debate_escalation`-only) outcome and counts invocations.
+    /// (`request_debate_escalation`-only) outcome and records each
+    /// invocation's `can_continue` flag (in call order) alongside the count.
     struct MockEscalationHandler {
         outcome: Result<HumanDecision, HumanInterventionError>,
         calls: Mutex<usize>,
+        can_continue_calls: Mutex<Vec<bool>>,
     }
 
     impl MockEscalationHandler {
@@ -744,6 +773,7 @@ mod tests {
             Self {
                 outcome,
                 calls: Mutex::new(0),
+                can_continue_calls: Mutex::new(Vec::new()),
             }
         }
     }
@@ -764,8 +794,10 @@ mod tests {
             _question: &str,
             _unresolved: &[Objection],
             _transcript_summary: &str,
+            can_continue: bool,
         ) -> Result<HumanDecision, HumanInterventionError> {
             *self.calls.lock().unwrap() += 1;
+            self.can_continue_calls.lock().unwrap().push(can_continue);
             self.outcome.clone()
         }
     }
@@ -817,7 +849,6 @@ mod tests {
 
     /// Builds a single `REBUTTAL_ID`/`RULING`/`REASON` block for use inside
     /// [`verdict_response`]'s `rulings` slice.
-    #[allow(dead_code)] // no target test in this file currently needs a ruling block
     fn ruling_block(id: &str, accepted: bool, reason: &str) -> String {
         format!(
             "REBUTTAL_ID: {}\nRULING: {}\nREASON: {}",
@@ -1322,6 +1353,9 @@ mod tests {
     /// Builds a common fixture: opponent raises one CRITICAL rebuttal and the
     /// moderator declares `SETTLED` in round 1 without ruling on it — i.e. the
     /// moderator tries to settle early while a critical objection is still open.
+    ///
+    /// Paired with `debate_config(_, 1)` this makes round 1 the *final*
+    /// round, so the escalation this triggers has `can_continue = false`.
     fn escalation_gateway() -> ScriptedGateway {
         let gateway = ScriptedGateway::new();
         gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
@@ -1341,9 +1375,37 @@ mod tests {
         gateway
     }
 
+    /// Same round-1 premature-settle setup as [`escalation_gateway`], but
+    /// paired with `debate_config(_, 2)` so round 1 is *not* final —
+    /// `can_continue = true`. Scripts a round 2 that resolves the R1-1
+    /// objection and settles cleanly, so tests can assert the debate
+    /// actually continues (rather than aborting) after the escalation is
+    /// declined in round 1.
+    fn escalation_continues_gateway() -> ScriptedGateway {
+        let gateway = escalation_gateway();
+        gateway.respond(
+            Model::Gpt53Codex,
+            "Defense round 2: adds a cache warmer to mitigate the TTL gap.",
+        );
+        gateway.respond(Model::Gemini31Pro, "No further rebuttal.");
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            verdict_response(
+                true,
+                &[ruling_block(
+                    "R1-1",
+                    false,
+                    "cache warmer mitigates the TTL gap",
+                )],
+                "Write-through wins with a cache warmer.",
+            ),
+        );
+        gateway
+    }
+
     #[tokio::test]
-    async fn debate_early_settle_with_unresolved_critical_objection_is_auto_rejected() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_early_settle_reject_at_final_round_aborts() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         // RunQuorumInput::new() defaults to HilMode::AutoReject.
         let input = base_input(OrchestrationStrategy::Debate(config));
 
@@ -1359,6 +1421,35 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_early_settle_reject_at_non_final_round_continues_debate() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        // RunQuorumInput::new() defaults to HilMode::AutoReject — but at a
+        // non-final round that now means "decline the early settle and keep
+        // debating", not "abort".
+        let input = base_input(OrchestrationStrategy::Debate(config));
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
     }
 
     #[tokio::test]
@@ -1433,8 +1524,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn debate_interactive_escalation_reject_aborts_execute() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_interactive_escalation_reject_at_final_round_aborts_execute() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
         let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Reject)));
@@ -1451,12 +1542,47 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
+            false
+        ]);
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
     }
 
     #[tokio::test]
-    async fn debate_interactive_without_handler_falls_back_to_reject() {
-        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 3);
+    async fn debate_interactive_escalation_reject_at_non_final_round_continues_debate() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+        let handler = Arc::new(MockEscalationHandler::new(Ok(HumanDecision::Reject)));
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                Some(handler.clone() as Arc<dyn HumanInterventionPort>),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(*handler.calls.lock().unwrap(), 1);
+        assert_eq!(handler.can_continue_calls.lock().unwrap().as_slice(), &[
+            true
+        ]);
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_without_handler_falls_back_to_reject_at_final_round() {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 1);
         let input =
             base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
 
@@ -1472,6 +1598,34 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, RunQuorumError::DebateEscalationRejected(_)));
+    }
+
+    #[tokio::test]
+    async fn debate_interactive_without_handler_falls_back_to_reject_at_non_final_round_continues()
+     {
+        let config = debate_config(vec![Model::Gpt53Codex, Model::Gemini31Pro], 2);
+        let input =
+            base_input(OrchestrationStrategy::Debate(config)).with_hil_mode(HilMode::Interactive);
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(escalation_continues_gateway()),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result
+                .synthesis
+                .conclusion
+                .contains("Write-through wins with a cache warmer."),
+            "unexpected conclusion: {}",
+            result.synthesis.conclusion
+        );
     }
 
     #[tokio::test]

--- a/application/src/use_cases/run_quorum/test_support.rs
+++ b/application/src/use_cases/run_quorum/test_support.rs
@@ -15,6 +15,9 @@ use std::sync::{Arc, Mutex};
 #[derive(Default)]
 pub(super) struct ScriptedGateway {
     responses: Arc<Mutex<HashMap<Model, VecDeque<String>>>>,
+    /// Every prompt passed to `send()`, in call order, regardless of model —
+    /// lets tests assert on the exact content a caller constructed.
+    sent: Arc<Mutex<Vec<(Model, String)>>>,
 }
 
 impl ScriptedGateway {
@@ -31,11 +34,23 @@ impl ScriptedGateway {
             .or_default()
             .push_back(text.into());
     }
+
+    /// All prompts sent to `model` via `send()`, in call order.
+    pub(super) fn sent_prompts(&self, model: Model) -> Vec<String> {
+        self.sent
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(m, _)| *m == model)
+            .map(|(_, prompt)| prompt.clone())
+            .collect()
+    }
 }
 
 struct ScriptedSession {
     model: Model,
     responses: Arc<Mutex<HashMap<Model, VecDeque<String>>>>,
+    sent: Arc<Mutex<Vec<(Model, String)>>>,
 }
 
 #[async_trait]
@@ -44,7 +59,11 @@ impl LlmSession for ScriptedSession {
         &self.model
     }
 
-    async fn send(&self, _content: &str) -> Result<String, GatewayError> {
+    async fn send(&self, content: &str) -> Result<String, GatewayError> {
+        self.sent
+            .lock()
+            .unwrap()
+            .push((self.model.clone(), content.to_string()));
         self.responses
             .lock()
             .unwrap()
@@ -62,6 +81,7 @@ impl LlmGateway for ScriptedGateway {
         Ok(Box::new(ScriptedSession {
             model: model.clone(),
             responses: Arc::clone(&self.responses),
+            sent: Arc::clone(&self.sent),
         }))
     }
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,6 +48,16 @@ Lua からの変更は runtime でエージェントに伝播します。
 3 軸（consensus_level / phase_scope / strategy）の意味と組み合わせ制約は
 [Orchestration Axes](../explanation/orchestration-axes.md) を参照してください。
 
+`agent.hil_mode` は Plan Review の人間介入だけでなく、`agent.strategy = "debate"`
+（Debate 戦略）のエスカレーションにも効きます。moderator が critical/major な
+反論が未解決のまま settle しようとするたびに（最終ラウンドに限らず、途中の
+settle チェックポイントでも）このモードでゲートされます: `auto_reject` は
+最終ラウンドでは討議を中止しますが、途中ラウンドでは settle を却下して
+討議を続行します（討議自体を止めるのではなく、未解決のまま決着させないための
+fail-secure）。`auto_approve` は未解決のまま強制的に settle し、`interactive`
+は `HumanInterventionPort::request_debate_escalation` 経由で都度ユーザーに
+判断を委ねます。
+
 ### `models.*` — ロール別モデル設定
 
 | キー | 型 | 用途 |

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -175,16 +175,34 @@ plan/action/final review では省略される）:
    "key_points":[],"consensus":[],"disagreements":[]}}
 ```
 
+`debate`（`agent.strategy = "debate"`、敵対的パネル v2 #316）は `target` を
+持たず、`pr_review` と同様に `synthesis` を含む。`votes` は反論台帳
+（`ObjectionLedger`）の各エントリ1件につき1票（`reasoning` は
+`[REBUTTAL_ID][refuted|conceded|unresolved] claim: reason` 形式）に加え、
+討議全体の最終裁定を表す closing vote が末尾に1件付く:
+
+```json
+{"type":"quorum_result","timestamp":"2026-07-04T10:30:00.123Z",
+ "api_version":1,"topic":"debate",
+ "approved":true,"rule":"majority",
+ "votes":[
+   {"model":"claude-opus-4.5","verdict":"approve","reasoning":"[R1-1][refuted] cache never expires: TTL config is finite","confidence":null},
+   {"model":"claude-opus-4.5","verdict":"approve","reasoning":"Write-through wins.","confidence":null}
+ ],
+ "synthesis":{"moderator":"claude-opus-4.5","conclusion":"Write-through wins.",
+   "key_points":[],"consensus":[],"disagreements":[]}}
+```
+
 | フィールド | 型 | 説明 |
 |-----------|------|------|
 | `api_version` | int | エンベロープのスキーマバージョン（現在 1） |
-| `topic` | string | `plan_review` / `action_review` / `final_review` / `pr_review` |
-| `target` | object? | topic 依存の対象識別（action_review: `task_id`, `tool`。pr_review: `pr`, `title`）。なければ省略 |
+| `topic` | string | `plan_review` / `action_review` / `final_review` / `pr_review` / `debate` |
+| `target` | object? | topic 依存の対象識別（action_review: `task_id`, `tool`。pr_review: `pr`, `title`。debate では省略）。なければ省略 |
 | `approved` | bool | 投票の集計結果 |
 | `rule` | string | 集計ルール（現在は `majority` 固定） |
 | `votes[].verdict` | string | `approve` / `reject` / `abstain` / `model_error` |
 | `feedback` | string? | 否決時の rejection feedback 集約。承認時は省略 |
-| `synthesis` | object? | moderator による統合レビュー（pr_review のみ。`moderator`, `conclusion`, `key_points`, `consensus`, `disagreements`） |
+| `synthesis` | object? | moderator による統合レビュー（pr_review / debate のみ。`moderator`, `conclusion`, `key_points`, `consensus`, `disagreements`） |
 
 **注**: `pr_review` を JSONL に発行する `RunReviewUseCase` は `target` を持たずに publish する
 （review 対象の PR 番号/タイトルは呼び出し元の CLI 層のみが知っている一時情報のため）。

--- a/docs/reference/scripting.md
+++ b/docs/reference/scripting.md
@@ -105,6 +105,9 @@ Vim/Neovim のプラグインエコシステムに倣い、段階的に構築さ
 `QuorumResult` は `EventPublisher` 継ぎ目経由で配信される（progress bridge 経由ではない）。
 `task_id` / `tool` は action_review の相関情報（他 topic では nil）、`feedback` は否決時のみ。
 `votes_json` は `quorum_result` v1 契約の votes 配列（[Logging](logging.md) 参照）。
+`topic` は `plan_review` / `action_review` / `final_review` / `pr_review` に加え、
+Debate 戦略（`agent.strategy = "debate"`、敵対的パネル v2 #316）の最終裁定を表す
+`debate` を取り得る。
 
 ### ToolCallBefore キャンセルフロー
 

--- a/domain/src/prompt/debate.rs
+++ b/domain/src/prompt/debate.rs
@@ -256,45 +256,11 @@ Finally, exactly one of:
   rebuttal — that the next round should focus on>"#
     }
 
-    /// Per-round checkpoint prompt for the moderator.
-    ///
-    /// When `is_final_round` is `true`, the moderator is instructed to settle
-    /// regardless of remaining disagreement — `max_rounds` is a hard cap.
-    pub fn moderator_checkpoint_prompt(
-        question: &str,
-        transcript: &str,
-        round: usize,
-        max_rounds: usize,
-        is_final_round: bool,
-    ) -> String {
-        let final_notice = if is_final_round {
-            "\nThis is the final allowed round. You MUST respond with VERDICT: SETTLED \
-             and produce your rulings and the best conclusion possible from the debate \
-             so far, even if disagreement remains."
-        } else {
-            ""
-        };
-        format!(
-            r#"Question under debate:
-
-{}
-
-Debate so far (round {} of {}):
-
-{}
-
-Has the debate settled? Rule on each rebuttal raised so far, per your instructions.{}"#,
-            question, round, max_rounds, transcript, final_notice
-        )
-    }
-
     /// Per-round checkpoint prompt for the moderator, with the still-open
     /// objections (from an [`ObjectionLedger`](crate::quorum::ObjectionLedger))
     /// explicitly enumerated by ID and claim.
     ///
-    /// This is the `ObjectionLedger`-aware counterpart to
-    /// [`moderator_checkpoint_prompt`](Self::moderator_checkpoint_prompt):
-    /// instead of asking the moderator to re-derive rebuttal identity from
+    /// Instead of asking the moderator to re-derive rebuttal identity from
     /// prose, it hands over the exact `REBUTTAL_ID`s the moderator must rule
     /// on and echo back, so [`parse_moderator_rulings`](crate::quorum::parsing::parse_moderator_rulings)
     /// can match rulings to ledger entries by exact ID.
@@ -460,20 +426,6 @@ mod tests {
             "--- Proponent ---\nUse REST for simplicity.",
         );
         assert!(prompt.contains("Use REST for simplicity."));
-    }
-
-    #[test]
-    fn test_moderator_checkpoint_final_round_forces_settle() {
-        let prompt =
-            DebatePromptTemplate::moderator_checkpoint_prompt("Q", "transcript", 3, 3, true);
-        assert!(prompt.contains("MUST respond with VERDICT: SETTLED"));
-    }
-
-    #[test]
-    fn test_moderator_checkpoint_non_final_round_allows_continue() {
-        let prompt =
-            DebatePromptTemplate::moderator_checkpoint_prompt("Q", "transcript", 1, 3, false);
-        assert!(!prompt.contains("MUST respond with VERDICT: SETTLED"));
     }
 
     #[test]

--- a/domain/src/quorum/objection.rs
+++ b/domain/src/quorum/objection.rs
@@ -114,17 +114,28 @@ impl ObjectionLedger {
     /// Apply the moderator's ruling to an objection by ID.
     ///
     /// `ruling: true` means the objection was conceded (upheld);
-    /// `ruling: false` means it was refuted (rejected). No-op if the ID
-    /// is not found.
-    pub fn apply_ruling(&mut self, id: &str, ruling: bool, reason: impl Into<String>) {
-        if let Some(objection) = self.objections.iter_mut().find(|o| o.id == id) {
-            objection.status = if ruling {
-                ObjectionStatus::Conceded
-            } else {
-                ObjectionStatus::Refuted
-            };
-            objection.ruling_reason = Some(reason.into());
+    /// `ruling: false` means it was refuted (rejected).
+    ///
+    /// Only applies when the objection is still `Unresolved` — a later
+    /// round's moderator re-ruling on the same `REBUTTAL_ID` does not
+    /// silently overwrite an already-`Conceded`/`Refuted` verdict from an
+    /// earlier round. Returns `true` if the ruling was applied, `false` if
+    /// the ID was not found or the objection was already resolved (the
+    /// caller may want to log a warning on `false`).
+    pub fn apply_ruling(&mut self, id: &str, ruling: bool, reason: impl Into<String>) -> bool {
+        let Some(objection) = self.objections.iter_mut().find(|o| o.id == id) else {
+            return false;
+        };
+        if objection.status != ObjectionStatus::Unresolved {
+            return false;
         }
+        objection.status = if ruling {
+            ObjectionStatus::Conceded
+        } else {
+            ObjectionStatus::Refuted
+        };
+        objection.ruling_reason = Some(reason.into());
+        true
     }
 
     /// All objections in the ledger, in insertion order.
@@ -192,7 +203,7 @@ mod tests {
     fn apply_ruling_conceded() {
         let mut ledger = ObjectionLedger::new();
         let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
-        ledger.apply_ruling(&id, true, "critic's evidence is solid");
+        assert!(ledger.apply_ruling(&id, true, "critic's evidence is solid"));
 
         let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
         assert_eq!(objection.status, ObjectionStatus::Conceded);
@@ -206,7 +217,7 @@ mod tests {
     fn apply_ruling_refuted() {
         let mut ledger = ObjectionLedger::new();
         let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Minor);
-        ledger.apply_ruling(&id, false, "already addressed in round 1");
+        assert!(ledger.apply_ruling(&id, false, "already addressed in round 1"));
 
         let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
         assert_eq!(objection.status, ObjectionStatus::Refuted);
@@ -216,10 +227,30 @@ mod tests {
     fn apply_ruling_unknown_id_is_noop() {
         let mut ledger = ObjectionLedger::new();
         ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
-        ledger.apply_ruling("R99-1", true, "does not exist");
+        assert!(!ledger.apply_ruling("R99-1", true, "does not exist"));
 
         // Original objection remains unresolved; nothing panics.
         assert_eq!(ledger.open_objections().len(), 1);
+    }
+
+    #[test]
+    fn apply_ruling_already_resolved_is_ignored() {
+        // A later round's moderator re-mentioning the same REBUTTAL_ID must
+        // not silently overwrite an already-decided ruling.
+        let mut ledger = ObjectionLedger::new();
+        let id = ledger.add(1, "claim", "evidence", ObjectionSeverity::Major);
+        assert!(ledger.apply_ruling(&id, false, "refuted in round 1"));
+
+        // A conflicting re-ruling on the same ID is rejected...
+        assert!(!ledger.apply_ruling(&id, true, "conceded in round 2 — should not stick"));
+
+        // ...and the original ruling is untouched.
+        let objection = ledger.all().iter().find(|o| o.id == id).unwrap();
+        assert_eq!(objection.status, ObjectionStatus::Refuted);
+        assert_eq!(
+            objection.ruling_reason.as_deref(),
+            Some("refuted in round 1")
+        );
     }
 
     #[test]

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -19,6 +19,27 @@
 
 use super::objection::ObjectionSeverity;
 
+/// Check whether `line` (after trimming leading whitespace) starts with
+/// `label`, case-insensitively, and return the trimmed rest if so.
+///
+/// Compares as byte slices (`[u8]::eq_ignore_ascii_case`) rather than
+/// slicing `&str` by byte length: `label` is always ASCII, but `line` may
+/// not be (e.g. CJK text before a label appears, or in the label's value).
+/// Slicing a `&str` at an arbitrary byte offset panics if that offset falls
+/// inside a multi-byte character; comparing raw bytes via `.get(..n)` never
+/// panics, and a successful case-insensitive match against an all-ASCII
+/// label guarantees every matched byte is itself ASCII — so the following
+/// `&trimmed[label.len()..]` slice always lands on a valid char boundary.
+fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    let trimmed = line.trim_start();
+    let prefix = trimmed.as_bytes().get(..label.len())?;
+    if prefix.eq_ignore_ascii_case(label.as_bytes()) {
+        Some(trimmed[label.len()..].trim_start())
+    } else {
+        None
+    }
+}
+
 /// Parse a review response to extract approval status and feedback.
 ///
 /// Checks for explicit APPROVE/REJECT keywords in the response text.
@@ -272,15 +293,6 @@ pub fn parse_opponent_rebuttals(text: &str) -> Vec<(String, String, ObjectionSev
         }
     }
 
-    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
-            Some(trimmed[label.len()..].trim_start())
-        } else {
-            None
-        }
-    }
-
     let mut results = Vec::new();
     let mut claim: Option<String> = None;
     let mut evidence: Option<String> = None;
@@ -396,15 +408,6 @@ pub fn parse_moderator_rulings(text: &str) -> Vec<(String, bool, String)> {
         RebuttalId,
         Ruling,
         Reason,
-    }
-
-    fn label_rest<'a>(line: &'a str, label: &str) -> Option<&'a str> {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= label.len() && trimmed[..label.len()].eq_ignore_ascii_case(label) {
-            Some(trimmed[label.len()..].trim_start())
-        } else {
-            None
-        }
     }
 
     fn ruling_accepted(value: &str) -> bool {
@@ -563,9 +566,8 @@ pub fn parse_decomposition_request(text: &str) -> Option<String> {
     const NEAR_TOP_LINES: usize = 5;
 
     for line in text.lines().take(NEAR_TOP_LINES) {
-        let trimmed = line.trim_start();
-        if trimmed.len() >= LABEL.len() && trimmed[..LABEL.len()].eq_ignore_ascii_case(LABEL) {
-            let target = trimmed[LABEL.len()..].trim().to_string();
+        if let Some(rest) = label_rest(line, LABEL) {
+            let target = rest.trim().to_string();
             if !target.is_empty() {
                 return Some(target);
             }
@@ -862,6 +864,31 @@ SEVERITY: CRITICAL";
         assert_eq!(rebuttals[0].2, ObjectionSeverity::Minor);
     }
 
+    #[test]
+    fn test_opponent_rebuttals_multibyte_line_before_label_does_not_panic() {
+        // Regression: a non-ASCII line preceding a label used to panic when
+        // slicing `trimmed[..label.len()]` landed mid-character (e.g. inside
+        // 'こ') instead of returning "no match" for the byte comparison.
+        let text = "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].0, "キャッシュは無効");
+        assert_eq!(rebuttals[0].1, "根拠あり");
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Major);
+    }
+
+    #[test]
+    fn test_opponent_rebuttals_emoji_line_before_label_does_not_panic() {
+        // Same class of bug, exercised with a 4-byte emoji character instead
+        // of a 3-byte CJK one.
+        let text = "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
+        let rebuttals = parse_opponent_rebuttals(text);
+        assert_eq!(rebuttals.len(), 1);
+        assert_eq!(rebuttals[0].0, "🎉 emoji claim");
+        assert_eq!(rebuttals[0].1, "🎉 emoji evidence");
+        assert_eq!(rebuttals[0].2, ObjectionSeverity::Critical);
+    }
+
     // ==================== parse_moderator_rulings Tests ====================
 
     #[test]
@@ -936,6 +963,17 @@ REASON: second";
         assert_eq!(rulings.len(), 2);
         assert_eq!(rulings[0].0, "R1-1");
         assert_eq!(rulings[1].0, "R1-10");
+    }
+
+    #[test]
+    fn test_moderator_rulings_multibyte_line_before_label_does_not_panic() {
+        // Regression: see test_opponent_rebuttals_multibyte_line_before_label_does_not_panic.
+        let text = "→ 裁定は以下の通り\nREBUTTAL_ID: R1-1\nRULING: ACCEPTED\nREASON: 妥当";
+        let rulings = parse_moderator_rulings(text);
+        assert_eq!(rulings.len(), 1);
+        assert_eq!(rulings[0].0, "R1-1");
+        assert!(rulings[0].1);
+        assert_eq!(rulings[0].2, "妥当");
     }
 
     // ==================== parse_divergence_check Tests ====================
@@ -1020,5 +1058,15 @@ REASON: second";
     #[test]
     fn test_decomposition_request_empty_target_returns_none() {
         assert_eq!(parse_decomposition_request("DECOMPOSE_REQUEST:   "), None);
+    }
+
+    #[test]
+    fn test_decomposition_request_multibyte_line_before_label_does_not_panic() {
+        // Regression: see test_opponent_rebuttals_multibyte_line_before_label_does_not_panic.
+        let text = "a主張の分解を要求します\nDECOMPOSE_REQUEST: この複合主張";
+        assert_eq!(
+            parse_decomposition_request(text),
+            Some("この複合主張".to_string())
+        );
     }
 }

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -486,10 +486,13 @@ pub fn parse_moderator_rulings(text: &str) -> Vec<(String, bool, String)> {
 /// `DIVERGENT: YES` or `DIVERGENT: NO` line, followed by either the shared
 /// premise (if not divergent) or a note on what diverges (if divergent).
 ///
-/// Conservative: if the first line doesn't clearly declare `DIVERGENT: YES`,
-/// this returns `divergent = false` — an ambiguous or malformed response is
-/// treated as "no divergence detected" rather than triggering a possibly
-/// unwarranted decomposition.
+/// Conservative: if the first line doesn't clearly declare `DIVERGENT: NO`,
+/// this returns `divergent = true` — the caller only takes action (running
+/// the extra contrarian-brief LLM call, and folding the raw response text
+/// into the prompt as a "shared premise") when it reads `divergent = false`.
+/// An ambiguous or malformed response should not silently trigger that
+/// extra work just because the moderator ignored the format; "no action"
+/// is the safe default here, not "divergence detected".
 ///
 /// # Returns
 ///
@@ -519,7 +522,7 @@ pub fn parse_divergence_check(text: &str) -> (bool, String) {
     let first_upper = first_line.to_uppercase();
 
     if !first_upper.contains("DIVERGENT") {
-        return (false, text.trim().to_string());
+        return (true, text.trim().to_string());
     }
 
     let divergent = first_upper.contains("YES") && !first_upper.contains("NO");
@@ -1002,9 +1005,11 @@ REASON: second";
     }
 
     #[test]
-    fn test_divergence_check_missing_format_defaults_to_not_divergent() {
+    fn test_divergence_check_missing_format_defaults_to_divergent() {
+        // Fail-secure: an unparseable response must not silently trigger the
+        // contrarian-brief detour (see doc comment on parse_divergence_check).
         let (divergent, note) = parse_divergence_check("The two sides seem to agree overall.");
-        assert!(!divergent);
+        assert!(divergent);
         assert_eq!(note, "The two sides seem to agree overall.");
     }
 

--- a/domain/src/quorum/parsing.rs
+++ b/domain/src/quorum/parsing.rs
@@ -872,7 +872,8 @@ SEVERITY: CRITICAL";
         // Regression: a non-ASCII line preceding a label used to panic when
         // slicing `trimmed[..label.len()]` landed mid-character (e.g. inside
         // 'こ') instead of returning "no match" for the byte comparison.
-        let text = "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
+        let text =
+            "→ この主張は誤りです\nCLAIM: キャッシュは無効\nEVIDENCE: 根拠あり\nSEVERITY: MAJOR";
         let rebuttals = parse_opponent_rebuttals(text);
         assert_eq!(rebuttals.len(), 1);
         assert_eq!(rebuttals[0].0, "キャッシュは無効");
@@ -884,7 +885,8 @@ SEVERITY: CRITICAL";
     fn test_opponent_rebuttals_emoji_line_before_label_does_not_panic() {
         // Same class of bug, exercised with a 4-byte emoji character instead
         // of a 3-byte CJK one.
-        let text = "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
+        let text =
+            "🎉 disagree\nCLAIM: 🎉 emoji claim\nEVIDENCE: 🎉 emoji evidence\nSEVERITY: CRITICAL";
         let rebuttals = parse_opponent_rebuttals(text);
         assert_eq!(rebuttals.len(), 1);
         assert_eq!(rebuttals[0].0, "🎉 emoji claim");

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -45,10 +45,14 @@
 //! | `/edit` | `edit`, `e` | Edit plan (not yet implemented) |
 //!
 //! The same handler also implements `request_debate_escalation` for the
-//! Debate strategy's round-limit escalation: it shows the question, the
-//! remaining unresolved objections (claim/evidence/severity), and a
-//! transcript summary, then accepts `/approve` (force a decision) or
-//! `/reject` (abort the debate).
+//! Debate strategy's settle-checkpoint escalation (triggered whenever the
+//! moderator tries to settle with unresolved critical/major objections —
+//! not only at the round limit): it shows the question, the remaining
+//! unresolved objections (claim/evidence/severity), and a transcript
+//! summary, then accepts `/approve` (force a decision) or `/reject`. What
+//! `/reject` does depends on whether a next round exists: it declines the
+//! early settle and continues the debate in a non-final round, or aborts
+//! the debate entirely at the final round.
 
 use async_trait::async_trait;
 use colored::Colorize;
@@ -174,6 +178,7 @@ impl InteractiveHumanIntervention {
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) {
         println!();
         println!(
@@ -191,10 +196,17 @@ impl InteractiveHumanIntervention {
         );
         println!();
 
-        println!(
-            "The debate reached its round limit with {} unresolved objection(s).",
-            unresolved.len()
-        );
+        if can_continue {
+            println!(
+                "The moderator wants to settle early with {} unresolved objection(s) still open.",
+                unresolved.len()
+            );
+        } else {
+            println!(
+                "The debate reached its round limit with {} unresolved objection(s).",
+                unresolved.len()
+            );
+        }
         println!();
 
         // Show original question
@@ -238,7 +250,14 @@ impl InteractiveHumanIntervention {
             "  {}  - Force a decision, proceeding despite unresolved objections",
             "/approve".green()
         );
-        println!("  {}   - Abort the debate", "/reject".red());
+        if can_continue {
+            println!(
+                "  {}   - Decline the early settle, continue the debate to the next round",
+                "/reject".red()
+            );
+        } else {
+            println!("  {}   - Abort the debate", "/reject".red());
+        }
         println!();
     }
 
@@ -385,8 +404,9 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
         question: &str,
         unresolved: &[quorum_domain::quorum::Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
-        self.display_debate_escalation_prompt(question, unresolved, transcript_summary);
+        self.display_debate_escalation_prompt(question, unresolved, transcript_summary, can_continue);
 
         loop {
             let input = self.read_command()?;
@@ -402,7 +422,11 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
                 }
                 "/reject" | "reject" | "r" | "q" => {
                     println!();
-                    println!("{}", "✗ Debate aborted by human".red());
+                    if can_continue {
+                        println!("{}", "✗ Early settle declined — debate continues".red());
+                    } else {
+                        println!("{}", "✗ Debate aborted by human".red());
+                    }
                     return Ok(HumanDecision::Reject);
                 }
                 "" => continue,

--- a/presentation/src/agent/human_intervention.rs
+++ b/presentation/src/agent/human_intervention.rs
@@ -406,7 +406,12 @@ impl HumanInterventionPort for InteractiveHumanIntervention {
         transcript_summary: &str,
         can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
-        self.display_debate_escalation_prompt(question, unresolved, transcript_summary, can_continue);
+        self.display_debate_escalation_prompt(
+            question,
+            unresolved,
+            transcript_summary,
+            can_continue,
+        );
 
         loop {
             let input = self.read_command()?;

--- a/presentation/src/tui/app_hil.rs
+++ b/presentation/src/tui/app_hil.rs
@@ -40,6 +40,7 @@ pub(super) fn handle_hil_request(
             question,
             unresolved,
             transcript_summary,
+            can_continue,
         } => (
             "Debate Requires Human Ruling".to_string(),
             question.clone(),
@@ -54,11 +55,19 @@ pub(super) fn handle_hil_request(
                     format!("[{}] ({}) {}", o.id, severity, o.claim)
                 })
                 .collect(),
-            format!(
-                "{} unresolved objection(s). {} Approve to force a decision, reject to abort.",
-                unresolved.len(),
-                transcript_summary
-            ),
+            if *can_continue {
+                format!(
+                    "{} unresolved objection(s). Moderator wants to settle early. {} Approve to force a decision, reject to continue the debate.",
+                    unresolved.len(),
+                    transcript_summary
+                )
+            } else {
+                format!(
+                    "{} unresolved objection(s) at the round limit. {} Approve to force a decision, reject to abort.",
+                    unresolved.len(),
+                    transcript_summary
+                )
+            },
         ),
     };
 
@@ -151,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_hil_request_builds_prompt_for_debate_escalation() {
+    fn handle_hil_request_builds_prompt_for_debate_escalation_at_final_round() {
         let mut state = TuiState::new();
         let (response_tx, _response_rx) = oneshot::channel();
         let pending_hil_tx = Arc::new(Mutex::new(None));
@@ -161,6 +170,7 @@ mod tests {
                 question: "Should we ship the migration?".to_string(),
                 unresolved: vec![sample_objection()],
                 transcript_summary: "3 rounds, 1 objection remains".to_string(),
+                can_continue: false,
             },
             response_tx,
         };
@@ -174,7 +184,33 @@ mod tests {
         assert!(prompt.tasks[0].contains("MAJOR"));
         assert!(prompt.tasks[0].contains("The plan ignores concurrent writes"));
         assert!(prompt.message.contains("1 unresolved objection"));
+        assert!(prompt.message.contains("round limit"));
+        assert!(prompt.message.contains("reject to abort"));
         assert!(prompt.message.contains("3 rounds, 1 objection remains"));
+        assert!(pending_hil_tx.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn handle_hil_request_builds_prompt_for_debate_escalation_at_early_settle() {
+        let mut state = TuiState::new();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let pending_hil_tx = Arc::new(Mutex::new(None));
+
+        let request = HilRequest {
+            kind: HilKind::DebateEscalation {
+                question: "Should we ship the migration?".to_string(),
+                unresolved: vec![sample_objection()],
+                transcript_summary: "1 round, 1 objection remains".to_string(),
+                can_continue: true,
+            },
+            response_tx,
+        };
+
+        handle_hil_request(&mut state, &pending_hil_tx, request);
+
+        let prompt = state.hil_prompt.expect("hil_prompt should be set");
+        assert!(prompt.message.contains("settle early"));
+        assert!(prompt.message.contains("reject to continue the debate"));
         assert!(pending_hil_tx.lock().unwrap().is_some());
     }
 

--- a/presentation/src/tui/event.rs
+++ b/presentation/src/tui/event.rs
@@ -225,13 +225,18 @@ pub enum HilKind {
         request: String,
         plan: Plan,
     },
-    /// Debate strategy round-limit escalation — unresolved objections remain
-    /// after the moderator ran out of checkpoint rounds (see
-    /// `HumanInterventionPort::request_debate_escalation`).
+    /// Debate strategy settle-checkpoint escalation — the moderator tried to
+    /// settle while critical/major objections remain unresolved (see
+    /// `HumanInterventionPort::request_debate_escalation`). Fires at every
+    /// such checkpoint, not only the final round.
     DebateEscalation {
         question: String,
         unresolved: Vec<Objection>,
         transcript_summary: String,
+        /// `true` when this is a non-final round: rejecting declines the
+        /// early settle and continues the debate. `false` at the final
+        /// round: rejecting aborts the debate entirely.
+        can_continue: bool,
     },
 }
 

--- a/presentation/src/tui/human_intervention.rs
+++ b/presentation/src/tui/human_intervention.rs
@@ -83,6 +83,7 @@ impl HumanInterventionPort for TuiHumanIntervention {
         question: &str,
         unresolved: &[Objection],
         transcript_summary: &str,
+        can_continue: bool,
     ) -> Result<HumanDecision, HumanInterventionError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -91,6 +92,7 @@ impl HumanInterventionPort for TuiHumanIntervention {
                 question: question.to_string(),
                 unresolved: unresolved.to_vec(),
                 transcript_summary: transcript_summary.to_string(),
+                can_continue,
             },
             response_tx,
         };


### PR DESCRIPTION
## 概要

PR #319（敵対的パネル v2、#316 対応）のレビューで見つかった不具合の修正。ベースは `feat/316-adversarial-panel-v2`（PR #319 の head）。

## 指摘対応

### ① [High] パーサーが多バイト文字でパニック
`parse_opponent_rebuttals` / `parse_moderator_rulings` / `parse_decomposition_request` の `label_rest` が `trimmed[..label.len()]` とバイト境界を確認せずスライスしており、行頭が多バイト文字だと panic していた。バイト列比較（`as_bytes().get(..) + eq_ignore_ascii_case`）に統一し、重複していた `label_rest` をモジュールレベルの1関数に統合。レビューで実証された3入力（日本語・絵文字）を回帰テストとして追加。

### ② [Medium] 発散チェックが分解発動時に誤ったペアを比較
round 1 で `DECOMPOSE_REQUEST` が発動すると、opponent の実際の攻撃より先に proponent の分解回答が transcript に push されるため、`transcript[1]` を直接参照する発散チェックは opening と proponent 自身の文章を比較していた。`attack_text` が transcript に push される前の値を直接渡すよう修正。`ScriptedGateway` にプロンプト記録機能を追加し、分解発動時でも opening と opponent の実際の攻撃を比較することを検証する回帰テストを追加。

### ③ [Medium] 発散チェックの保守的デフォルトが逆向き
`parse_divergence_check` は不正形式の応答を `divergent = false` に倒していたが、呼び出し側は `if !divergent` で天邪鬼ブリーフ（追加LLM呼び出し + 応答全文のプロンプト混入）を発動するため、モデレーターがフォーマットを無視しただけで介入パスが発動してしまっていた。デフォルトを `divergent = true`（＝何もしない）に反転し、doc コメントの誤記述も修正。

### ④ [Medium] エスカレーションの文言の嘘と Reject の破壊的すぎる意味論
エスカレーションは全 settle チェックポイントで発動する設計なのに、CLI/TUI は常に「ラウンド上限に到達」と表示し、非最終ラウンドで Reject すると討議全体が即死していた。
- 非最終ラウンドの Reject/Edit は settle を却下し討議を続行するよう変更（最終ラウンドの Reject のみ従来どおり中止）
- `HumanInterventionPort::request_debate_escalation` と `HilKind::DebateEscalation` に `can_continue: bool` を追加し、CLI/TUI の文言を実態に合わせて分岐
- `AutoReject` も非最終ラウンドでは続行に倒し、最終ラウンドのみ Err（fail-secure の趣旨は「未解決のまま決着させない」ことであって「討議を殺す」ことではないため）
- escalation 系テストを両分岐（非最終=続行・最終=中止）に更新・追加

### ⑤ [Medium] transcript_summary が summary ではなく全文
`render_transcript` のフル transcript をそのままエスカレーションに渡していたため、TUI モーダルが崩れ CLI も全文 dump になっていた。`truncate_head_tail`（UTF-8 セーフな head/tail 切り詰め）で `TRANSCRIPT_SUMMARY_MAX_BYTES`（2000 バイト）に切り詰めてから渡すよう修正。port の doc も実態に合わせて更新。

### Low（ついでに直した）
- 未使用の `moderator_checkpoint_prompt`（`moderator_checkpoint_prompt_with_objections` に置き換わり済み）をテストごと削除
- `Vote` の `reasoning` に裁定種別（`[R1-1][refuted]` 等）を明示し、verdict との対応を読み違えにくくした
- `ObjectionLedger::apply_ruling` が確定済み（Conceded/Refuted）の裁定を無言で上書きできる問題を修正。`Unresolved` のみ受け付け、適用可否を bool で返すように変更

### ドキュメント
- `agent.hil_mode` が Debate 戦略のエスカレーション（全 settle チェックポイント）にも効く旨を追記
- `quorum_result` の `topic` に `debate` が追加された旨を `logging.md` / `scripting.md` に追記

## テスト
- `cargo build --workspace`
- `cargo test --workspace`（全 crate green）
- `cargo clippy --workspace --all-targets`（新規警告なし）
- `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)