### PR TITLE
feat(tui): Command モードに vim ライク Tab 補完を追加 (#326)

### DIFF
--- a/presentation/src/tui/app_action_handler.rs
+++ b/presentation/src/tui/app_action_handler.rs
@@ -1,8 +1,9 @@
 //! KeyAction handling — maps semantic key actions to state changes and commands.
 
+use super::command_completion;
 use super::content::ContentRegistry;
 use super::event::TuiCommand;
-use super::mode::{InputMode, KeyAction, VisualDirection};
+use super::mode::{CompletionDirection, InputMode, KeyAction, VisualDirection};
 use super::state::{DisplayMessage, TuiState, VisualSelection, YankMode, content_slot_label};
 use super::tab::PaneKind;
 use std::cell::RefCell;
@@ -31,16 +32,33 @@ pub(super) fn handle_action(
             state.mode = InputMode::Command;
             state.command_input.clear();
             state.command_cursor = 0;
+            state.command_completion = None;
         }
         KeyAction::ExitToNormal => {
-            state.mode = InputMode::Normal;
-            state.visual_selection = None;
+            // Esc during an active completion session cancels the
+            // completion (restoring what was typed before Tab) and stays in
+            // Command mode — mirrors vim's wildmenu Esc behavior (#326).
+            if state.mode == InputMode::Command
+                && let Some(completion) = state.command_completion.take()
+            {
+                state.command_input = completion.original_input;
+                state.command_cursor = state.command_input.len();
+            } else {
+                state.mode = InputMode::Normal;
+                state.visual_selection = None;
+            }
         }
 
         // Text editing
-        KeyAction::InsertChar(c) => state.insert_char(c),
+        KeyAction::InsertChar(c) => {
+            state.command_completion = None;
+            state.insert_char(c);
+        }
         KeyAction::InsertNewline => state.insert_newline(),
-        KeyAction::DeleteChar => state.delete_char(),
+        KeyAction::DeleteChar => {
+            state.command_completion = None;
+            state.delete_char();
+        }
         KeyAction::CursorLeft => state.cursor_left(),
         KeyAction::CursorRight => state.cursor_right(),
         KeyAction::CursorHome => state.cursor_home(),
@@ -133,12 +151,14 @@ pub(super) fn handle_action(
             state.mode = InputMode::Command;
             state.command_input = "ask ".into();
             state.command_cursor = state.command_input.len();
+            state.command_completion = None;
         }
         KeyAction::SwitchDiscuss => {
             // Enter command mode with "discuss " pre-filled
             state.mode = InputMode::Command;
             state.command_input = "discuss ".into();
             state.command_cursor = state.command_input.len();
+            state.command_completion = None;
         }
 
         // Scrolling
@@ -238,8 +258,47 @@ pub(super) fn handle_action(
                 content_slot_label(&state.focused_slot)
             ));
         }
+
+        KeyAction::CommandComplete(direction) => {
+            complete_command(state, scripting_engine, direction);
+        }
     }
     None
+}
+
+/// Advance Command-mode wildmenu completion by one Tab/Shift+Tab press (#326).
+/// No-op outside Command mode (Tab/BackTab only dispatch this action from
+/// `handle_command()`, so this guard should never actually trigger).
+fn complete_command(
+    state: &mut TuiState,
+    scripting_engine: &Arc<dyn quorum_application::ScriptingEnginePort>,
+    direction: CompletionDirection,
+) {
+    if state.mode != InputMode::Command {
+        return;
+    }
+    let lua_command_names: Vec<String> = scripting_engine
+        .registered_commands()
+        .into_iter()
+        .map(|(name, _description, _usage, _callback_id)| name)
+        .collect();
+
+    match command_completion::advance(
+        &state.command_input,
+        state.command_completion.as_ref(),
+        &lua_command_names,
+        direction,
+    ) {
+        Some((new_input, new_completion)) => {
+            state.command_input = new_input;
+            state.command_cursor = state.command_input.len();
+            state.command_completion = Some(new_completion);
+        }
+        None => {
+            state.command_completion = None;
+            state.set_flash("No matching command");
+        }
+    }
 }
 
 /// Shared yank helper — extract text from the focused slot, write to clipboard,
@@ -432,5 +491,149 @@ mod tests {
         // No local echo — the spawn path echoes via InteractionSpawned, so the
         // placeholder pane must not have pushed a duplicate user message.
         assert!(state.tabs.active_pane().conversation.messages.is_empty());
+    }
+
+    // -- Command-mode completion (#326) --
+
+    fn enter_command(state: &mut TuiState, cmd_tx: &mpsc::UnboundedSender<TuiCommand>, text: &str) {
+        run(state, KeyAction::EnterCommand, cmd_tx);
+        for c in text.chars() {
+            run(state, KeyAction::InsertChar(c), cmd_tx);
+        }
+    }
+
+    #[test]
+    fn tab_completes_command_name_to_longest_prefix() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "st");
+
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+
+        assert_eq!(state.command_input, "strategy");
+        assert!(state.command_completion.is_some());
+    }
+
+    #[test]
+    fn tab_cycles_through_multiple_matches() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "q");
+
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+        let first = state.command_input.clone();
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+        let second = state.command_input.clone();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn shift_tab_cycles_backward() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "q");
+
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Backward),
+            &tx,
+        );
+
+        let completion = state.command_completion.as_ref().unwrap();
+        assert_eq!(completion.cycle_index, Some(completion.matches.len() - 1));
+    }
+
+    #[test]
+    fn typing_after_tab_discards_completion_state() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "q");
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+        assert!(state.command_completion.is_some());
+
+        run(&mut state, KeyAction::InsertChar('a'), &tx);
+
+        assert!(state.command_completion.is_none());
+    }
+
+    #[test]
+    fn backspace_after_tab_discards_completion_state() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "q");
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+        assert!(state.command_completion.is_some());
+
+        run(&mut state, KeyAction::DeleteChar, &tx);
+
+        assert!(state.command_completion.is_none());
+    }
+
+    #[test]
+    fn esc_during_completion_restores_original_input_and_stays_in_command_mode() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "st");
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+        assert_eq!(state.command_input, "strategy");
+
+        run(&mut state, KeyAction::ExitToNormal, &tx);
+
+        assert_eq!(state.command_input, "st");
+        assert!(state.command_completion.is_none());
+        assert_eq!(state.mode, InputMode::Command);
+    }
+
+    #[test]
+    fn esc_without_completion_exits_to_normal_as_before() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "q");
+
+        run(&mut state, KeyAction::ExitToNormal, &tx);
+
+        assert_eq!(state.mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn tab_with_no_matches_sets_flash_and_leaves_input_untouched() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut state = TuiState::new();
+        enter_command(&mut state, &tx, "zzz");
+
+        run(
+            &mut state,
+            KeyAction::CommandComplete(CompletionDirection::Forward),
+            &tx,
+        );
+
+        assert_eq!(state.command_input, "zzz");
+        assert!(state.command_completion.is_none());
+        assert!(state.flash_message.is_some());
     }
 }

--- a/presentation/src/tui/command_completion.rs
+++ b/presentation/src/tui/command_completion.rs
@@ -1,0 +1,405 @@
+//! Vim-like `wildmode=longest:full` completion for Command mode (`:`, #326).
+//!
+//! Pure logic only — no rendering, no `TuiState` mutation. `advance()` is the
+//! single entry point `app_action_handler` calls from `KeyAction::CommandComplete`;
+//! everything else here is a private helper covered directly by unit tests.
+//!
+//! Step semantics (mirrors vim's `wildmode=longest:full`, simplified by one
+//! detail noted below):
+//! - 1st Tab: extend the word to the longest common prefix of all matches.
+//! - If that doesn't change anything (already at the longest prefix, or a
+//!   single exact match), the *same* keypress starts full cycling instead of
+//!   requiring a second, no-op Tab press first — a deliberate small
+//!   deviation from vim to avoid a dead keystroke.
+//! - Further Tab/Shift+Tab presses cycle forward/backward through the full
+//!   match list.
+
+use super::command_registry;
+use super::mode::CompletionDirection;
+
+/// Active completion state, carried in `TuiState` across Tab presses within
+/// the same completion session (discarded on text edits or Esc — see
+/// `app_action_handler`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandCompletion {
+    /// Full `command_input` text as typed before the first Tab press.
+    /// Restored verbatim when Esc cancels the completion.
+    pub original_input: String,
+    /// Portion of `command_input` before the completed word (e.g.
+    /// `"strategy "` for `:strategy q<Tab>`). Unchanged across cycling.
+    pub prefix: String,
+    /// Sorted, deduped candidate pool matching the word at the time Tab was
+    /// first pressed.
+    pub matches: Vec<String>,
+    /// `None` while still in the "longest common prefix" step. `Some(i)`
+    /// once cycling has started — `matches[i]` is the currently shown entry.
+    pub cycle_index: Option<usize>,
+}
+
+/// Advance completion by one Tab (`Forward`) / Shift+Tab (`Backward`) press.
+///
+/// `command_input` is the current Command-mode buffer; `prior` is the
+/// completion state from the previous press in this session (`None` on the
+/// first press). `lua_command_names` supplies user-defined command names
+/// (`quorum.command.register`) so they complete alongside builtins.
+///
+/// Returns `None` when there is nothing to complete (Tab is then a no-op —
+/// the caller decides how to surface that, e.g. a flash message). Otherwise
+/// returns the replacement `command_input` text and the completion state to
+/// keep for the next press.
+pub fn advance(
+    command_input: &str,
+    prior: Option<&CommandCompletion>,
+    lua_command_names: &[String],
+    direction: CompletionDirection,
+) -> Option<(String, CommandCompletion)> {
+    if let Some(state) = prior.filter(|s| !s.matches.is_empty()) {
+        let len = state.matches.len();
+        let next_index = match (state.cycle_index, direction) {
+            (None, CompletionDirection::Forward) => 0,
+            (None, CompletionDirection::Backward) => len - 1,
+            (Some(i), CompletionDirection::Forward) => (i + 1) % len,
+            (Some(i), CompletionDirection::Backward) => (i + len - 1) % len,
+        };
+        let new_input = format!("{}{}", state.prefix, state.matches[next_index]);
+        return Some((
+            new_input,
+            CommandCompletion {
+                original_input: state.original_input.clone(),
+                prefix: state.prefix.clone(),
+                matches: state.matches.clone(),
+                cycle_index: Some(next_index),
+            },
+        ));
+    }
+
+    let scope = completion_scope(command_input, lua_command_names);
+    let matches = matches_for_prefix(&scope.candidates, &scope.word);
+    if matches.is_empty() {
+        return None;
+    }
+    let original_input = command_input.to_string();
+    let lcp = longest_common_prefix(&matches);
+    if lcp.len() > scope.word.len() {
+        let new_input = format!("{}{}", scope.prefix, lcp);
+        Some((
+            new_input,
+            CommandCompletion {
+                original_input,
+                prefix: scope.prefix,
+                matches,
+                cycle_index: None,
+            },
+        ))
+    } else {
+        let idx = match direction {
+            CompletionDirection::Forward => 0,
+            CompletionDirection::Backward => matches.len() - 1,
+        };
+        let new_input = format!("{}{}", scope.prefix, matches[idx]);
+        Some((
+            new_input,
+            CommandCompletion {
+                original_input,
+                prefix: scope.prefix,
+                matches,
+                cycle_index: Some(idx),
+            },
+        ))
+    }
+}
+
+/// What `command_input` is asking to complete: the text to keep as-is
+/// (`prefix`), the token being completed (`word`), and the full candidate
+/// pool for that word (unfiltered by `word` — `advance` filters by prefix).
+struct CompletionScope {
+    prefix: String,
+    word: String,
+    candidates: Vec<String>,
+}
+
+/// Resolve completion scope from the raw Command-mode buffer.
+///
+/// - No space yet → completing the command name itself (builtin + alias +
+///   Lua-registered names).
+/// - Exactly one space, nothing after it but the first argument word →
+///   completing that command's first-argument candidates (`:strategy`,
+///   `:config` — #326 stretch scope; unknown commands have no candidates).
+/// - Anything past the first argument → no completion (future scope).
+fn completion_scope(input: &str, lua_command_names: &[String]) -> CompletionScope {
+    match input.split_once(' ') {
+        None => CompletionScope {
+            prefix: String::new(),
+            word: input.to_string(),
+            candidates: command_name_candidates(lua_command_names),
+        },
+        Some((cmd, rest)) if !rest.contains(' ') => CompletionScope {
+            prefix: format!("{} ", cmd),
+            word: rest.to_string(),
+            candidates: first_arg_candidates(cmd),
+        },
+        Some(_) => CompletionScope {
+            prefix: input.to_string(),
+            word: String::new(),
+            candidates: Vec::new(),
+        },
+    }
+}
+
+/// Command-name candidate pool: builtin canonical names + aliases (#302's
+/// `command_registry`, the single source of truth) plus Lua-registered
+/// command names.
+fn command_name_candidates(lua_command_names: &[String]) -> Vec<String> {
+    let mut names: Vec<String> = command_registry::builtin_commands()
+        .iter()
+        .flat_map(|c| {
+            std::iter::once(c.name.to_string()).chain(c.aliases.iter().map(|a| a.to_string()))
+        })
+        .collect();
+    names.extend(lua_command_names.iter().cloned());
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// First-argument candidate pool for commands with a fixed value set.
+/// Everything else (including Lua-registered commands, which have no
+/// argument metadata) has no candidates — Tab is then a no-op there.
+fn first_arg_candidates(cmd: &str) -> Vec<String> {
+    match cmd {
+        "strategy" => vec!["quorum".to_string(), "debate".to_string()],
+        "config" => quorum_domain::known_keys()
+            .iter()
+            .map(|k| k.key.to_string())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Candidates whose name starts with `word`. `candidates` is already sorted
+/// (see `command_name_candidates`), so filtering preserves order.
+fn matches_for_prefix(candidates: &[String], word: &str) -> Vec<String> {
+    candidates
+        .iter()
+        .filter(|c| c.starts_with(word))
+        .cloned()
+        .collect()
+}
+
+/// Longest common byte prefix of `items` (command/config names are ASCII,
+/// so byte-wise comparison is safe and avoids UTF-8 boundary bookkeeping).
+fn longest_common_prefix(items: &[String]) -> String {
+    match items.split_first() {
+        None => String::new(),
+        Some((first, rest)) => {
+            let mut len = first.len();
+            for s in rest {
+                let common = first
+                    .bytes()
+                    .zip(s.bytes())
+                    .take_while(|(a, b)| a == b)
+                    .count();
+                len = len.min(common);
+            }
+            first[..len].to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    // -- longest_common_prefix --
+
+    #[test]
+    fn lcp_of_empty_is_empty() {
+        assert_eq!(longest_common_prefix(&[]), "");
+    }
+
+    #[test]
+    fn lcp_of_single_is_itself() {
+        assert_eq!(longest_common_prefix(&names(&["solo"])), "solo");
+    }
+
+    #[test]
+    fn lcp_stops_at_divergence() {
+        assert_eq!(longest_common_prefix(&names(&["scope", "solo"])), "s");
+        assert_eq!(
+            longest_common_prefix(&names(&["strategy", "scope", "solo"])),
+            "s"
+        );
+    }
+
+    #[test]
+    fn lcp_of_shared_prefix_word() {
+        assert_eq!(longest_common_prefix(&names(&["q", "qa"])), "q");
+    }
+
+    // -- matches_for_prefix --
+
+    #[test]
+    fn filters_by_prefix_preserving_order() {
+        let pool = names(&["ask", "agent", "config"]);
+        assert_eq!(matches_for_prefix(&pool, "a"), names(&["ask", "agent"]));
+    }
+
+    #[test]
+    fn empty_prefix_matches_everything() {
+        let pool = names(&["a", "b"]);
+        assert_eq!(matches_for_prefix(&pool, ""), pool);
+    }
+
+    // -- command_name_candidates --
+
+    #[test]
+    fn command_name_candidates_include_aliases_and_lua() {
+        let cands = command_name_candidates(&names(&["mytool"]));
+        assert!(cands.contains(&"qa".to_string()));
+        assert!(cands.contains(&"qall".to_string())); // alias of qa
+        assert!(cands.contains(&"mytool".to_string()));
+    }
+
+    #[test]
+    fn command_name_candidates_dedup_and_sorted() {
+        // "help" alias "h" and "?" shouldn't collide with anything, but the
+        // list overall must be sorted + deduped even with repeats from Lua.
+        let cands = command_name_candidates(&names(&["q", "q"]));
+        let mut sorted = cands.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(cands, sorted);
+    }
+
+    // -- advance: command-name completion --
+
+    #[test]
+    fn advance_extends_to_longest_common_prefix() {
+        // "s" matches scope/solo/strategy among builtins. Their LCP is just
+        // "s" again (no shared second character), so this press can't
+        // extend the text — it falls straight into cycling (see module doc
+        // deviation from vim).
+        let (new_input, state) = advance("s", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(state.matches, names(&["scope", "solo", "strategy"]));
+        assert_eq!(new_input, "scope");
+        assert_eq!(state.cycle_index, Some(0));
+    }
+
+    #[test]
+    fn advance_extends_partial_word_to_lcp() {
+        // "st" narrows to strategy only among builtins — LCP extends fully.
+        let (new_input, state) = advance("st", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(new_input, "strategy");
+        assert_eq!(state.matches, names(&["strategy"]));
+        assert_eq!(state.cycle_index, None);
+    }
+
+    #[test]
+    fn advance_cycles_forward_through_matches() {
+        // "q" matches q, qa (+ aliases quit/qall/quitall/exit) — LCP is "q"
+        // itself, so the very first Tab starts cycling.
+        let (first, state1) = advance("q", None, &[], CompletionDirection::Forward).unwrap();
+        let (second, state2) =
+            advance(&first, Some(&state1), &[], CompletionDirection::Forward).unwrap();
+        assert_ne!(first, second);
+        assert_eq!(state2.matches, state1.matches);
+        assert_eq!(state2.cycle_index, Some(1));
+    }
+
+    #[test]
+    fn advance_cycle_wraps_around() {
+        let (_, state1) = advance("q", None, &[], CompletionDirection::Forward).unwrap();
+        let total = state1.matches.len();
+        let mut state = state1;
+        for _ in 0..total - 1 {
+            let (_, next) = advance("", Some(&state), &[], CompletionDirection::Forward).unwrap();
+            state = next;
+        }
+        // We've now cycled through every match once; one more Forward wraps to 0.
+        let (_, wrapped) = advance("", Some(&state), &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(wrapped.cycle_index, Some(0));
+    }
+
+    #[test]
+    fn advance_backward_cycles_in_reverse() {
+        let (_, state1) = advance("q", None, &[], CompletionDirection::Backward).unwrap();
+        // Backward on first press with an already-maximal LCP jumps straight
+        // to the last match.
+        assert_eq!(state1.cycle_index, Some(state1.matches.len() - 1));
+    }
+
+    #[test]
+    fn advance_no_match_returns_none() {
+        assert_eq!(
+            advance("zzz", None, &[], CompletionDirection::Forward),
+            None
+        );
+    }
+
+    #[test]
+    fn advance_single_match_completes_fully() {
+        let (new_input, state) = advance("hel", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(new_input, "help");
+        assert_eq!(state.matches, names(&["help"]));
+    }
+
+    #[test]
+    fn advance_preserves_original_input_across_cycles() {
+        let (_, state1) = advance("q", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(state1.original_input, "q");
+        let (_, state2) = advance("qa", Some(&state1), &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(state2.original_input, "q");
+    }
+
+    // -- advance: argument completion (stretch scope) --
+
+    #[test]
+    fn advance_completes_strategy_argument() {
+        let (new_input, state) =
+            advance("strategy ", None, &[], CompletionDirection::Forward).unwrap();
+        // LCP of quorum/debate is empty — falls straight into cycling.
+        // Declared order (quorum first) is kept rather than sorted
+        // alphabetically, since quorum is the default strategy.
+        assert_eq!(state.matches, names(&["quorum", "debate"]));
+        assert_eq!(new_input, "strategy quorum");
+    }
+
+    #[test]
+    fn advance_completes_strategy_argument_with_partial_word() {
+        let (new_input, _state) =
+            advance("strategy q", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(new_input, "strategy quorum");
+    }
+
+    #[test]
+    fn advance_completes_config_key_argument() {
+        let (new_input, _state) =
+            advance("config agent.cons", None, &[], CompletionDirection::Forward).unwrap();
+        assert_eq!(new_input, "config agent.consensus_level");
+    }
+
+    #[test]
+    fn advance_unknown_command_argument_has_no_candidates() {
+        assert_eq!(
+            advance("solo x", None, &[], CompletionDirection::Forward),
+            None
+        );
+    }
+
+    #[test]
+    fn advance_beyond_first_argument_has_no_candidates() {
+        assert_eq!(
+            advance(
+                "strategy quorum extra",
+                None,
+                &[],
+                CompletionDirection::Forward
+            ),
+            None
+        );
+    }
+}

--- a/presentation/src/tui/mod.rs
+++ b/presentation/src/tui/mod.rs
@@ -12,6 +12,7 @@ mod app_hil;
 mod app_render;
 mod app_tab_command;
 mod app_tui_changes;
+mod command_completion;
 mod command_registry;
 pub mod content;
 pub mod editor;

--- a/presentation/src/tui/mode.rs
+++ b/presentation/src/tui/mode.rs
@@ -116,6 +116,11 @@ pub enum KeyAction {
 
     // -- Lua scripting --
     LuaCallback(u64),
+
+    // -- Command-mode completion (#326) --
+    /// `Tab` / `Shift+Tab` in Command mode — advance wildmenu-style
+    /// completion one step in the given direction.
+    CommandComplete(CompletionDirection),
 }
 
 /// Directions for extending the Visual selection.
@@ -127,6 +132,15 @@ pub enum VisualDirection {
     LineEnd,
     WordLeft,
     WordRight,
+}
+
+/// Direction to step through Command-mode completion candidates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionDirection {
+    /// `Tab`
+    Forward,
+    /// `Shift+Tab` (`BackTab`)
+    Backward,
 }
 
 /// A table of custom keybindings registered from Lua scripts.
@@ -246,6 +260,7 @@ pub fn parse_key_descriptor(desc: &str) -> Option<(KeyCode, KeyModifiers)> {
         "Esc" => KeyCode::Esc,
         "Enter" => KeyCode::Enter,
         "Tab" => KeyCode::Tab,
+        "BackTab" => KeyCode::BackTab,
         "Backspace" => KeyCode::Backspace,
         "Delete" => KeyCode::Delete,
         "Space" => KeyCode::Char(' '),
@@ -420,6 +435,8 @@ fn handle_command(key: KeyEvent) -> KeyAction {
         KeyCode::Right => KeyAction::CursorRight,
         KeyCode::Home => KeyAction::CursorHome,
         KeyCode::End => KeyAction::CursorEnd,
+        KeyCode::Tab => KeyAction::CommandComplete(CompletionDirection::Forward),
+        KeyCode::BackTab => KeyAction::CommandComplete(CompletionDirection::Backward),
         KeyCode::Char(c) if is_text_input(&key) => KeyAction::InsertChar(c),
         _ => KeyAction::None,
     }
@@ -615,6 +632,24 @@ mod tests {
     }
 
     #[test]
+    fn test_command_tab_completes_forward() {
+        let key = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
+        assert_eq!(
+            handle_key_event(InputMode::Command, key, None),
+            KeyAction::CommandComplete(CompletionDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn test_command_backtab_completes_backward() {
+        let key = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
+        assert_eq!(
+            handle_key_event(InputMode::Command, key, None),
+            KeyAction::CommandComplete(CompletionDirection::Backward)
+        );
+    }
+
+    #[test]
     fn test_normal_quick_commands() {
         let cases = vec![
             ('s', KeyAction::SwitchSolo),
@@ -753,6 +788,10 @@ mod tests {
         assert_eq!(
             parse_key_descriptor("Backspace"),
             Some((KeyCode::Backspace, KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_key_descriptor("BackTab"),
+            Some((KeyCode::BackTab, KeyModifiers::NONE))
         );
     }
 

--- a/presentation/src/tui/state.rs
+++ b/presentation/src/tui/state.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 
+use super::command_completion::CommandCompletion;
 use super::content::{ContentRegistry, ContentSlot};
 use super::layout::TuiLayoutConfig;
 use super::mode::InputMode;
@@ -20,6 +21,9 @@ pub struct TuiState {
     // -- Command buffer (for : mode) — global, not per-tab --
     pub command_input: String,
     pub command_cursor: usize,
+    /// Active wildmenu-style completion state (Tab/Shift+Tab, #326).
+    /// `None` when no completion session is in progress.
+    pub command_completion: Option<CommandCompletion>,
 
     // -- Tabs (own per-pane input, messages, streaming, scroll, progress) --
     pub tabs: TabManager,
@@ -77,6 +81,7 @@ impl Default for TuiState {
             mode: InputMode::default(),
             command_input: String::new(),
             command_cursor: 0,
+            command_completion: None,
             tabs: TabManager::new(),
             route: RouteTable::default(),
             pending_key: None,
@@ -187,6 +192,7 @@ impl TuiState {
     /// Take the command buffer contents and clear it
     pub fn take_command(&mut self) -> String {
         self.command_cursor = 0;
+        self.command_completion = None;
         std::mem::take(&mut self.command_input)
     }
 

--- a/presentation/src/tui/widgets/input.rs
+++ b/presentation/src/tui/widgets/input.rs
@@ -79,7 +79,7 @@ impl<'a> Widget for InputWidget<'a> {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .title(" Input ")
+            .title(wildmenu_title(self.state))
             .style(border_style);
 
         // Inner area height (excluding borders) — used for scroll
@@ -110,6 +110,37 @@ impl<'a> Widget for InputWidget<'a> {
             .scroll((scroll_offset as u16, 0))
             .render(area, buf);
     }
+}
+
+/// Build the Input block's title — the default " Input " label, or a
+/// wildmenu-style candidate list while Command-mode completion is active
+/// (#326). Rendered in the border directly above the input text, so no
+/// layout changes are needed to make room for it.
+fn wildmenu_title(state: &TuiState) -> Line<'static> {
+    let Some(completion) = &state.command_completion else {
+        return Line::from(" Input ");
+    };
+    if completion.matches.len() < 2 {
+        return Line::from(" Input ");
+    }
+
+    let mut spans = vec![Span::raw(" ")];
+    for (i, candidate) in completion.matches.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::raw(" "));
+        }
+        let style = if completion.cycle_index == Some(i) {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Yellow)
+        };
+        spans.push(Span::styled(candidate.clone(), style));
+    }
+    spans.push(Span::raw(" "));
+    Line::from(spans)
 }
 
 /// Build lines for active (Insert/Command) mode with cursor rendering


### PR DESCRIPTION
## 概要

TUI の Command モード(`:` 入力中)に vim ライクな Tab 補完を実装した。

## 実装内容

### 必須スコープ
- **コマンド名補完**: `:st` + Tab → 共通プレフィックスまで補完(vim の `wildmode=longest:full` 相当)
- **候補巡回**: 候補が複数あるとき、さらに Tab で候補を順に巡回、Shift+Tab (BackTab) で逆順
- **wildmenu 風表示**: Input 枠のタイトル(枠線)に候補一覧を表示し、選択中の候補をハイライト。レイアウト変更なしで既存の枠に収まる場所を選んだ
- **Esc でキャンセル**: 補完中に Esc を押すと、Tab を押す前の入力に復元して Command モードに留まる(vim の wildmenu と同じ挙動)。補完していない状態での Esc は従来どおり Normal モードへ抜ける
- **文字入力/Backspace で補完状態を破棄**: 通常の編集をすると補完セッションは終了する
- **エイリアスも候補に含む**: `command_registry::builtin_commands()` の name + aliases、および `quorum.command.register` で登録された Lua コマンド名を候補プールに含める

### 発展スコープ(実装済み)
- `:strategy ` + Tab → `quorum` / `debate` の引数補完
- `:config ` + Tab → `known_keys()` のキー名(ドット区切りフルパス)補完

未実装(今後の課題):
- 第二引数以降の補完(例: `:config agent.` の先の値候補など)
- `:tabnew agent/ask/discuss` のような他コマンドの引数補完

## 設計

補完ロジックは描画・状態管理から分離し、`presentation/src/tui/command_completion.rs` に純粋関数として切り出した:
- `CommandCompletion` 構造体(候補リスト・巡回位置・元の入力・prefix を保持)
- `advance()` が唯一のエントリポイント(`wildmode=longest:full` のステップ計算)
- 候補フィルタ・共通プレフィックス計算などの内部ヘルパーも含め、単体テストで個別に検証

補完状態は Command モードの入力状態と同じ `TuiState`(`command_input`/`command_cursor` の隣)に `command_completion: Option<CommandCompletion>` として保持。

`KeyAction::CommandComplete(CompletionDirection)` を追加し、`mode.rs::handle_command()` で `Tab`/`BackTab` から変換。`enum` ディスパッチは既存方針どおり exhaustive match を維持。

## 実機確認 (headless + RPC)

`cargo build` 後、`--headless --listen` で起動し `keys.feed`/`screen.capture` で確認した。

**コマンド名補完(複数候補の巡回 + wildmenu):**
```
:q <Tab>          → command_input="q"    (候補5件: q qa qall quit quitall / 先頭 "q" が黒地黄色でハイライト)
<Tab>             → command_input="qa"
<Tab>             → command_input="qall"
<BackTab>         → command_input="qa"
```
screen.capture の Input 枠タイトル行:
```
┌ q qa qall quit quitall ────────────────────────────────────────┐
│:qa                                                              │
```
style_runs でも先頭候補が `fg=Black bg=Yellow BOLD`、他は `fg=Yellow` のみと確認。

**単一候補への完全補完:**
```
:st <Tab> → command_input="strategy"  (候補1件なので wildmenu は非表示、"Input" のまま)
```

**Esc キャンセル:**
```
:st <Tab> → "strategy"
<Esc>     → command_input="st" に復元、mode="command" のまま
<Esc>     → mode="normal" (2回目で通常の Esc 動作)
```

**引数補完(発展スコープ):**
```
:strategy <Tab>        → "strategy quorum"
<Tab>                  → "strategy debate"
:config agent. <Tab>   → wildmenu = "agent.consensus_level agent.phase_scope agent.strategy agent.hil_mode agent.max_plan_revisions"
:config agent.c <Tab>  → "config agent.consensus_level" (単一候補)
```

**候補なし:**
```
:zzz <Tab> → flash="No matching command"、入力は変化しない
```

## 気づいた点(指示外)

- `parse_key_descriptor()`(`mode.rs`、RPC `keys.feed` や Lua `quorum.keymap.set` が共有)に `"BackTab"` という文字列表現が無く、Shift+Tab を打鍵テストできなかった。実ターミナルでは crossterm が legacy CSI (`ESC[Z`) でも kitty keyboard protocol でも Shift+Tab を確実に `KeyCode::BackTab` + `SHIFT` に正規化することをソースで確認済みなので実装自体は正しいが、検証性と将来の Lua キーバインド(`Shift+Tab` を BackTab として登録したい場合)のために `"BackTab" => KeyCode::BackTab` を追加した(既存の `"Tab"` 追加と同じ形の小さな変更)。

## テスト

- `cargo test --workspace` 全通過(presentation crate 299 tests / 全体 1266+ tests)
- `command_completion.rs` に純粋ロジックのユニットテスト一式(LCP計算・prefix フィルタ・候補巡回・引数補完・Esc復元など)
- `mode.rs` / `app_action_handler.rs` にも Tab/BackTab のディスパッチ・状態遷移テストを追加
- push 前に `cargo fmt --all` 実行済み

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)