### PR TITLE
feat(config): Debate 戦略のロースター/パラメータを設定可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,7 @@ User config via `~/.config/copilot-quorum/init.lua`, loaded at startup. Feature-
 
 **Config Key Sections** (all mutable at runtime):
 - `agent.*` — consensus_level, phase_scope, strategy, hil_mode, max_plan_revisions
+- `debate.*` — models, max_rounds, intensity, allow_interjection（Debate 戦略のロースター/パラメータ。`QuorumConfig` が `DebateConfig` を独立保持するため `agent.strategy` の quorum⇔debate 往復でも失われない。`debate.models` が空なら `models.participants` にフォールバック — #325）
 - `models.*` — exploration, decision, review, participants, moderator, ask
 - `execution.*` — max_iterations, max_tool_turns
 - `output.*` — format, color

--- a/application/src/config/quorum_config.rs
+++ b/application/src/config/quorum_config.rs
@@ -28,8 +28,9 @@ use crate::use_cases::run_quorum::RunQuorumInput;
 use quorum_domain::agent::validation::{ConfigIssue, Severity};
 use quorum_domain::config::config_key::lookup_key;
 use quorum_domain::{
-    AgentPolicy, ConsensusLevel, HilMode, Model, ModelConfig, OrchestrationStrategy, OutputFormat,
-    PhaseScope, ProviderConfig, SessionMode, SupervisorReporterMode,
+    AgentPolicy, ConsensusLevel, DebateConfig, DebateIntensity, HilMode, Model, ModelConfig,
+    OrchestrationStrategy, OutputFormat, PhaseScope, ProviderConfig, SessionMode,
+    SupervisorReporterMode,
 };
 
 /// Configuration container for buffer controllers.
@@ -43,6 +44,10 @@ pub struct QuorumConfig {
     models: ModelConfig,
     policy: AgentPolicy,
     execution: ExecutionParams,
+    // Persisted independently of `mode.strategy` so `debate.*` settings
+    // survive round-trips through `agent.strategy` (quorum <-> debate, #325)
+    // instead of being reset to `DebateConfig::default()` every switch.
+    debate_config: DebateConfig,
     output_format: OutputFormat,
     color: bool,
     show_progress: bool,
@@ -70,6 +75,7 @@ impl Default for QuorumConfig {
             models: ModelConfig::default(),
             policy: AgentPolicy::default(),
             execution: ExecutionParams::default(),
+            debate_config: DebateConfig::default(),
             output_format: OutputFormat::default(),
             color: true,
             show_progress: true,
@@ -102,6 +108,7 @@ impl QuorumConfig {
             models,
             policy,
             execution,
+            debate_config: DebateConfig::default(),
             output_format: OutputFormat::default(),
             color: true,
             show_progress: true,
@@ -140,6 +147,39 @@ impl QuorumConfig {
     /// Mutable access to model configuration.
     pub fn models_mut(&mut self) -> &mut ModelConfig {
         &mut self.models
+    }
+
+    /// Debate strategy roster/parameters (`debate.*` config keys, #325).
+    /// Persisted independently of `mode.strategy` — see [`Self::use_debate_strategy`].
+    pub fn debate_config(&self) -> &DebateConfig {
+        &self.debate_config
+    }
+
+    /// Mutable access to debate strategy configuration.
+    pub fn debate_config_mut(&mut self) -> &mut DebateConfig {
+        &mut self.debate_config
+    }
+
+    /// Switch the active orchestration strategy to Quorum.
+    pub fn use_quorum_strategy(&mut self) {
+        self.mode.strategy = OrchestrationStrategy::default();
+    }
+
+    /// Switch the active orchestration strategy to Debate, carrying over the
+    /// persisted `debate_config` rather than resetting to
+    /// `DebateConfig::default()` — so `debate.*` settings survive a
+    /// quorum -> debate -> quorum -> debate round-trip (#325).
+    pub fn use_debate_strategy(&mut self) {
+        self.mode.strategy = OrchestrationStrategy::Debate(self.debate_config.clone());
+    }
+
+    /// Mirrors `self.debate_config` into `self.mode.strategy` when Debate is
+    /// already active, so a `debate.*` setter takes effect immediately
+    /// without requiring `agent.strategy` to be re-set.
+    fn sync_debate_strategy(&mut self) {
+        if matches!(self.mode.strategy, OrchestrationStrategy::Debate(_)) {
+            self.mode.strategy = OrchestrationStrategy::Debate(self.debate_config.clone());
+        }
     }
 
     /// Agent behavioral policy.
@@ -356,6 +396,21 @@ impl ConfigAccessorPort for QuorumConfig {
             "agent.max_plan_revisions" => {
                 Ok(ConfigValue::Integer(self.policy.max_plan_revisions as i64))
             }
+            // ---- debate.* ----
+            "debate.models" => Ok(ConfigValue::StringList(
+                self.debate_config
+                    .models
+                    .iter()
+                    .map(|m| m.to_string())
+                    .collect(),
+            )),
+            "debate.max_rounds" => Ok(ConfigValue::Integer(self.debate_config.max_rounds as i64)),
+            "debate.intensity" => Ok(ConfigValue::String(
+                self.debate_config.intensity.to_string(),
+            )),
+            "debate.allow_interjection" => {
+                Ok(ConfigValue::Boolean(self.debate_config.allow_interjection))
+            }
             // ---- models.* ----
             "models.exploration" => Ok(ConfigValue::String(self.models.exploration.to_string())),
             "models.decision" => Ok(ConfigValue::String(self.models.decision.to_string())),
@@ -452,13 +507,8 @@ impl ConfigAccessorPort for QuorumConfig {
             "agent.strategy" => {
                 let s = extract_string(key, value)?;
                 match s.to_lowercase().as_str() {
-                    "quorum" => {
-                        self.mode.strategy = OrchestrationStrategy::default();
-                    }
-                    "debate" => {
-                        self.mode.strategy =
-                            OrchestrationStrategy::Debate(quorum_domain::DebateConfig::default());
-                    }
+                    "quorum" => self.use_quorum_strategy(),
+                    "debate" => self.use_debate_strategy(),
                     _ => {
                         return Err(ConfigAccessError::InvalidValue {
                             key: key.to_string(),
@@ -482,6 +532,40 @@ impl ConfigAccessorPort for QuorumConfig {
             "agent.max_plan_revisions" => {
                 let n = extract_positive_int(key, value)?;
                 self.policy.max_plan_revisions = n;
+                Ok(vec![])
+            }
+            // ---- debate.* (DebateConfig) ----
+            "debate.models" => {
+                let list = extract_string_list(key, value)?;
+                self.debate_config.models = list
+                    .into_iter()
+                    .map(|s| s.parse::<Model>().unwrap())
+                    .collect();
+                self.sync_debate_strategy();
+                Ok(vec![])
+            }
+            "debate.max_rounds" => {
+                let n = extract_positive_int(key, value)?;
+                self.debate_config.max_rounds = n;
+                self.sync_debate_strategy();
+                Ok(vec![])
+            }
+            "debate.intensity" => {
+                let s = extract_string(key, value)?;
+                let intensity =
+                    s.parse::<DebateIntensity>()
+                        .map_err(|e| ConfigAccessError::InvalidValue {
+                            key: key.to_string(),
+                            message: e,
+                        })?;
+                self.debate_config.intensity = intensity;
+                self.sync_debate_strategy();
+                Ok(vec![])
+            }
+            "debate.allow_interjection" => {
+                let b = extract_bool(key, value)?;
+                self.debate_config.allow_interjection = b;
+                self.sync_debate_strategy();
                 Ok(vec![])
             }
             // ---- models.* (ModelConfig) ----
@@ -892,6 +976,155 @@ mod tests {
         ));
     }
 
+    // ==================== debate.* Tests (#325) ====================
+
+    #[test]
+    fn test_config_get_debate_defaults() {
+        let config = QuorumConfig::default();
+        assert_eq!(
+            config.config_get("debate.models").unwrap(),
+            ConfigValue::StringList(vec![])
+        );
+        assert_eq!(
+            config.config_get("debate.max_rounds").unwrap(),
+            ConfigValue::Integer(3)
+        );
+        assert_eq!(
+            config.config_get("debate.intensity").unwrap(),
+            ConfigValue::String("mild".to_string())
+        );
+        assert_eq!(
+            config.config_get("debate.allow_interjection").unwrap(),
+            ConfigValue::Boolean(false)
+        );
+    }
+
+    #[test]
+    fn test_config_set_get_debate_roundtrip() {
+        let mut config = QuorumConfig::default();
+        config
+            .config_set(
+                "debate.models",
+                ConfigValue::StringList(vec![
+                    "claude-opus-4.5".to_string(),
+                    "gpt-5.2-codex".to_string(),
+                ]),
+            )
+            .unwrap();
+        config
+            .config_set("debate.max_rounds", ConfigValue::Integer(5))
+            .unwrap();
+        config
+            .config_set(
+                "debate.intensity",
+                ConfigValue::String("strong".to_string()),
+            )
+            .unwrap();
+        config
+            .config_set("debate.allow_interjection", ConfigValue::Boolean(true))
+            .unwrap();
+
+        assert_eq!(
+            config.debate_config().models,
+            vec![Model::ClaudeOpus45, Model::Gpt52Codex]
+        );
+        assert_eq!(config.debate_config().max_rounds, 5);
+        assert_eq!(
+            config.debate_config().intensity,
+            quorum_domain::DebateIntensity::Strong
+        );
+        assert!(config.debate_config().allow_interjection);
+
+        assert_eq!(
+            config.config_get("debate.models").unwrap(),
+            ConfigValue::StringList(vec![
+                "claude-opus-4.5".to_string(),
+                "gpt-5.2-codex".to_string(),
+            ])
+        );
+        assert_eq!(
+            config.config_get("debate.max_rounds").unwrap(),
+            ConfigValue::Integer(5)
+        );
+        assert_eq!(
+            config.config_get("debate.intensity").unwrap(),
+            ConfigValue::String("strong".to_string())
+        );
+        assert_eq!(
+            config.config_get("debate.allow_interjection").unwrap(),
+            ConfigValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn test_config_set_debate_intensity_rejects_invalid_value() {
+        let mut config = QuorumConfig::default();
+        let err = config
+            .config_set(
+                "debate.intensity",
+                ConfigValue::String("extreme".to_string()),
+            )
+            .unwrap_err();
+        assert!(matches!(err, ConfigAccessError::InvalidValue { .. }));
+    }
+
+    #[test]
+    fn test_debate_config_survives_strategy_round_trip() {
+        // debate.* set first, *then* agent.strategy switched to debate —
+        // settings must not be reset to DebateConfig::default().
+        let mut config = QuorumConfig::default();
+        config
+            .config_set("debate.max_rounds", ConfigValue::Integer(7))
+            .unwrap();
+        config
+            .config_set(
+                "debate.intensity",
+                ConfigValue::String("strong".to_string()),
+            )
+            .unwrap();
+
+        config
+            .config_set("agent.strategy", ConfigValue::String("debate".to_string()))
+            .unwrap();
+        let OrchestrationStrategy::Debate(active) = &config.mode().strategy else {
+            panic!("expected Debate strategy");
+        };
+        assert_eq!(active.max_rounds, 7);
+        assert_eq!(active.intensity, quorum_domain::DebateIntensity::Strong);
+
+        // Round-trip through quorum and back to debate — still preserved.
+        config
+            .config_set("agent.strategy", ConfigValue::String("quorum".to_string()))
+            .unwrap();
+        config
+            .config_set("agent.strategy", ConfigValue::String("debate".to_string()))
+            .unwrap();
+        let OrchestrationStrategy::Debate(active) = &config.mode().strategy else {
+            panic!("expected Debate strategy");
+        };
+        assert_eq!(active.max_rounds, 7);
+        assert_eq!(active.intensity, quorum_domain::DebateIntensity::Strong);
+    }
+
+    #[test]
+    fn test_debate_config_setter_applies_immediately_when_already_debate() {
+        // agent.strategy switched to debate *first*, then debate.* set —
+        // the change must be reflected in mode.strategy right away, without
+        // needing to re-set agent.strategy.
+        let mut config = QuorumConfig::default();
+        config
+            .config_set("agent.strategy", ConfigValue::String("debate".to_string()))
+            .unwrap();
+        config
+            .config_set("debate.max_rounds", ConfigValue::Integer(9))
+            .unwrap();
+
+        let OrchestrationStrategy::Debate(active) = &config.mode().strategy else {
+            panic!("expected Debate strategy");
+        };
+        assert_eq!(active.max_rounds, 9);
+    }
+
     #[test]
     fn test_config_set_hil_mode() {
         let mut config = QuorumConfig::default();
@@ -1141,10 +1374,10 @@ mod tests {
     }
 
     #[test]
-    fn test_config_keys_returns_all_30() {
+    fn test_config_keys_returns_all_34() {
         let config = QuorumConfig::default();
         let keys = config.config_keys();
-        assert_eq!(keys.len(), 30);
+        assert_eq!(keys.len(), 34);
         // Spot-check existing keys
         assert!(keys.contains(&"models.participants".to_string()));
         assert!(keys.contains(&"output.format".to_string()));
@@ -1157,6 +1390,11 @@ mod tests {
         assert!(keys.contains(&"tui.layout.flex_threshold".to_string()));
         // Spot-check supervisor key
         assert!(keys.contains(&"supervisor.reporter".to_string()));
+        // Spot-check debate keys (#325)
+        assert!(keys.contains(&"debate.models".to_string()));
+        assert!(keys.contains(&"debate.max_rounds".to_string()));
+        assert!(keys.contains(&"debate.intensity".to_string()));
+        assert!(keys.contains(&"debate.allow_interjection".to_string()));
     }
 
     #[test]

--- a/application/src/use_cases/agent_controller.rs
+++ b/application/src/use_cases/agent_controller.rs
@@ -631,16 +631,16 @@ impl AgentController {
 
         match args.split_whitespace().next().unwrap_or("") {
             "quorum" | "q" => {
-                self.config().mode_mut().strategy = quorum_domain::OrchestrationStrategy::default();
+                self.config().use_quorum_strategy();
                 let _ = self.tx.send(UiEvent::StrategyChanged {
                     strategy: "quorum".to_string(),
                     description: "equal discussion + review + synthesis".to_string(),
                 });
             }
             "debate" | "d" => {
-                self.config().mode_mut().strategy = quorum_domain::OrchestrationStrategy::Debate(
-                    quorum_domain::DebateConfig::default(),
-                );
+                // Carries over any persisted `debate.*` settings rather than
+                // resetting to `DebateConfig::default()` (#325).
+                self.config().use_debate_strategy();
                 let _ = self.tx.send(UiEvent::StrategyChanged {
                     strategy: "debate".to_string(),
                     description: "adversarial discussion + consensus building".to_string(),

--- a/application/src/use_cases/run_quorum/debate_strategy.rs
+++ b/application/src/use_cases/run_quorum/debate_strategy.rs
@@ -1373,6 +1373,58 @@ mod tests {
         assert!(matches!(err, RunQuorumError::NotEnoughModelsForDebate(1)));
     }
 
+    #[tokio::test]
+    async fn debate_roster_falls_back_to_model_config_participants_when_empty() {
+        // DebateConfig.models is empty (its default, since #325) — roster()
+        // must fall back to ModelConfig.participants rather than erroring.
+        let config = DebateConfig {
+            models: vec![],
+            moderator: Some(Model::ClaudeSonnet45),
+            intensity: DebateIntensity::Strong,
+            allow_interjection: false,
+            max_rounds: 1,
+        };
+        let models = ModelConfig {
+            participants: vec![Model::Gpt53Codex, Model::Gemini31Pro],
+            ..ModelConfig::default()
+        };
+        let input =
+            RunQuorumInput::new("Should the cache be write-through or write-behind?", models)
+                .with_strategy(OrchestrationStrategy::Debate(config));
+
+        let gateway = ScriptedGateway::new();
+        gateway.respond(Model::Gpt53Codex, "Opening: write-through.");
+        gateway.respond(Model::Gemini31Pro, "Attack round 1: latency matters more.");
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            divergence_response(true, "They disagree on consistency vs. latency tradeoffs."),
+        );
+        gateway.respond(
+            Model::ClaudeSonnet45,
+            verdict_response(true, &[], "Write-through wins."),
+        );
+
+        let result = DebateStrategyExecutor::new()
+            .execute(
+                &input,
+                Arc::new(gateway),
+                &NoProgress,
+                Arc::new(NoEventPublisher),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.models,
+            vec![
+                Model::Gpt53Codex.to_string(),
+                Model::Gemini31Pro.to_string()
+            ]
+        );
+        assert_eq!(result.responses[0].model, Model::Gpt53Codex.to_string());
+    }
+
     /// Builds a common fixture: opponent raises one CRITICAL rebuttal and the
     /// moderator declares `SETTLED` in round 1 without ruling on it — i.e. the
     /// moderator tries to settle early while a critical objection is still open.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,7 +24,8 @@ Rust defaults  →  init.lua  →  plugins/*.lua (アルファベット順)  →
 ```
 
 後段が前段を上書きします。CLI フラグ（`--ensemble` 等）が最優先です。
-設定全体は `QuorumConfig`（4型コンテナ: SessionMode / ModelConfig / AgentPolicy / ExecutionParams）で管理され、
+設定全体は `QuorumConfig`（SessionMode / ModelConfig / AgentPolicy / ExecutionParams に加え、
+Debate 戦略専用の DebateConfig を保持）で管理され、
 `AgentController` と `LuaScriptingEngine` が `Arc<Mutex<QuorumConfig>>` を共有するため、
 Lua からの変更は runtime でエージェントに伝播します。
 
@@ -32,7 +33,7 @@ Lua からの変更は runtime でエージェントに伝播します。
 
 ## Configuration Keys / 設定キー一覧
 
-`quorum.config.set(key, value)` / `quorum.config.get(key)` で読み書きできる全 29 キー。
+`quorum.config.set(key, value)` / `quorum.config.get(key)` で読み書きできる全 34 キー。
 すべて runtime で変更可能です。
 
 ### `agent.*` — エージェント動作
@@ -57,6 +58,24 @@ settle チェックポイントでも）このモードでゲートされます:
 fail-secure）。`auto_approve` は未解決のまま強制的に settle し、`interactive`
 は `HumanInterventionPort::request_debate_escalation` 経由で都度ユーザーに
 判断を委ねます。
+
+### `debate.*` — Debate 戦略のロースター/パラメータ（#325）
+
+| キー | 型 | 値 | デフォルト |
+|------|-----|-----|-----------|
+| `debate.models` | StringList | Debate のロースター（先頭2つが proponent/opponent、3つ目以降は interjector 候補） | `[]`（空の場合は `models.participants` にフォールバック） |
+| `debate.max_rounds` | Integer | 最大討議ラウンド数 | `3` |
+| `debate.intensity` | String | `"mild"`, `"strong"` | `"mild"` |
+| `debate.allow_interjection` | Boolean | 第三者モデルの割り込み発言を許可するか | `false` |
+
+`debate.*` の設定値は `agent.strategy` を `quorum` ⇔ `debate` と切り替えても失われません
+（`QuorumConfig` が `DebateConfig` を独立に保持し、`debate` へ切り替えるたびにその値を
+引き継ぎます）。設定する順序（`debate.*` を先に設定してから `agent.strategy = "debate"`
+にする／その逆）はどちらでも同じ結果になります。
+
+`debate.models` を空のままにした場合、`DebateStrategyExecutor::roster()` が
+`models.participants` にフォールバックします — Debate 専用のロースターを別途用意しなくても、
+Quorum Discussion と同じ参加モデル構成で討議できます。
 
 ### `models.*` — ロール別モデル設定
 
@@ -313,4 +332,4 @@ quorum.tui.content.slots()
 - [How to Write Lua Plugins](../how-to/write-lua-plugins.md) - プラグイン作成手順
 - [Tutorial: Customizing with Lua](../tutorials/customizing-with-lua.md) - 入門チュートリアル
 
-<!-- LLM Context: 設定は Lua (init.lua + plugins/*.lua) のみ。TOML (quorum.toml) 基盤は撤去済み。Boot: Rust defaults → init.lua → plugins → CLI flags。全30キー runtime 変更可能: agent.*(5), models.*(6), execution.*(2), output.*(2), repl.*(2), context_budget.*(3), tui.input.*(7), tui.layout.*(2), supervisor.*(1)。QuorumConfig(application/src/config/quorum_config.rs) が4型コンテナ(SessionMode/ModelConfig/AgentPolicy/ExecutionParams)。AgentController と LuaScriptingEngine が Arc<Mutex<QuorumConfig>> を共有し runtime 伝播。Lua API: quorum.config/{get,set,keys}+metatable proxy, quorum.providers.{set_default,route,bedrock,anthropic,openai}, quorum.tools.register, quorum.keymap.set, quorum.command.register, quorum.on, quorum.tui.{routes,layout,content}。 -->
+<!-- LLM Context: 設定は Lua (init.lua + plugins/*.lua) のみ。TOML (quorum.toml) 基盤は撤去済み。Boot: Rust defaults → init.lua → plugins → CLI flags。全34キー runtime 変更可能: agent.*(5), debate.*(4), models.*(6), execution.*(2), output.*(2), repl.*(2), context_budget.*(3), tui.input.*(7), tui.layout.*(2), supervisor.*(1)。QuorumConfig(application/src/config/quorum_config.rs) が SessionMode/ModelConfig/AgentPolicy/ExecutionParams に加え DebateConfig を保持(agent.strategy の quorum⇔debate 往復でも debate.* を保持するため、#325)。AgentController と LuaScriptingEngine が Arc<Mutex<QuorumConfig>> を共有し runtime 伝播。Lua API: quorum.config/{get,set,keys}+metatable proxy, quorum.providers.{set_default,route,bedrock,anthropic,openai}, quorum.tools.register, quorum.keymap.set, quorum.command.register, quorum.on, quorum.tui.{routes,layout,content}。 -->

--- a/domain/src/config/config_key.rs
+++ b/domain/src/config/config_key.rs
@@ -36,7 +36,7 @@ pub fn lookup_key(key: &str) -> Option<&'static ConfigKeyInfo> {
     KNOWN_KEYS.iter().find(|k| k.key == key)
 }
 
-static KNOWN_KEYS: [ConfigKeyInfo; 30] = [
+static KNOWN_KEYS: [ConfigKeyInfo; 34] = [
     // ==================== agent.* (SessionMode + AgentPolicy) ====================
     ConfigKeyInfo {
         key: "agent.consensus_level",
@@ -65,6 +65,31 @@ static KNOWN_KEYS: [ConfigKeyInfo; 30] = [
     ConfigKeyInfo {
         key: "agent.max_plan_revisions",
         description: "Maximum plan revision attempts",
+        mutability: Mutability::Mutable,
+        valid_values: &[],
+    },
+    // ==================== debate.* (DebateConfig) ====================
+    ConfigKeyInfo {
+        key: "debate.models",
+        description: "Debate roster (empty falls back to models.participants)",
+        mutability: Mutability::Mutable,
+        valid_values: &[],
+    },
+    ConfigKeyInfo {
+        key: "debate.max_rounds",
+        description: "Maximum number of debate rounds",
+        mutability: Mutability::Mutable,
+        valid_values: &[],
+    },
+    ConfigKeyInfo {
+        key: "debate.intensity",
+        description: "Debate intensity: mild or strong",
+        mutability: Mutability::Mutable,
+        valid_values: &["mild", "strong"],
+    },
+    ConfigKeyInfo {
+        key: "debate.allow_interjection",
+        description: "Whether third-party models can interject during the debate",
         mutability: Mutability::Mutable,
         valid_values: &[],
     },
@@ -254,12 +279,12 @@ mod tests {
 
     #[test]
     fn test_all_keys_mutable() {
-        // All 30 keys are mutable
+        // All 34 keys are mutable
         let mutable: Vec<_> = known_keys()
             .iter()
             .filter(|k| k.mutability == Mutability::Mutable)
             .collect();
-        assert_eq!(mutable.len(), 30);
+        assert_eq!(mutable.len(), 34);
     }
 
     #[test]
@@ -269,6 +294,16 @@ mod tests {
             .filter(|k| k.mutability == Mutability::ReadOnly)
             .collect();
         assert_eq!(readonly.len(), 0);
+    }
+
+    #[test]
+    fn test_debate_keys() {
+        assert!(lookup_key("debate.models").is_some());
+        assert!(lookup_key("debate.max_rounds").is_some());
+        let intensity = lookup_key("debate.intensity").unwrap();
+        assert!(intensity.valid_values.contains(&"mild"));
+        assert!(intensity.valid_values.contains(&"strong"));
+        assert!(lookup_key("debate.allow_interjection").is_some());
     }
 
     #[test]

--- a/domain/src/orchestration/strategy.rs
+++ b/domain/src/orchestration/strategy.rs
@@ -89,7 +89,10 @@ impl std::fmt::Display for OrchestrationStrategy {
 /// opposing positions, moderated by an optional moderator model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DebateConfig {
-    /// Models participating in the debate
+    /// Models participating in the debate. Empty by default — falls back to
+    /// `ModelConfig.participants` at runtime (see `DebateStrategyExecutor::roster()`
+    /// in `application/src/use_cases/run_quorum/debate_strategy.rs`) so a debate
+    /// roster doesn't need its own hardcoded default (#325).
     pub models: Vec<Model>,
     /// Optional moderator to guide the debate
     pub moderator: Option<Model>,
@@ -104,7 +107,7 @@ pub struct DebateConfig {
 impl Default for DebateConfig {
     fn default() -> Self {
         Self {
-            models: Model::default_models(),
+            models: vec![],
             moderator: None,
             intensity: DebateIntensity::default(),
             allow_interjection: false,
@@ -171,6 +174,13 @@ mod tests {
         let strategy = OrchestrationStrategy::Debate(DebateConfig::default());
         let phases = strategy.phases();
         assert_eq!(phases.len(), 3);
+    }
+
+    #[test]
+    fn test_debate_config_default_models_is_empty() {
+        // Empty by default so `DebateStrategyExecutor::roster()` falls back to
+        // `ModelConfig.participants` (#325) instead of a hardcoded roster.
+        assert!(DebateConfig::default().models.is_empty());
     }
 
     #[test]

--- a/quorum.example.lua
+++ b/quorum.example.lua
@@ -34,6 +34,22 @@ quorum.config.set("agent.hil_mode", "interactive")
 -- Maximum plan revisions before human intervention (default: 3)
 -- quorum.config.set("agent.max_plan_revisions", 3)
 
+-- ==================== Debate Strategy ====================
+-- Roster/parameters for the Debate strategy (agent.strategy = "debate", #325).
+-- Persisted independently of agent.strategy, so these survive a
+-- quorum <-> debate round-trip.
+
+-- Debate roster: first two are proponent/opponent, the rest are optional
+-- interjectors (only used if allow_interjection is true).
+-- Leave unset (default: {}) to fall back to models.participants.
+-- quorum.config.set("debate.models", { "gpt-5.3-codex", "claude-sonnet-4.5", "gemini-3.1-pro-preview" })
+-- Maximum number of debate rounds (default: 3)
+-- quorum.config.set("debate.max_rounds", 3)
+-- Debate intensity: "mild" (collaborative pushback) or "strong" (aggressive challenge) (default: "mild")
+-- quorum.config.set("debate.intensity", "mild")
+-- Allow third-party models (roster[2..]) to interject during rounds (default: false)
+-- quorum.config.set("debate.allow_interjection", false)
+
 -- ==================== Output ====================
 
 -- Output format: "full", "synthesis", or "json" (default: synthesis)


### PR DESCRIPTION
## 概要

Issue #325 の実装。Debate 戦略のロースター/パラメータを config キーとして設定可能にし、あわせて `models.participants` フォールバックを実際に到達可能にする(案 A + B の併用)。

## 変更内容

### 案A: `debate.*` config キーの追加

- `debate.models`(StringList) — Debate のロースター。先頭2つが proponent/opponent、3つ目以降は interjector 候補
- `debate.max_rounds`(Integer) — 最大討議ラウンド数
- `debate.intensity`(String: `mild`/`strong`)
- `debate.allow_interjection`(Boolean)

単一情報源は `domain/src/config/config_key.rs` の `known_keys()`。ここに追加したことで `quorum.config.keys()` / RPC `config.keys` にも自動で載る。

### 案B: `DebateConfig::default().models` を空に

`Model::default_models()` のハードコードをやめ `vec![]` に変更。これにより `DebateStrategyExecutor::roster()` の「`config.models` が空なら `models.participants` にフォールバック」というロジックが実際に到達可能になった(従来は default が必ず非空だったため到達不能だった)。

### 設定の永続化

`application/src/config/quorum_config.rs`(application 層の `QuorumConfig`)に `DebateConfig` を独立フィールドとして持たせた。`agent.strategy` を `"agent.strategy" => "debate"` に切り替えるたびに毎回 `DebateConfig::default()` を作り直していたのが participants 無視の根本原因だったため、代わりに永続化済みの `debate_config` を引き継ぐ `use_quorum_strategy()` / `use_debate_strategy()` を新設し、`config_set("agent.strategy", ...)` と REPL `/strategy` コマンド(`agent_controller.rs`)の両方をこの経路に統一した。

- `debate.*` を先に設定 → 後から `agent.strategy = "debate"` にする
- `agent.strategy = "debate"` にしてから `debate.*` を設定する

のどちらの順序でも同じ結果になる(`sync_debate_strategy()` が Debate 稼働中の即時反映も担当)。

## テスト

- `application/src/config/quorum_config.rs`: config_get/config_set のラウンドトリップ、`agent.strategy` 往復での設定保持、順序非依存の直接反映
- `application/src/use_cases/run_quorum/debate_strategy.rs`: `debate.models` が空のとき `models.participants` へフォールバックして実際に討議が成立することを確認
- `domain/src/config/config_key.rs` / `domain/src/orchestration/strategy.rs`: 新キーのメタデータ、`DebateConfig::default().models` が空であること

`cargo test --workspace` 全緑(既存テスト含め regression なし)。`cargo fmt --all` 済み。

## ドキュメント更新

- `docs/reference/configuration.md` に `debate.*` セクションを追記(全34キーに更新)
- `CLAUDE.md` の Config Key Sections に追記
- `quorum.example.lua` に設定例を追記

Closes #325